### PR TITLE
feat: route image-only 0-card uploads to Photo to Deck

### DIFF
--- a/src/lib/upload/isImageOnlyUpload.test.ts
+++ b/src/lib/upload/isImageOnlyUpload.test.ts
@@ -1,0 +1,45 @@
+import { isImageOnlyUpload } from './isImageOnlyUpload';
+
+describe('isImageOnlyUpload', () => {
+  it('returns true when every uploaded file is an image', () => {
+    expect(
+      isImageOnlyUpload([
+        { originalname: 'page-1.png' },
+        { originalname: 'page-2.JPG' },
+        { originalname: 'diagram.jpeg' },
+      ])
+    ).toBe(true);
+  });
+
+  it('returns true for a single image upload', () => {
+    expect(isImageOnlyUpload([{ originalname: 'notes.png' }])).toBe(true);
+  });
+
+  it('returns false when any file is text-bearing', () => {
+    expect(
+      isImageOnlyUpload([
+        { originalname: 'page-1.png' },
+        { originalname: 'notes.html' },
+      ])
+    ).toBe(false);
+  });
+
+  it('returns false for a lone non-image file', () => {
+    expect(isImageOnlyUpload([{ originalname: 'study-notes.zip' }])).toBe(
+      false
+    );
+  });
+
+  it('returns false when there are no files', () => {
+    expect(isImageOnlyUpload([])).toBe(false);
+    expect(isImageOnlyUpload(undefined)).toBe(false);
+  });
+
+  it('returns false when a filename is missing', () => {
+    expect(isImageOnlyUpload([{ originalname: undefined }])).toBe(false);
+  });
+
+  it('rejects a filename that attempts path traversal', () => {
+    expect(isImageOnlyUpload([{ originalname: '../secret.png' }])).toBe(false);
+  });
+});

--- a/src/lib/upload/isImageOnlyUpload.ts
+++ b/src/lib/upload/isImageOnlyUpload.ts
@@ -1,0 +1,15 @@
+import { isImageFile } from '../storage/checks';
+
+interface NamedUpload {
+  originalname?: string;
+}
+
+export function isImageOnlyUpload(files: NamedUpload[] | undefined): boolean {
+  if (files == null || files.length === 0) {
+    return false;
+  }
+  return files.every((file) => {
+    const name = file.originalname;
+    return typeof name === 'string' && Boolean(isImageFile(name));
+  });
+}

--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -361,6 +361,81 @@ describe('UploadService.handleUpload — error paths', () => {
     expect(body.docsLink).toBe('/documentation/help/common-problems');
   });
 
