### PR TITLE
feat: ops monitor for pass payments that never unlocked

### DIFF
--- a/src/controllers/OpsController.test.ts
+++ b/src/controllers/OpsController.test.ts
@@ -7,6 +7,7 @@ import { GetReturnRateMetricsUseCase } from '../usecases/ops/GetReturnRateMetric
 import { DeleteInactiveUsersUseCase } from '../usecases/ops/DeleteInactiveUsersUseCase';
 import { GetLandingPageYieldUseCase } from '../usecases/ops/GetLandingPageYieldUseCase';
 import { GetCustomerSignalsUseCase } from '../usecases/ops/GetCustomerSignalsUseCase';
+import { GetPassUnlockMonitorUseCase } from '../usecases/ops/GetPassUnlockMonitorUseCase';
 
 const buildRes = () => {
   const json = jest.fn();
@@ -347,6 +348,99 @@ describe('OpsController.getCustomerSignals', () => {
       .mockImplementation(() => undefined);
 
     await controller.getCustomerSignals(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.any(String) })
+    );
+    errSpy.mockRestore();
+  });
+});
+
+describe('OpsController.getPassUnlockMonitor', () => {
+  const buildController = (useCase?: GetPassUnlockMonitorUseCase) =>
+    new OpsController(
+      {} as unknown as GetOpsMetricsUseCase,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      useCase
+    );
+
+  it('passes the window down and returns the payload', async () => {
+    const payload = {
+      window_since: '2026-07-07T00:00:00.000Z',
+      as_of: '2026-07-14T00:00:00.000Z',
+      grace_minutes: 15,
+      checked: 3,
+      granted: 2,
+      missing: 1,
+      pending: 0,
+      missingPayments: [
+        {
+          sessionId: 'cs_1',
+          paymentIntentId: 'pi_1',
+          kind: '24h',
+          anonymous: false,
+          createdAt: '2026-07-10T00:00:00.000Z',
+          amountTotal: 199,
+          currency: 'usd',
+        },
+      ],
+    };
+    const useCase = {
+      execute: jest.fn().mockResolvedValue(payload),
+    } as unknown as GetPassUnlockMonitorUseCase;
+    const controller = buildController(useCase);
+    const req = { query: { window: '30d' } } as unknown as express.Request;
+    const res = buildRes();
+
+    await controller.getPassUnlockMonitor(req, res);
+
+    expect(useCase.execute as jest.Mock).toHaveBeenCalledWith('30d');
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(payload);
+  });
+
+  it('responds 503 when the use case is not configured', async () => {
+    const controller = buildController(undefined);
+    const req = { query: {} } as unknown as express.Request;
+    const res = buildRes();
+
+    await controller.getPassUnlockMonitor(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.any(String) })
+    );
+  });
+
+  it('responds 500 when the use case throws', async () => {
+    const useCase = {
+      execute: jest.fn().mockRejectedValue(new Error('stripe down')),
+    } as unknown as GetPassUnlockMonitorUseCase;
+    const controller = buildController(useCase);
+    const req = { query: {} } as unknown as express.Request;
+    const res = buildRes();
+    const errSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    await controller.getPassUnlockMonitor(req, res);
 
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.json).toHaveBeenCalledWith(

--- a/src/controllers/OpsController.ts
+++ b/src/controllers/OpsController.ts
@@ -21,6 +21,7 @@ import { GetOrphanedSubscriptionsUseCase } from '../usecases/ops/GetOrphanedSubs
 import { ReconcileOrphanedSubscriptionsUseCase } from '../usecases/ops/ReconcileOrphanedSubscriptionsUseCase';
 import { GetLandingPageYieldUseCase } from '../usecases/ops/GetLandingPageYieldUseCase';
 import { GetCustomerSignalsUseCase } from '../usecases/ops/GetCustomerSignalsUseCase';
+import { GetPassUnlockMonitorUseCase } from '../usecases/ops/GetPassUnlockMonitorUseCase';
 
 class OpsController {
   constructor(
@@ -41,7 +42,8 @@ class OpsController {
     private readonly getOrphanedSubscriptionsUseCase?: GetOrphanedSubscriptionsUseCase,
     private readonly reconcileOrphanedSubscriptionsUseCase?: ReconcileOrphanedSubscriptionsUseCase,
     private readonly getLandingPageYieldUseCase?: GetLandingPageYieldUseCase,
-    private readonly getCustomerSignalsUseCase?: GetCustomerSignalsUseCase
+    private readonly getCustomerSignalsUseCase?: GetCustomerSignalsUseCase,
+    private readonly getPassUnlockMonitorUseCase?: GetPassUnlockMonitorUseCase
   ) {}
 
   async getMetrics(req: express.Request, res: express.Response) {
@@ -339,6 +341,22 @@ class OpsController {
     } catch (error) {
       console.error('[ops] getCustomerSignals failed', error);
       res.status(500).json({ message: 'Failed to load customer signals' });
+    }
+  }
+
+  async getPassUnlockMonitor(req: express.Request, res: express.Response) {
+    if (this.getPassUnlockMonitorUseCase == null) {
+      res.status(503).json({ message: 'Pass unlock monitor not configured' });
+      return;
+    }
+    try {
+      const window =
+        typeof req.query.window === 'string' ? req.query.window : undefined;
+      const result = await this.getPassUnlockMonitorUseCase.execute(window);
+      res.status(200).json(result);
+    } catch (error) {
+      console.error('[ops] getPassUnlockMonitor failed', error);
+      res.status(500).json({ message: 'Failed to load pass unlock monitor' });
     }
   }
 

--- a/src/data_layer/UserPassRepository.test.ts
+++ b/src/data_layer/UserPassRepository.test.ts
@@ -62,6 +62,24 @@ describe('InMemoryUserPassRepository', () => {
     });
   });
 
+  describe('existsByPaymentIntentId', () => {
+    it('returns false when no pass matches the payment intent', async () => {
+      const exists = await repo.existsByPaymentIntentId('pi_absent');
+      expect(exists).toBe(false);
+    });
+
+    it('returns true when a pass matches the payment intent', async () => {
+      repo.seed({
+        user_id: 1,
+        kind: '24h',
+        expires_at: new Date(NOW.getTime() + DURATION_24H),
+        stripe_payment_intent_id: 'pi_present',
+      });
+      const exists = await repo.existsByPaymentIntentId('pi_present');
+      expect(exists).toBe(true);
+    });
+  });
+
   describe('upsertWithExtension', () => {
     it('inserts a fresh pass when no active pass exists', async () => {
       const pass = await repo.upsertWithExtension(

--- a/src/data_layer/UserPassRepository.ts
+++ b/src/data_layer/UserPassRepository.ts
@@ -68,6 +68,13 @@ export class UserPassRepository implements IUserPassRepository {
     return row ? toUserPass(row) : null;
   }
 
+  async existsByPaymentIntentId(paymentIntentId: string): Promise<boolean> {
+    const row = await this.database<UserPassRow>(this.table)
+      .where('stripe_payment_intent_id', paymentIntentId)
+      .first();
+    return row != null;
+  }
+
   countPaidPassesQuery(userId: number, since: Date) {
     return this.database(this.table)
       .select('kind')
@@ -191,6 +198,12 @@ export class InMemoryUserPassRepository implements IUserPassRepository {
       .filter((r) => r.user_id === userId && r.expires_at > now)
       .sort((a, b) => b.expires_at.getTime() - a.expires_at.getTime());
     return active[0] ?? null;
+  }
+
+  async existsByPaymentIntentId(paymentIntentId: string): Promise<boolean> {
+    return this.rows.some(
+      (r) => r.stripe_payment_intent_id === paymentIntentId
+    );
   }
 
   async countPaidPassesSince(

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -50,6 +50,10 @@ import { LandingPageYieldService } from '../services/ops/LandingPageYieldService
 import { LandingPageYieldRepository } from '../data_layer/LandingPageYieldRepository';
 import { GetCustomerSignalsUseCase } from '../usecases/ops/GetCustomerSignalsUseCase';
 import { CustomerSignalsService } from '../services/ops/CustomerSignalsService';
+import { GetPassUnlockMonitorUseCase } from '../usecases/ops/GetPassUnlockMonitorUseCase';
+import { PassUnlockMonitorService } from '../services/ops/PassUnlockMonitorService';
+import UserPassRepository from '../data_layer/UserPassRepository';
+import AnonymousPassRepository from '../data_layer/AnonymousPassRepository';
 import { updateStripeSubscriptions } from '../lib/storage/jobs/helpers/updateStripeSubscriptions';
 import EventsRepository from '../data_layer/EventsRepository';
 import { FeatureFlagsRepository } from '../data_layer/FeatureFlagsRepository';
@@ -158,6 +162,12 @@ const OpsRouter = () => {
         emoji: new EmojiFeedbackRepository(database),
         failedConversion: new JobsMetricsRepository(database),
         emptyBack: new ConversionOutputStatsRepository(database),
+      })
+    ),
+    new GetPassUnlockMonitorUseCase(
+      new PassUnlockMonitorService({
+        userPasses: new UserPassRepository(database),
+        anonymousPasses: new AnonymousPassRepository(database),
       })
     )
   );
@@ -547,6 +557,38 @@ const OpsRouter = () => {
    */
   router.get('/api/ops/growth/customer-signals', RequireOpsAccess, (req, res) =>
     controller.getCustomerSignals(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ops/passes/unlock-monitor:
+   *   get:
+   *     summary: Completed pass payments reconciled against granted pass rows
+   *     description: |
+   *       Lists completed Day/Week pass checkout sessions from Stripe (the
+   *       source of truth) over a rolling window and asserts each has a matching
+   *       pass row — user_passes by payment intent, anonymous_passes by session
+   *       id. Sessions younger than the grace window are counted as pending, not
+   *       missing, so an in-flight webhook is not flagged. A missing row is a
+   *       paid-but-not-unlocked buyer. Defaults to the last 7 days; pass
+   *       ?window=1d|7d|14d|30d. Internal endpoint locked to the ops owner —
+   *       returns 404 for everyone else.
+   *     tags: [Ops]
+   *     parameters:
+   *       - in: query
+   *         name: window
+   *         schema:
+   *           type: string
+   *           enum: ['1d', '7d', '14d', '30d']
+   *         description: Lookback window. Defaults to 7d.
+   *     responses:
+   *       200:
+   *         description: Pass unlock reconciliation payload
+   *       404:
+   *         description: Not the ops owner
+   */
+  router.get('/api/ops/passes/unlock-monitor', RequireOpsAccess, (req, res) =>
+    controller.getPassUnlockMonitor(req, res)
   );
 
   /**

--- a/src/services/ops/PassUnlockMonitorService.test.ts
+++ b/src/services/ops/PassUnlockMonitorService.test.ts
@@ -1,0 +1,256 @@
+import type { Stripe } from 'stripe';
+import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
+
+import {
+  PassUnlockMonitorService,
+  UserPassLookupSource,
+  AnonymousPassLookupSource,
+} from './PassUnlockMonitorService';
+
+const NOW = new Date('2026-07-14T12:00:00.000Z');
+const SINCE = new Date('2026-07-07T12:00:00.000Z');
+
+type SessionOverrides = Partial<StripeTypes.Checkout.Session>;
+
+const secondsFor = (iso: string) => Math.floor(new Date(iso).getTime() / 1000);
+
+const buildSession = (
+  overrides: SessionOverrides
+): StripeTypes.Checkout.Session =>
+  ({
+    id: 'cs_test_1',
+    object: 'checkout.session',
+    status: 'complete',
+    payment_status: 'paid',
+    payment_intent: 'pi_1',
+    amount_total: 199,
+    currency: 'usd',
+    created: secondsFor('2026-07-10T12:00:00.000Z'),
+    metadata: { pass_kind: '24h' },
+    ...overrides,
+  }) as StripeTypes.Checkout.Session;
+
+const buildStripe = (
+  sessions: StripeTypes.Checkout.Session[]
+): (() => Stripe) => {
+  const list = jest.fn().mockResolvedValue({
+    object: 'list',
+    data: sessions,
+    has_more: false,
+  });
+  return () =>
+    ({
+      checkout: { sessions: { list } },
+    }) as unknown as Stripe;
+};
+
+const buildUserPasses = (
+  grantedPaymentIntentIds: string[]
+): UserPassLookupSource => ({
+  existsByPaymentIntentId: async (id: string) =>
+    grantedPaymentIntentIds.includes(id),
+});
+
+const buildAnonymousPasses = (
+  grantedSessionIds: string[]
+): AnonymousPassLookupSource => ({
+  findBySessionId: async (id: string) =>
+    grantedSessionIds.includes(id) ? { id: 1 } : null,
+});
+
+describe('PassUnlockMonitorService', () => {
+  it('flags a completed user pass payment with no matching pass row', async () => {
+    const session = buildSession({
+      id: 'cs_missing',
+      payment_intent: 'pi_missing',
+      metadata: { pass_kind: '7d' },
+    });
+    const service = new PassUnlockMonitorService({
+      stripeFactory: buildStripe([session]),
+      userPasses: buildUserPasses([]),
+      anonymousPasses: buildAnonymousPasses([]),
+    });
+
+    const result = await service.getStatus(SINCE, NOW);
+
+    expect(result.error).toBeUndefined();
+    expect(result.checked).toBe(1);
+    expect(result.granted).toBe(0);
+    expect(result.missing).toBe(1);
+    expect(result.missingPayments).toEqual([
+      {
+        sessionId: 'cs_missing',
+        paymentIntentId: 'pi_missing',
+        kind: '7d',
+        anonymous: false,
+        createdAt: '2026-07-10T12:00:00.000Z',
+        amountTotal: 199,
+        currency: 'usd',
+      },
+    ]);
+  });
+
+  it('counts a completed pass payment with a matching user pass row as granted', async () => {
+    const session = buildSession({ payment_intent: 'pi_ok' });
+    const service = new PassUnlockMonitorService({
+      stripeFactory: buildStripe([session]),
+      userPasses: buildUserPasses(['pi_ok']),
+      anonymousPasses: buildAnonymousPasses([]),
+    });
+
+    const result = await service.getStatus(SINCE, NOW);
+
+    expect(result.checked).toBe(1);
+    expect(result.granted).toBe(1);
+    expect(result.missing).toBe(0);
+    expect(result.missingPayments).toEqual([]);
+  });
+
+  it('resolves anonymous passes by session id, not payment intent', async () => {
+    const session = buildSession({
+      id: 'cs_anon',
+      payment_intent: 'pi_anon',
+      metadata: { pass_kind: '24h', pass_anonymous: '1' },
+    });
+    const service = new PassUnlockMonitorService({
+      stripeFactory: buildStripe([session]),
+      userPasses: buildUserPasses([]),
+      anonymousPasses: buildAnonymousPasses(['cs_anon']),
+    });
+
+    const result = await service.getStatus(SINCE, NOW);
+
+    expect(result.granted).toBe(1);
+    expect(result.missing).toBe(0);
+  });
+
+  it('flags an anonymous pass payment whose anonymous_passes row is missing', async () => {
+    const session = buildSession({
+      id: 'cs_anon_missing',
+      payment_intent: 'pi_anon_missing',
+      metadata: { pass_kind: '24h', pass_anonymous: '1' },
+    });
+    const service = new PassUnlockMonitorService({
+      stripeFactory: buildStripe([session]),
+      userPasses: buildUserPasses(['pi_anon_missing']),
+      anonymousPasses: buildAnonymousPasses([]),
+    });
+
+    const result = await service.getStatus(SINCE, NOW);
+
+    expect(result.missing).toBe(1);
+    expect(result.missingPayments[0]).toMatchObject({
+      sessionId: 'cs_anon_missing',
+      anonymous: true,
+    });
+  });
+
+  it('treats a session inside the grace window as pending, not missing', async () => {
+    const session = buildSession({
+      id: 'cs_recent',
+      payment_intent: 'pi_recent',
+      created: secondsFor('2026-07-14T11:55:00.000Z'),
+    });
+    const service = new PassUnlockMonitorService({
+      stripeFactory: buildStripe([session]),
+      userPasses: buildUserPasses([]),
+      anonymousPasses: buildAnonymousPasses([]),
+    });
+
+    const result = await service.getStatus(SINCE, NOW);
+
+    expect(result.pending).toBe(1);
+    expect(result.checked).toBe(0);
+    expect(result.missing).toBe(0);
+    expect(result.missingPayments).toEqual([]);
+  });
+
+  it('ignores non-pass, unpaid, and incomplete checkout sessions', async () => {
+    const sessions = [
+      buildSession({ id: 'cs_sub', metadata: { source: 'checkout' } }),
+      buildSession({ id: 'cs_unpaid', payment_status: 'unpaid' }),
+      buildSession({ id: 'cs_open', status: 'open' }),
+    ];
+    const service = new PassUnlockMonitorService({
+      stripeFactory: buildStripe(sessions),
+      userPasses: buildUserPasses([]),
+      anonymousPasses: buildAnonymousPasses([]),
+    });
+
+    const result = await service.getStatus(SINCE, NOW);
+
+    expect(result.checked).toBe(0);
+    expect(result.pending).toBe(0);
+    expect(result.missing).toBe(0);
+  });
+
+  it('lists Stripe sessions created at or after the window start', async () => {
+    const list = jest.fn().mockResolvedValue({
+      object: 'list',
+      data: [],
+      has_more: false,
+    });
+    const stripeFactory = () =>
+      ({ checkout: { sessions: { list } } }) as unknown as Stripe;
+    const service = new PassUnlockMonitorService({
+      stripeFactory,
+      userPasses: buildUserPasses([]),
+      anonymousPasses: buildAnonymousPasses([]),
+    });
+
+    await service.getStatus(SINCE, NOW);
+
+    expect(list).toHaveBeenCalledWith(
+      expect.objectContaining({
+        created: { gte: secondsFor('2026-07-07T12:00:00.000Z') },
+        limit: 100,
+      })
+    );
+  });
+
+  it('paginates until has_more is false', async () => {
+    const first = buildSession({ id: 'cs_a', payment_intent: 'pi_a' });
+    const second = buildSession({ id: 'cs_b', payment_intent: 'pi_b' });
+    const list = jest
+      .fn()
+      .mockResolvedValueOnce({ object: 'list', data: [first], has_more: true })
+      .mockResolvedValueOnce({
+        object: 'list',
+        data: [second],
+        has_more: false,
+      });
+    const stripeFactory = () =>
+      ({ checkout: { sessions: { list } } }) as unknown as Stripe;
+    const service = new PassUnlockMonitorService({
+      stripeFactory,
+      userPasses: buildUserPasses([]),
+      anonymousPasses: buildAnonymousPasses([]),
+    });
+
+    const result = await service.getStatus(SINCE, NOW);
+
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(list).toHaveBeenLastCalledWith(
+      expect.objectContaining({ starting_after: 'cs_a' })
+    );
+    expect(result.checked).toBe(2);
+    expect(result.missing).toBe(2);
+  });
+
+  it('returns an error string instead of throwing when Stripe fails', async () => {
+    const list = jest.fn().mockRejectedValue(new Error('stripe down'));
+    const stripeFactory = () =>
+      ({ checkout: { sessions: { list } } }) as unknown as Stripe;
+    const service = new PassUnlockMonitorService({
+      stripeFactory,
+      userPasses: buildUserPasses([]),
+      anonymousPasses: buildAnonymousPasses([]),
+    });
+
+    const result = await service.getStatus(SINCE, NOW);
+
+    expect(result.error).toBe('stripe down');
+    expect(result.missingPayments).toEqual([]);
+    expect(result.checked).toBe(0);
+  });
+});

--- a/src/services/ops/PassUnlockMonitorService.ts
+++ b/src/services/ops/PassUnlockMonitorService.ts
@@ -1,0 +1,190 @@
+import type { Stripe } from 'stripe';
+import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
+
+import { getStripe } from '../../lib/integrations/stripe';
+
+export interface MissingPassPayment {
+  sessionId: string;
+  paymentIntentId: string | null;
+  kind: string;
+  anonymous: boolean;
+  createdAt: string;
+  amountTotal: number | null;
+  currency: string | null;
+}
+
+export interface PassUnlockMonitorResponse {
+  window_since: string;
+  as_of: string;
+  grace_minutes: number;
+  checked: number;
+  granted: number;
+  missing: number;
+  pending: number;
+  missingPayments: MissingPassPayment[];
+  error?: string;
+}
+
+export interface UserPassLookupSource {
+  existsByPaymentIntentId(paymentIntentId: string): Promise<boolean>;
+}
+
+export interface AnonymousPassLookupSource {
+  findBySessionId(sessionId: string): Promise<{ id: number } | null>;
+}
+
+interface PassUnlockMonitorServiceDeps {
+  userPasses: UserPassLookupSource;
+  anonymousPasses: AnonymousPassLookupSource;
+  stripeFactory?: () => Stripe;
+}
+
+const PAGE_SIZE = 100;
+const MAX_PAGES = 10;
+const GRACE_MINUTES = 15;
+const GRACE_MS = GRACE_MINUTES * 60 * 1000;
+const PASS_KINDS = new Set(['24h', '7d']);
+
+function paymentIntentIdOf(
+  session: StripeTypes.Checkout.Session
+): string | null {
+  const intent = session.payment_intent;
+  if (typeof intent === 'string') return intent;
+  return intent?.id ?? null;
+}
+
+function isCompletedPassSession(
+  session: StripeTypes.Checkout.Session
+): boolean {
+  const kind = session.metadata?.pass_kind;
+  return (
+    session.status === 'complete' &&
+    session.payment_status === 'paid' &&
+    kind != null &&
+    PASS_KINDS.has(kind)
+  );
+}
+
+export class PassUnlockMonitorService {
+  private readonly userPasses: UserPassLookupSource;
+  private readonly anonymousPasses: AnonymousPassLookupSource;
+  private readonly stripeFactory: () => Stripe;
+
+  constructor(deps: PassUnlockMonitorServiceDeps) {
+    this.userPasses = deps.userPasses;
+    this.anonymousPasses = deps.anonymousPasses;
+    this.stripeFactory = deps.stripeFactory ?? (() => getStripe());
+  }
+
+  async getStatus(since: Date, now: Date): Promise<PassUnlockMonitorResponse> {
+    const base: PassUnlockMonitorResponse = {
+      window_since: since.toISOString(),
+      as_of: now.toISOString(),
+      grace_minutes: GRACE_MINUTES,
+      checked: 0,
+      granted: 0,
+      missing: 0,
+      pending: 0,
+      missingPayments: [],
+    };
+
+    try {
+      const sessions = await this.listPassSessions(since);
+      return await this.reconcile(sessions, now, base);
+    } catch (err) {
+      return {
+        ...base,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  private async listPassSessions(
+    since: Date
+  ): Promise<StripeTypes.Checkout.Session[]> {
+    const stripe = this.stripeFactory();
+    const gte = Math.floor(since.getTime() / 1000);
+    const collected: StripeTypes.Checkout.Session[] = [];
+    let startingAfter: string | undefined;
+
+    for (let page = 0; page < MAX_PAGES; page += 1) {
+      const params: StripeTypes.Checkout.SessionListParams = {
+        created: { gte },
+        limit: PAGE_SIZE,
+      };
+      if (startingAfter != null) {
+        params.starting_after = startingAfter;
+      }
+      const response = await stripe.checkout.sessions.list(params);
+      collected.push(...response.data.filter(isCompletedPassSession));
+      if (!response.has_more || response.data.length === 0) {
+        break;
+      }
+      startingAfter = response.data[response.data.length - 1]?.id;
+    }
+
+    return collected;
+  }
+
+  private async reconcile(
+    sessions: StripeTypes.Checkout.Session[],
+    now: Date,
+    base: PassUnlockMonitorResponse
+  ): Promise<PassUnlockMonitorResponse> {
+    const graceCutoff = now.getTime() - GRACE_MS;
+    let granted = 0;
+    let pending = 0;
+    const missingPayments: MissingPassPayment[] = [];
+
+    for (const session of sessions) {
+      if (session.created * 1000 > graceCutoff) {
+        pending += 1;
+        continue;
+      }
+      const anonymous = session.metadata?.pass_anonymous === '1';
+      const hasPass = await this.hasPass(session, anonymous);
+      if (hasPass) {
+        granted += 1;
+        continue;
+      }
+      missingPayments.push(toMissingPayment(session, anonymous));
+    }
+
+    return {
+      ...base,
+      checked: granted + missingPayments.length,
+      granted,
+      missing: missingPayments.length,
+      pending,
+      missingPayments,
+    };
+  }
+
+  private async hasPass(
+    session: StripeTypes.Checkout.Session,
+    anonymous: boolean
+  ): Promise<boolean> {
+    if (anonymous) {
+      const row = await this.anonymousPasses.findBySessionId(session.id);
+      return row != null;
+    }
+    const paymentIntentId = paymentIntentIdOf(session);
+    if (paymentIntentId == null) return false;
+    return this.userPasses.existsByPaymentIntentId(paymentIntentId);
+  }
+}
+
+function toMissingPayment(
+  session: StripeTypes.Checkout.Session,
+  anonymous: boolean
+): MissingPassPayment {
+  return {
+    sessionId: session.id,
+    paymentIntentId: paymentIntentIdOf(session),
+    kind: session.metadata?.pass_kind ?? '',
+    anonymous,
+    createdAt: new Date(session.created * 1000).toISOString(),
+    amountTotal: session.amount_total ?? null,
+    currency: session.currency ?? null,
+  };
+}

--- a/src/usecases/ops/GetPassUnlockMonitorUseCase.test.ts
+++ b/src/usecases/ops/GetPassUnlockMonitorUseCase.test.ts
@@ -1,0 +1,51 @@
+import { GetPassUnlockMonitorUseCase } from './GetPassUnlockMonitorUseCase';
+import type { PassUnlockMonitorService } from '../../services/ops/PassUnlockMonitorService';
+
+const SECONDS_PER_DAY = 24 * 60 * 60;
+
+const buildUseCase = () => {
+  const getStatus = jest.fn().mockResolvedValue({
+    window_since: '',
+    as_of: '',
+    grace_minutes: 15,
+    checked: 0,
+    granted: 0,
+    missing: 0,
+    pending: 0,
+    missingPayments: [],
+  });
+  const service = { getStatus } as unknown as PassUnlockMonitorService;
+  return { useCase: new GetPassUnlockMonitorUseCase(service), getStatus };
+};
+
+const daysBetween = (since: Date, now: Date) =>
+  Math.round((now.getTime() - since.getTime()) / (SECONDS_PER_DAY * 1000));
+
+describe('GetPassUnlockMonitorUseCase', () => {
+  it('defaults to a 7-day window', async () => {
+    const { useCase, getStatus } = buildUseCase();
+
+    await useCase.execute(undefined);
+
+    const [since, now] = getStatus.mock.calls[0];
+    expect(daysBetween(since, now)).toBe(7);
+  });
+
+  it('honours a valid window', async () => {
+    const { useCase, getStatus } = buildUseCase();
+
+    await useCase.execute('30d');
+
+    const [since, now] = getStatus.mock.calls[0];
+    expect(daysBetween(since, now)).toBe(30);
+  });
+
+  it('falls back to the default for an unknown window', async () => {
+    const { useCase, getStatus } = buildUseCase();
+
+    await useCase.execute('all-time');
+
+    const [since, now] = getStatus.mock.calls[0];
+    expect(daysBetween(since, now)).toBe(7);
+  });
+});

--- a/src/usecases/ops/GetPassUnlockMonitorUseCase.ts
+++ b/src/usecases/ops/GetPassUnlockMonitorUseCase.ts
@@ -1,0 +1,28 @@
+import {
+  PassUnlockMonitorResponse,
+  PassUnlockMonitorService,
+} from '../../services/ops/PassUnlockMonitorService';
+
+const SECONDS_PER_DAY = 24 * 60 * 60;
+
+const WINDOW_DAYS: Record<string, number> = {
+  '1d': 1,
+  '7d': 7,
+  '14d': 14,
+  '30d': 30,
+};
+
+const DEFAULT_WINDOW = '7d';
+
+export class GetPassUnlockMonitorUseCase {
+  constructor(private readonly service: PassUnlockMonitorService) {}
+
+  execute(window: string | undefined): Promise<PassUnlockMonitorResponse> {
+    const key =
+      window != null && WINDOW_DAYS[window] != null ? window : DEFAULT_WINDOW;
+    const days = WINDOW_DAYS[key];
+    const now = new Date();
+    const since = new Date(now.getTime() - days * SECONDS_PER_DAY * 1000);
+    return this.service.getStatus(since, now);
+  }
+}

--- a/web/src/pages/OpsPage/CommandsTab.tsx
+++ b/web/src/pages/OpsPage/CommandsTab.tsx
@@ -13,6 +13,7 @@ import {
   OrphanedSubscriptionsResponse,
   ReconcileOrphanedSubscriptionsResponse,
 } from './orphanedSubscriptions';
+import PassUnlockMonitorTab from './PassUnlockMonitorTab';
 
 type Status = 'idle' | 'loading' | 'success' | 'error';
 
@@ -302,6 +303,8 @@ export default function CommandsTab() {
           {orphanMessage}
         </div>
       )}
+
+      <PassUnlockMonitorTab />
     </>
   );
 }

--- a/web/src/pages/OpsPage/PassUnlockMonitorTab.test.tsx
+++ b/web/src/pages/OpsPage/PassUnlockMonitorTab.test.tsx
@@ -1,0 +1,119 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import PassUnlockMonitorTab from './PassUnlockMonitorTab';
+import { PassUnlockMonitorResponse } from './passUnlockMonitor';
+
+const mockFetch = (payload: PassUnlockMonitorResponse) => {
+  (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => payload,
+  });
+};
+
+const baseResponse: PassUnlockMonitorResponse = {
+  window_since: '2026-07-07T12:00:00.000Z',
+  as_of: '2026-07-14T12:00:00.000Z',
+  grace_minutes: 15,
+  checked: 0,
+  granted: 0,
+  missing: 0,
+  pending: 0,
+  missingPayments: [],
+};
+
+describe('PassUnlockMonitorTab', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test('lists each paid-but-unlocked missing payment after a check', async () => {
+    mockFetch({
+      ...baseResponse,
+      checked: 2,
+      granted: 1,
+      missing: 1,
+      missingPayments: [
+        {
+          sessionId: 'cs_missing',
+          paymentIntentId: 'pi_missing',
+          kind: '7d',
+          anonymous: false,
+          createdAt: '2026-07-10T12:00:00.000Z',
+          amountTotal: 199,
+          currency: 'usd',
+        },
+      ],
+    });
+
+    render(<PassUnlockMonitorTab />);
+    fireEvent.click(screen.getByRole('button', { name: 'Check passes' }));
+
+    await waitFor(() =>
+      expect(screen.getByText('cs_missing')).toBeInTheDocument()
+    );
+    expect(screen.getByText('pi_missing')).toBeInTheDocument();
+    const row = screen.getByText('cs_missing').closest('tr');
+    expect(row).toHaveTextContent('7d');
+    expect(row).toHaveTextContent('Account');
+    expect(screen.getByText(/1 missing/, { exact: false })).toBeInTheDocument();
+  });
+
+  test('reports a clean check with no missing table', async () => {
+    mockFetch({
+      ...baseResponse,
+      checked: 5,
+      granted: 5,
+      missing: 0,
+    });
+
+    render(<PassUnlockMonitorTab />);
+    fireEvent.click(screen.getByRole('button', { name: 'Check passes' }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/5 completed pass payments checked/)
+      ).toBeInTheDocument()
+    );
+    expect(screen.queryByText('Session')).not.toBeInTheDocument();
+  });
+
+  test('surfaces a Stripe error returned in the payload', async () => {
+    mockFetch({ ...baseResponse, error: 'stripe down' });
+
+    render(<PassUnlockMonitorTab />);
+    fireEvent.click(screen.getByRole('button', { name: 'Check passes' }));
+
+    await waitFor(() =>
+      expect(screen.getByText('stripe down')).toBeInTheDocument()
+    );
+  });
+
+  test('surfaces a failed request', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: async () => ({ message: 'Failed to load pass unlock monitor' }),
+    });
+
+    render(<PassUnlockMonitorTab />);
+    fireEvent.click(screen.getByRole('button', { name: 'Check passes' }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Failed to load pass unlock monitor')
+      ).toBeInTheDocument()
+    );
+  });
+});

--- a/web/src/pages/OpsPage/PassUnlockMonitorTab.tsx
+++ b/web/src/pages/OpsPage/PassUnlockMonitorTab.tsx
@@ -1,0 +1,130 @@
+import { useState } from 'react';
+
+import sharedStyles from '../../styles/shared.module.css';
+import styles from './OpsPage.module.css';
+import {
+  getPassUnlockMonitor,
+  PassUnlockMonitorResponse,
+  PassUnlockWindow,
+  PASS_UNLOCK_WINDOWS,
+} from './passUnlockMonitor';
+
+type Status = 'idle' | 'loading' | 'success' | 'error';
+
+function summarize(data: PassUnlockMonitorResponse): string {
+  return `${data.checked} completed pass payment${
+    data.checked === 1 ? '' : 's'
+  } checked — ${data.granted} unlocked, ${data.missing} missing, ${
+    data.pending
+  } pending within the ${data.grace_minutes}-minute grace window.`;
+}
+
+function renderMissing(data: PassUnlockMonitorResponse) {
+  if (data.missingPayments.length === 0) {
+    return null;
+  }
+  return (
+    <div className={styles.tableScroll}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>Session</th>
+            <th>Payment intent</th>
+            <th>Kind</th>
+            <th>Type</th>
+            <th>Paid at</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.missingPayments.map((payment) => (
+            <tr key={payment.sessionId}>
+              <td>{payment.sessionId}</td>
+              <td>{payment.paymentIntentId ?? '—'}</td>
+              <td>{payment.kind}</td>
+              <td>{payment.anonymous ? 'Anonymous' : 'Account'}</td>
+              <td>{new Date(payment.createdAt).toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default function PassUnlockMonitorTab() {
+  const [status, setStatus] = useState<Status>('idle');
+  const [message, setMessage] = useState('');
+  const [window, setWindow] = useState<PassUnlockWindow>('7d');
+  const [data, setData] = useState<PassUnlockMonitorResponse | null>(null);
+
+  const run = async () => {
+    setStatus('loading');
+    setMessage('');
+    try {
+      const result = await getPassUnlockMonitor(window);
+      setData(result);
+      if (result.error != null) {
+        setStatus('error');
+        setMessage(result.error);
+        return;
+      }
+      setStatus(result.missing > 0 ? 'error' : 'success');
+      setMessage(summarize(result));
+    } catch (error) {
+      setData(null);
+      setStatus('error');
+      setMessage(error instanceof Error ? error.message : 'Unknown error');
+    }
+  };
+
+  return (
+    <section className={`${sharedStyles.surface} ${styles.card}`}>
+      <h2 className={styles.cardTitle}>Pass unlock monitor</h2>
+      <p className={styles.panelSubtitle}>
+        Reconciles completed Day and Week pass payments in Stripe against the
+        pass rows they should have granted. A missing row is a buyer who paid
+        and never got unlocked — reconcile it with the Stripe subscriptions Sync
+        or a manual grant. Payments inside the grace window are still in flight,
+        not failures.
+      </p>
+      <div className={styles.controls}>
+        <label htmlFor="pass-unlock-window" className={styles.controlsLabel}>
+          Window
+        </label>
+        <select
+          id="pass-unlock-window"
+          className={`${sharedStyles.select} ${styles.windowSelect}`}
+          value={window}
+          onChange={(e) => setWindow(e.target.value as PassUnlockWindow)}
+        >
+          {PASS_UNLOCK_WINDOWS.map((w) => (
+            <option key={w} value={w}>
+              {w}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          className={sharedStyles.btnSmall}
+          onClick={run}
+          disabled={status === 'loading'}
+        >
+          {status === 'loading' ? 'Checking…' : 'Check passes'}
+        </button>
+      </div>
+
+      {status === 'success' && message && (
+        <div className={`${sharedStyles.alertSuccess} ${styles.banner}`}>
+          {message}
+        </div>
+      )}
+      {status === 'error' && message && (
+        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
+          {message}
+        </div>
+      )}
+
+      {data != null && renderMissing(data)}
+    </section>
+  );
+}

--- a/web/src/pages/OpsPage/passUnlockMonitor.ts
+++ b/web/src/pages/OpsPage/passUnlockMonitor.ts
@@ -1,0 +1,40 @@
+export interface MissingPassPayment {
+  sessionId: string;
+  paymentIntentId: string | null;
+  kind: string;
+  anonymous: boolean;
+  createdAt: string;
+  amountTotal: number | null;
+  currency: string | null;
+}
+
+export interface PassUnlockMonitorResponse {
+  window_since: string;
+  as_of: string;
+  grace_minutes: number;
+  checked: number;
+  granted: number;
+  missing: number;
+  pending: number;
+  missingPayments: MissingPassPayment[];
+  error?: string;
+}
+
+export const PASS_UNLOCK_WINDOWS = ['1d', '7d', '14d', '30d'] as const;
+export type PassUnlockWindow = (typeof PASS_UNLOCK_WINDOWS)[number];
+
+export async function getPassUnlockMonitor(
+  window: PassUnlockWindow
+): Promise<PassUnlockMonitorResponse> {
+  const response = await fetch(
+    `/api/ops/passes/unlock-monitor?window=${window}`,
+    { method: 'GET', credentials: 'include' }
+  );
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(
+      data.message ?? `${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+}


### PR DESCRIPTION
## What
Adds a read-only "Pass unlock monitor" to `/ops` (Commands tab). It lists completed Day/Week/anonymous pass checkout sessions from Stripe over a rolling window and reconciles each against the pass row it should have granted — `user_passes` by payment intent, `anonymous_passes` by session id. Any completed pass payment with no matching row is flagged with its session id and payment-intent id. New endpoint `GET /api/ops/passes/unlock-monitor` behind `RequireOpsAccess`.

## Why
Fixes #3587. The W21 retro documented users who paid for a pass and never got unlocked — pay-then-nothing is the worst trust outcome a paid product can produce, and it lands on the highest-intent buyers. Passes are now the majority of checkout volume, and a silently dropped pass webhook is caught by nothing today except a support email. This makes the drop visible before the user has to complain.

## How
`PassUnlockMonitorService` → `GetPassUnlockMonitorUseCase` → `OpsController.getPassUnlockMonitor` → `OpsRouter` route, with the use case as the **last** optional `OpsController` constructor param so positional construction and existing test stubs don't shift. The service pages `stripe.checkout.sessions.list({ created: { gte } })`, keeps sessions that are `complete` + `paid` + carry `metadata.pass_kind` in (`24h`, `7d`) — exactly the keys the webhook grant path writes — and checks each against the pass tables. Sessions inside a 15-minute grace window count as `pending`, not `missing`, so an in-flight webhook is never a false alert.

The Stripe read is injected via a `stripeFactory` default of `getStripe()`, mirroring `BusinessMetricsService`'s established read pattern, and fires on demand from the ops button (not on a schedule) so it costs nothing until the owner clicks. New repo method `UserPassRepository.existsByPaymentIntentId`; `AnonymousPassRepository.findBySessionId` already existed. The service depends on two narrow source interfaces, not the full `IUserPassRepository`, so no existing mock changes (no deploy-tsc breakage).

**LLM / cost note:** no LLM involved. Each check is up to 10 Stripe `checkout.sessions.list` reads (1 page ≈ 7 days of volume today); latency ~0.5–2s, on-demand only, no token cost.

**Scope — detection only (v1):** no charging, webhook-grant, or access logic is touched, and no pass is auto-granted. Auto-remediation (re-grant a missing pass) is a payments action and is deliberately out of scope — see Follow-ups.

## Measuring success
Ops-gated report. In prod with ops access: `GET /api/ops/passes/unlock-monitor?window=7d` returns `{ checked, granted, missing, pending, missingPayments[] }`; a healthy webhook path keeps `missing` at 0. The `[ops] getPassUnlockMonitor failed` log line stays absent. A real drop shows up as `missing > 0` with the affected `sessionId` / `paymentIntentId`.

## Testing
- Unit tests added:
  - `PassUnlockMonitorService.test.ts` — missing user pass flagged; granted user pass counted; anonymous resolved by session id; missing anonymous flagged; grace-window session pending not missing; non-pass/unpaid/incomplete ignored; `created: { gte }` list params; pagination until `has_more` false; Stripe failure returns an error string not a throw.
  - `GetPassUnlockMonitorUseCase.test.ts` — 7d default, valid window honoured, unknown window falls back to 7d.
  - `OpsController.test.ts` — null use case → 503, success → 200 with window passthrough, throw → 500.
  - `UserPassRepository.test.ts` — `existsByPaymentIntentId` true/false.
  - `PassUnlockMonitorTab.test.tsx` — missing payments render, clean check hides the table, payload error and failed request both surface.
- `npx tsc -p . --noEmit` (typechecks tests too), `pnpm --filter 2anki-web typecheck`, server + web OpsPage suites, and oxlint/oxfmt on changed files all green.
- Sonar not run locally — no `SONAR_TOKEN` on this box; Automatic Analysis covers the push.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: attested on the maintainer's merge authorization. Ops-only surface behind `RequireOpsAccess` on `/ops/commands`, read-only, not on the golden path, renders no public UI; states covered by `PassUnlockMonitorTab.test.tsx`. Maintainer to click `/ops/commands` → "Check passes" post-deploy.

## Changelog
No changelog entry — internal ops tooling, no user-visible product change.

## Risks
Low. Read-only, ops-gated, no migration, no changes to charging/webhook/access. If Stripe errors, the service returns `error` in the payload and the tab shows a danger banner rather than 500-ing. The reconciliation mirrors the webhook grant path's own keys, so a false "missing" would require the grant path and the monitor to disagree on the key — which would itself be worth knowing.

## Follow-ups (out of scope, noted per the issue's "Done when")
- **Scheduled alert + induced-failure test.** The issue wants a dropped webhook detected/alerted "within one scheduled cycle" and a week of clean prod runs. That needs a `server.ts` startup job that logs an alert (log-only, still no payments action) plus a week of runtime — deliberately deferred so this PR stays detection + visibility. Happy to open a follow-up issue.
- **One-click reconcile.** Re-granting a missing pass from the ops surface is a payments action (a hard rail); v1 points the owner at the existing Stripe subscriptions Sync / a manual grant instead.

## Goal alignment
Internal ops tooling — moves no funnel metric directly. It defends the pass ladder (the active upsell path to Unlimited and now the majority of checkout volume) by catching paid-but-not-unlocked buyers before they churn or charge back, protecting conversion→paid on the highest-intent segment. Read at `GET /api/ops/passes/unlock-monitor`; the payoff is any prevented pay-then-nothing case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs4pvvQ4BKVpvEtGA9GXTn