+  it('returns image_only_no_text with a Photo to Deck link when an image-only upload yields 0 cards', async () => {
+    MockGeneratePackagesUseCase.mockImplementation(
+      () =>
+        ({
+          execute: jest.fn().mockResolvedValue({ packages: [] }),
+        }) as unknown as InstanceType<typeof GeneratePackagesUseCase>
+    );
+
+    const service = new UploadService(
+      buildRepository(),
+      {} as JobRepository,
+      buildUsersRepo()
+    );
+    const req = buildRequest({
+      files: [
+        {
+          originalname: 'lecture-page.png',
+          mimetype: 'image/png',
+          size: 2048,
+          path: '/tmp/lecture-page.png',
+        } as unknown as Express.Multer.File,
+      ],
+      cookies: { anon_id: 'anon-image-only' },
+    } as Partial<express.Request>);
+    const { res, capturedStatus, capturedJson } = buildResponse();
+
+    await service.handleUpload(req, res);
+
+    expect(capturedStatus()).toBe(400);
+    const body = capturedJson() as {
+      code: string;
+      message: string;
+      filename: string;
+      photoToDeckUrl: string;
+    };
+    expect(body.code).toBe('image_only_no_text');
+    expect(body.photoToDeckUrl).toBe('/photo-to-deck');
+    expect(body.filename).toBe('lecture-page.png');
+    expect(body.message).toMatch(/Photo to Deck/);
+    expect(trackMock).toHaveBeenCalledWith(
+      'image_only_no_text_shown',
+      expect.objectContaining({
+        anonymousId: 'anon-image-only',
+        props: expect.objectContaining({ source: 'upload' }),
+      })
+    );
+  });
+
+  it('keeps the plain empty_export state for a non-image file that yields 0 cards', async () => {
+    MockGeneratePackagesUseCase.mockImplementation(
+      () =>
+        ({
+          execute: jest.fn().mockResolvedValue({ packages: [] }),
+        }) as unknown as InstanceType<typeof GeneratePackagesUseCase>
+    );
+
+    const service = new UploadService(
+      buildRepository(),
+      {} as JobRepository,
+      buildUsersRepo()
+    );
+    const req = buildRequest();
+    const { res, capturedStatus, capturedJson } = buildResponse();
+
+    await service.handleUpload(req, res);
+
+    expect(capturedStatus()).toBe(400);
+    const body = capturedJson() as { code: string };
+    expect(body.code).toBe('empty_export');
+    expect(trackMock).not.toHaveBeenCalledWith(
+      'image_only_no_text_shown',
+      expect.anything()
+    );
+  });
+
   it('EmptyDeckError response body contains no HTML tags', async () => {
     MockGeneratePackagesUseCase.mockImplementation(
       () =>

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -20,6 +20,7 @@ import { isPaying } from '../lib/isPaying';
 import { isLimitError } from '../lib/misc/isLimitError';
 import { handleUploadLimitError } from '../controllers/Upload/helpers/handleUploadLimitError';
 import { getUploadValidationError } from '../lib/upload/getUploadValidationError';
+import { isImageOnlyUpload } from '../lib/upload/isImageOnlyUpload';
 import { EmptyDeckError } from '../usecases/jobs/EmptyDeckError';
 import { UploadFileUnavailableError } from '../usecases/uploads/UploadFileUnavailableError';
 import { isExpectedClientFault } from '../lib/misc/isExpectedClientFault';
@@ -70,6 +71,16 @@ interface MarkdownLossyResponse {
   message: string;
   filename: string;
 }
+
+interface ImageOnlyResponse {
+  code: 'image_only_no_text';
+  message: string;
+  filename: string;
+  photoToDeckUrl: string;
+}
+
+const IMAGE_ONLY_NO_TEXT_MESSAGE =
+  'These look like images — no text to read. Turn them into cards with Photo to Deck.';
 
 interface DeckTooLargeResponse {
   message: string;
@@ -480,6 +491,21 @@ class UploadService {
             code: 'markdown_likely_lossy',
             message: MARKDOWN_LIKELY_LOSSY_REASON,
             filename,
+          };
+          return res.status(400).json(body);
+        }
+        if (isImageOnlyUpload(files)) {
+          const owner = getOwner(res);
+          track('image_only_no_text_shown', {
+            userId: owner != null ? Number(owner) : null,
+            anonymousId: this.resolveAnonId(req),
+            props: { source: this.resolveUploadSource(req) },
+          });
+          const body: ImageOnlyResponse = {
+            code: 'image_only_no_text',
+            message: IMAGE_ONLY_NO_TEXT_MESSAGE,
+            filename,
+            photoToDeckUrl: '/photo-to-deck',
           };
           return res.status(400).json(body);
         }

--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -83,6 +83,7 @@ export const KNOWN_EVENTS = new Set([
   'ankify_review_completed',
   'ankify_review_session_exited',
   'image_drop_notice_shown',
+  'image_only_no_text_shown',
   'conversion_pathology_shown',
   'producer_intent_captured',
   'producer_entry_viewed',

--- a/web/src/lib/analytics/events.ts
+++ b/web/src/lib/analytics/events.ts
@@ -61,6 +61,8 @@ export const KNOWN_EVENTS = new Set([
   'ankify_review_session_exited',
   'ankify_decklist_sorted',
   'image_drop_notice_shown',
+  'image_only_photo_deck_shown',
+  'image_only_photo_deck_clicked',
   'columns_guessed_notice_shown',
   'conversion_pathology_shown',
   'producer_intent_captured',

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -1005,6 +1005,80 @@ describe('UploadForm analytics events', () => {
     });
   });
 
+  it('routes a 400 with code=image_only_no_text into the Photo to Deck handoff', async () => {
+    const jsonBody = {
+      code: 'image_only_no_text',
+      message:
+        'These look like images — no text to read. Turn them into cards with Photo to Deck.',
+      filename: 'lecture-page.png',
+      photoToDeckUrl: '/photo-to-deck',
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        redirected: false,
+        status: 400,
+        clone: () => ({ json: () => Promise.resolve(jsonBody) }),
+        text: () => Promise.resolve(JSON.stringify(jsonBody)),
+        headers: new Headers({ 'Content-Type': 'application/json' }),
+      })
+    );
+
+    const { container } = renderUploadForm(
+      <UploadForm setErrorMessage={vi.fn()} />
+    );
+    const form = container.querySelector('form')!;
+    await act(async () => {
+      form.dispatchEvent(
+        new Event('submit', { bubbles: true, cancelable: true })
+      );
+    });
+
+    const cta = await screen.findByRole('link', { name: /Try Photo to Deck/i });
+    expect(cta).toHaveAttribute('href', '/photo-to-deck');
+    expect(container.querySelector('[class*="errorBody"]')).toBeNull();
+  });
+
+  it('fires image_only_photo_deck_clicked when the handoff CTA is clicked', async () => {
+    const { track } = await import('../../../../lib/analytics/track');
+    const trackMock = vi.mocked(track);
+    trackMock.mockClear();
+
+    const jsonBody = {
+      code: 'image_only_no_text',
+      message:
+        'These look like images — no text to read. Turn them into cards with Photo to Deck.',
+      filename: 'lecture-page.png',
+      photoToDeckUrl: '/photo-to-deck',
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        redirected: false,
+        status: 400,
+        clone: () => ({ json: () => Promise.resolve(jsonBody) }),
+        text: () => Promise.resolve(JSON.stringify(jsonBody)),
+        headers: new Headers({ 'Content-Type': 'application/json' }),
+      })
+    );
+
+    const { container } = renderUploadForm(
+      <UploadForm setErrorMessage={vi.fn()} />
+    );
+    const form = container.querySelector('form')!;
+    await act(async () => {
+      form.dispatchEvent(
+        new Event('submit', { bubbles: true, cancelable: true })
+      );
+    });
+
+    const cta = await screen.findByRole('link', { name: /Try Photo to Deck/i });
+    fireEvent.click(cta);
+
+    expect(trackMock).toHaveBeenCalledWith('image_only_photo_deck_shown');
+    expect(trackMock).toHaveBeenCalledWith('image_only_photo_deck_clicked');
+  });
+
   it('tracks upload_failed with reason=network when fetch throws a TypeError', async () => {
     const { track } = await import('../../../../lib/analytics/track');
     const trackMock = vi.mocked(track);

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -135,7 +135,10 @@ function toFriendlyThrownError(error: unknown): UploadErrorBody {
 
 function zoneStateForUploadError(
   message: UploadErrorBody
-): 'emptyDeck' | 'error' {
+): 'emptyDeck' | 'imageOnly' | 'error' {
+  if (message.code === 'image_only_no_text') {
+    return 'imageOnly';
+  }
   if (
     message.code === 'empty_export' ||
     message.code === 'markdown_likely_lossy'
@@ -486,6 +489,12 @@ function UploadForm({
     }
   }, [zoneState]);
 
+  useEffect(() => {
+    if (zoneState === 'imageOnly') {
+      track('image_only_photo_deck_shown');
+    }
+  }, [zoneState]);
+
   const uploadCancelledFiredRef = useRef(false);
   useEffect(() => {
     if (zoneState !== 'converting') return;
@@ -755,7 +764,9 @@ function UploadForm({
     zoneState === 'success' || zoneState === 'multiDeck'
       ? formStyles.dropZoneSuccess
       : '',
-    zoneState === 'emptyDeck' ? formStyles.dropZoneEmpty : '',
+    zoneState === 'emptyDeck' || zoneState === 'imageOnly'
+      ? formStyles.dropZoneEmpty
+      : '',
     zoneState === 'error' && !isExistingApkgReject
       ? formStyles.dropZoneError
       : '',
@@ -1461,6 +1472,33 @@ function UploadForm({
     );
   };
 
+  const renderImageOnlyState = () => (
+    <div className={formStyles.stateContent}>
+      <WarningIcon className={formStyles.iconWarning} />
+      <p className={formStyles.emptyTitle}>These look like images</p>
+      <p className={formStyles.emptyBody}>
+        No text to read, so there was nothing to turn into cards. Photo to Deck
+        reads images with AI and drafts cards you review before download.
+      </p>
+      <div className={formStyles.emptyActions}>
+        <Link
+          to="/photo-to-deck"
+          className={formStyles.actionButton}
+          onClick={() => track('image_only_photo_deck_clicked')}
+        >
+          Try Photo to Deck
+        </Link>
+        <button
+          type="button"
+          className={formStyles.resetLink}
+          onClick={resetForm}
+        >
+          Try a different file
+        </button>
+      </div>
+    </div>
+  );
+
   const renderZoneContent = () => {
     if (isUploadLocked && zoneState === 'idle') return renderLockedState();
     if (validation && zoneState === 'idle') return renderValidationState();
@@ -1468,6 +1506,7 @@ function UploadForm({
     if (zoneState === 'success') return renderSuccessState();
     if (zoneState === 'multiDeck') return renderMultiDeckState();
     if (zoneState === 'emptyDeck') return renderEmptyDeckState();
+    if (zoneState === 'imageOnly') return renderImageOnlyState();
     if (zoneState === 'limitReached' && limitInfo) return renderLimitState();
     if (zoneState === 'lockedPdf') return renderLockedPdfState();
     if (zoneState === 'error') return renderErrorState();
@@ -1492,6 +1531,9 @@ function UploadForm({
     }
     if (zoneState === 'emptyDeck') {
       return 'Conversion finished, but no cards were found.';
+    }
+    if (zoneState === 'imageOnly') {
+      return 'These look like images. Try Photo to Deck to turn them into cards.';
     }
     if (zoneState === 'error') return 'Conversion failed.';
     if (zoneState === 'limitReached') {

--- a/web/src/pages/UploadPage/components/UploadForm/hooks/useUploadFormState.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/hooks/useUploadFormState.ts
@@ -8,6 +8,7 @@ export type ZoneState =
   | 'success'
   | 'multiDeck'
   | 'emptyDeck'
+  | 'imageOnly'
   | 'limitReached'
   | 'error'
   | 'lockedPdf';

--- a/web/src/pages/UploadPage/helpers/extractErrorMessage.ts
+++ b/web/src/pages/UploadPage/helpers/extractErrorMessage.ts
@@ -16,6 +16,7 @@ function isValidCode(value: unknown): value is UploadErrorCode {
     value === 'corrupted_apkg' ||
     value === 'password_protected_pdf' ||
     value === 'empty_export' ||
+    value === 'image_only_no_text' ||
     value === 'unknown'
   );
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-14-images-to-photo-deck.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-14-images-to-photo-deck.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-14-images-to-photo-deck",
+  "date": "2026-07-14",
+  "type": "feature",
+  "title": "Image-only uploads point you to Photo to Deck instead of returning an empty deck"
+}

--- a/web/src/types/UploadErrorBody.ts
+++ b/web/src/types/UploadErrorBody.ts
@@ -9,6 +9,7 @@ export type UploadErrorCode =
   | 'docx_processing_failed'
   | 'claude_parse_failed'
   | 'empty_export'
+  | 'image_only_no_text'
   | 'markdown_likely_lossy'
   | 'parser_crash'
   | 'worker_timeout'


### PR DESCRIPTION
## What
When an upload is image-only (all files are images — PNG/JPG/etc.) and produces 0 cards, the upload form no longer shows the generic empty-deck failure. It shows a distinct "These look like images" state with a Photo to Deck handoff CTA.

## Why
Behavioral: image-only uploads (photos of notes, screenshots) produce a deck with 0 cards and count as a failure — observed live in prod logs. Adoption: photo-to-deck (Claude Vision) has a large view→convert gap. Said: "can you make cards from images?" is a recurring ask. Today the user hits a dead end; this routes them to the path that actually reads images.

## How
- New pure helper `isImageOnlyUpload(files)` — true only when every uploaded file is an image (reuses `isImageFile`, so a single text-bearing file falls through to the normal empty state).
- In `UploadService.handleUpload`, the `EmptyDeckError` branch now discriminates: an image-only 0-card upload returns a distinct `image_only_no_text` body (`{ code, message, filename, photoToDeckUrl: '/photo-to-deck' }`) with a `image_only_no_text_shown` server event; everything else keeps the existing `empty_export` / `markdown_likely_lossy` responses.
- Frontend maps `image_only_no_text` to a new `imageOnly` zone state that renders the Photo to Deck CTA.
- This is a **UX redirect, not auto-conversion**: no Vision call, no auto-charge. The CTA links to `/photo-to-deck` under the existing paywall/limit gate. The genuine empty-deck case (a text file with no cards) is untouched.

## Measuring success
Recovered-conversion funnel. Three events:
- `image_only_no_text_shown` (server, `props.source`) — how often image-only uploads hit the dead end.
- `image_only_photo_deck_shown` (web) — affordance rendered.
- `image_only_photo_deck_clicked` (web) — user took the handoff.
Read at `/api/ops/metrics`. Success = a non-trivial click-through from shown→clicked, and a downstream lift in `photo_upload_started` from users who arrived via this path.

## Testing
- Unit tests added:
  - `src/lib/upload/isImageOnlyUpload.test.ts` — all-image true, mixed/non-image/empty/traversal false.
  - `src/services/UploadService.test.ts` — image-only 0-card upload → `image_only_no_text` + `photoToDeckUrl` + `image_only_no_text_shown`; non-image 0-card upload → plain `empty_export`, no image event.
  - `UploadForm.test.tsx` — `image_only_no_text` renders the Photo to Deck CTA (href `/photo-to-deck`); clicking it fires `image_only_photo_deck_clicked`.
- Server tsc (`tsc -p . --noEmit`) + web typecheck green. Full web vitest (2232) green.
- Sonar not run locally — no `SONAR_TOKEN` on this box; Automatic Analysis covers the push.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: `pnpm --filter 2anki-web test:golden-path` green (2 passed, 375px viewport, console-error assertion).

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-07-14-images-to-photo-deck.json` — "Image-only uploads point you to Photo to Deck instead of returning an empty deck"

## Risks
Low. The new branch only fires inside the existing `EmptyDeckError` path (already a 0-card failure), so it can't change what counts as a success or break a working conversion. Discrimination is `every file is an image`; a mixed upload keeps the normal empty state. Rollback: revert the PR — the upload path returns to `empty_export` for image-only uploads.

## Goal alignment
Turns a logged failure into a routed conversion and lifts the conversion success-rate floor (mission: simplest/fastest path to cards). Funnel metric to move: recovered-conversion rate (`image_only_photo_deck_clicked` ÷ `image_only_no_text_shown`) and downstream `photo_upload_started`, read at `/api/ops/metrics`; first look T+7d post-deploy.
