### PR TITLE
fix: bound conversion worker memory and wire temp-file cleanup

### DIFF
--- a/src/env.example
+++ b/src/env.example
@@ -65,3 +65,9 @@ RELEASE=''
 # the defaults, down from the legacy 16). Replaces UPLOAD_BUILD_CONCURRENCY, which no
 # longer has any effect. Raise only after measuring per-Python RSS against the box.
 MAX_PYTHON_WORKERS='8'
+# Completed conversions after which the Piscina pool is recycled (drained + fresh
+# workers) so per-worker V8 heaps reset instead of ratcheting up for the whole
+# process lifetime. Unset = 50. Lower to reclaim memory sooner at the cost of more
+# worker cold-starts; raise to reduce churn. Must be an integer >= 1 or it falls
+# back to 50.
+CONVERSION_WORKER_RECYCLE_TASKS='50'

--- a/src/lib/conversionPool.test.ts
+++ b/src/lib/conversionPool.test.ts
@@ -16,8 +16,8 @@ jest.mock('piscina', () => {
     construct(options);
     return {
       run: (...args: unknown[]) => mockPoolRun(...args),
-      close: jest.fn(),
-      destroy: jest.fn(),
+      close: jest.fn().mockResolvedValue(undefined),
+      destroy: jest.fn().mockResolvedValue(undefined),
       queueSize: 0,
     };
   });
@@ -39,7 +39,10 @@ import {
   shutdownConversionPool,
   initConversionPool,
   resetConversionPoolForTesting,
+  shouldRecyclePool,
+  runConversion,
   POOL_CLOSE_TIMEOUT_MS,
+  MAX_OLD_GENERATION_SIZE_MB,
   ConversionWorkerRequest,
 } from './conversionPool';
 import { UploadGenerationTask } from '../usecases/uploads/uploadGenerationTypes';
@@ -289,5 +292,74 @@ describe('initConversionPool', () => {
 
   it('keeps the drain budget well above piscina default so large decks finish', () => {
     expect(POOL_CLOSE_TIMEOUT_MS).toBeGreaterThanOrEqual(60_000);
+  });
+
+  it('caps per-worker old-gen heap so V8 reclaims per-conversion buffers', () => {
+    initConversionPool();
+
+    expect(construct.mock.calls[0][0]).toMatchObject({
+      resourceLimits: { maxOldGenerationSizeMb: MAX_OLD_GENERATION_SIZE_MB },
+    });
+  });
+});
+
+describe('shouldRecyclePool', () => {
+  it.each([
+    [0, 50, false, false],
+    [49, 50, false, false],
+    [50, 50, false, true],
+    [75, 50, false, true],
+    [50, 50, true, false],
+  ])(
+    'completed=%p threshold=%p recycling=%p => %p',
+    (completed, threshold, recycling, expected) => {
+      expect(shouldRecyclePool(completed, threshold, recycling)).toBe(expected);
+    }
+  );
+});
+
+describe('conversion pool recycling', () => {
+  const construct = (Piscina as unknown as { construct: jest.Mock }).construct;
+  const previous = process.env.CONVERSION_WORKER_RECYCLE_TASKS;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    resetConversionPoolForTesting();
+    construct.mockClear();
+    (Piscina as unknown as jest.Mock).mockClear();
+    mockPoolRun.mockReset();
+    mockPoolRun.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    resetConversionPoolForTesting();
+    if (previous === undefined) {
+      delete process.env.CONVERSION_WORKER_RECYCLE_TASKS;
+    } else {
+      process.env.CONVERSION_WORKER_RECYCLE_TASKS = previous;
+    }
+  });
+
+  it('recreates the pool after the recycle threshold of completed tasks', async () => {
+    process.env.CONVERSION_WORKER_RECYCLE_TASKS = '2';
+
+    await runConversion(baseRequest);
+    expect(construct).toHaveBeenCalledTimes(1);
+
+    await runConversion(baseRequest);
+    // Second completion hits the threshold: the pool is drained and a fresh one
+    // is constructed so worker heaps reset.
+    expect(construct).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not recycle before the threshold is reached', async () => {
+    process.env.CONVERSION_WORKER_RECYCLE_TASKS = '5';
+
+    await runConversion(baseRequest);
+    await runConversion(baseRequest);
+
+    expect(construct).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/conversionPool.ts
+++ b/src/lib/conversionPool.ts
@@ -15,7 +15,10 @@ import BlocksCacheRepository from '../data_layer/BlocksCacheRepository';
 import JobRepository from '../data_layer/JobRepository';
 import { SetJobFailedUseCase } from '../usecases/jobs/SetJobFailedUseCase';
 import { NOTION_TOKEN_EXPIRED_REASON } from '../usecases/jobs/jobFailureReason';
-import { resolveConversionWorkers } from './pythonWorkerBudget';
+import {
+  resolveConversionWorkers,
+  resolveConversionWorkerRecycleTasks,
+} from './pythonWorkerBudget';
 
 export { resolveConversionWorkers } from './pythonWorkerBudget';
 
@@ -35,8 +38,32 @@ let pool: Piscina | null = null;
 
 export const POOL_CLOSE_TIMEOUT_MS = 80_000;
 
+// Piscina workers are a lifetime singleton, so each worker's V8 old-gen heap
+// ratchets up across conversions (large Notion decks hold image/PDF buffers and
+// rendered HTML) and never resets without a deploy — prod saw RSS climb 317MB →
+// 1.4GB over 20h on one process. Recycling the pool after a bounded number of
+// completed tasks drains the old workers and starts fresh ones, so the heap
+// resets periodically instead of only on restart. The old-gen cap stays at
+// 1024MB: lowering it risks OOMing the comprehensive/big-media path (which would
+// turn a slow leak into failed conversions), so recycling — not a smaller cap —
+// is the mechanism that bounds RSS.
+export const MAX_OLD_GENERATION_SIZE_MB = 1024;
+
+let completedTaskCount = 0;
+let recyclingPool = false;
+
+export function shouldRecyclePool(
+  completedTasks: number,
+  recycleThreshold: number,
+  isRecycling: boolean
+): boolean {
+  return !isRecycling && completedTasks >= recycleThreshold;
+}
+
 export function resetConversionPoolForTesting(): void {
   pool = null;
+  completedTaskCount = 0;
+  recyclingPool = false;
 }
 
 function workerEntry(): { filename: string; execArgv: string[] } {
@@ -56,7 +83,7 @@ export function initConversionPool(): Piscina {
     execArgv,
     maxThreads,
     minThreads: 1,
-    resourceLimits: { maxOldGenerationSizeMb: 1024 },
+    resourceLimits: { maxOldGenerationSizeMb: MAX_OLD_GENERATION_SIZE_MB },
     closeTimeout: POOL_CLOSE_TIMEOUT_MS,
   });
   return pool;
@@ -66,20 +93,64 @@ export function getConversionPool(): Piscina {
   return initConversionPool();
 }
 
+// Swap in a fresh pool and drain the retiring one in the background so heaps
+// reset without dropping in-flight conversions — close() waits for outstanding
+// tasks up to its budget. Guarded against re-entry so a burst of completions
+// past the threshold cannot start overlapping recycles.
+function recycleConversionPool(): void {
+  const retiring = pool;
+  if (recyclingPool || retiring == null) return;
+  recyclingPool = true;
+  completedTaskCount = 0;
+  pool = null;
+  initConversionPool();
+  void shutdownConversionPool({
+    handle: retiring,
+    timeoutMs: POOL_CLOSE_TIMEOUT_MS + 3_000,
+  })
+    .catch((error) => {
+      console.error('Conversion pool recycle drain failed:', error);
+    })
+    .finally(() => {
+      recyclingPool = false;
+    });
+}
+
+function noteTaskCompleted(): void {
+  completedTaskCount += 1;
+  if (
+    shouldRecyclePool(
+      completedTaskCount,
+      resolveConversionWorkerRecycleTasks(),
+      recyclingPool
+    )
+  ) {
+    recycleConversionPool();
+  }
+}
+
 export async function runConversion(
   request: ConversionWorkerRequest
 ): Promise<void> {
-  await getConversionPool().run(request);
+  try {
+    await getConversionPool().run(request);
+  } finally {
+    noteTaskCompleted();
+  }
 }
 
 export async function runUploadGeneration(
   task: UploadGenerationTask,
   transferList?: Transferable[]
 ): Promise<UploadGenerationResult> {
-  return getConversionPool().run(task, {
-    name: UPLOAD_GENERATION_TASK,
-    transferList: transferList as never, // piscina's TransferList type misinfers to StructuredSerializeOptions under lib.dom; the runtime expects an array
-  });
+  try {
+    return await getConversionPool().run(task, {
+      name: UPLOAD_GENERATION_TASK,
+      transferList: transferList as never, // piscina's TransferList type misinfers to StructuredSerializeOptions under lib.dom; the runtime expects an array
+    });
+  } finally {
+    noteTaskCompleted();
+  }
 }
 
 export async function shutdownConversionPool(

--- a/src/lib/pythonWorkerBudget.ts
+++ b/src/lib/pythonWorkerBudget.ts
@@ -13,3 +13,15 @@ export function resolvePerWorkerPythonCap(): number {
   const pool = resolveConversionWorkers();
   return Math.max(1, Math.floor(budget / pool));
 }
+
+export const DEFAULT_CONVERSION_WORKER_RECYCLE_TASKS = 50;
+
+export function resolveConversionWorkerRecycleTasks(): number {
+  const raw = Number.parseInt(
+    process.env.CONVERSION_WORKER_RECYCLE_TASKS ?? '',
+    10
+  );
+  return Number.isFinite(raw) && raw >= 1
+    ? raw
+    : DEFAULT_CONVERSION_WORKER_RECYCLE_TASKS;
+}

--- a/src/lib/storage/jobs/ScheduleCleanup.test.ts
+++ b/src/lib/storage/jobs/ScheduleCleanup.test.ts
@@ -1,0 +1,73 @@
+import type { Knex } from 'knex';
+
+jest.mock('./helpers/runFileSystemCleanup', () => ({
+  __esModule: true,
+  runFileSystemCleanup: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('./helpers/deleteOldUploads', () => ({
+  __esModule: true,
+  default: jest.fn().mockResolvedValue(undefined),
+  MS_21: 21 * 60 * 1000,
+  MS_24_HOURS: 24 * 60 * 60 * 1000,
+}));
+
+import { ScheduleCleanup } from './ScheduleCleanup';
+import { runFileSystemCleanup } from './helpers/runFileSystemCleanup';
+import deleteOldUploads, {
+  MS_21,
+  MS_24_HOURS,
+} from './helpers/deleteOldUploads';
+
+const db = { __id: 'fake-knex' } as unknown as Knex;
+
+describe('ScheduleCleanup', () => {
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    jest.spyOn(console, 'info').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    errorSpy.mockRestore();
+  });
+
+  it('runs the filesystem cleanup on every MS_21 tick', () => {
+    ScheduleCleanup(db);
+
+    expect(runFileSystemCleanup).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(MS_21);
+    expect(runFileSystemCleanup).toHaveBeenCalledTimes(1);
+    expect(runFileSystemCleanup).toHaveBeenCalledWith(db);
+
+    jest.advanceTimersByTime(MS_21);
+    expect(runFileSystemCleanup).toHaveBeenCalledTimes(2);
+  });
+
+  it('runs the old-upload cleanup on every 24h tick', () => {
+    ScheduleCleanup(db);
+
+    jest.advanceTimersByTime(MS_24_HOURS);
+    expect(deleteOldUploads).toHaveBeenCalledTimes(1);
+    expect(deleteOldUploads).toHaveBeenCalledWith(db);
+  });
+
+  it('swallows a rejected filesystem cleanup so the interval keeps running', async () => {
+    (runFileSystemCleanup as jest.Mock).mockRejectedValueOnce(
+      new Error('cleanup boom')
+    );
+
+    ScheduleCleanup(db);
+
+    jest.advanceTimersByTime(MS_21);
+    await Promise.resolve();
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.any(Error));
+  });
+});

--- a/src/lib/storage/jobs/ScheduleCleanup.ts
+++ b/src/lib/storage/jobs/ScheduleCleanup.ts
@@ -7,7 +7,9 @@ import deleteOldUploads, {
 import { runFileSystemCleanup } from './helpers/runFileSystemCleanup';
 
 export const ScheduleCleanup = (db: Knex) => {
-  setInterval(() => runFileSystemCleanup(db), MS_21);
+  setInterval(() => {
+    runFileSystemCleanup(db).catch(console.error);
+  }, MS_21);
 
   setInterval(
     () =>

--- a/src/lib/storage/jobs/helpers/deleteOldFiles.test.ts
+++ b/src/lib/storage/jobs/helpers/deleteOldFiles.test.ts
@@ -1,0 +1,66 @@
+import fs from 'fs';
+import osReal from 'os';
+import pathReal from 'path';
+import { randomUUID } from 'crypto';
+
+import deleteOldFiles from './deleteOldFiles';
+import { CLEANUP_AGE_SECONDS } from '../../../constants';
+
+// deleteOldFiles resolves each location against os.tmpdir(), so the fixture must
+// live directly under it and be referenced by its basename.
+describe('deleteOldFiles', () => {
+  let root: string;
+  let loc: string;
+
+  const setOld = (target: string) => {
+    const old = new Date(Date.now() - (CLEANUP_AGE_SECONDS + 3600) * 1000);
+    fs.utimesSync(target, old, old);
+  };
+
+  beforeEach(() => {
+    loc = `cleanup-fixture-${randomUUID()}`;
+    root = pathReal.join(osReal.tmpdir(), loc);
+    fs.mkdirSync(root, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('removes an aged workspace directory but keeps a fresh one', () => {
+    const oldDir = pathReal.join(root, 'aaaaaaaa-old-uuid');
+    const freshDir = pathReal.join(root, 'bbbbbbbb-fresh-uuid');
+    fs.mkdirSync(oldDir);
+    fs.mkdirSync(freshDir);
+    // Give each directory some content, then backdate the old one's mtime.
+    fs.writeFileSync(pathReal.join(oldDir, 'deck.apkg'), 'x');
+    fs.writeFileSync(pathReal.join(freshDir, 'deck.apkg'), 'x');
+    setOld(oldDir);
+
+    deleteOldFiles([loc]);
+
+    expect(fs.existsSync(oldDir)).toBe(false);
+    expect(fs.existsSync(freshDir)).toBe(true);
+  });
+
+  it('removes an aged extensioned file but keeps a fresh one', () => {
+    const oldFile = pathReal.join(root, 'stale.zip');
+    const freshFile = pathReal.join(root, 'recent.zip');
+    fs.writeFileSync(oldFile, 'x');
+    fs.writeFileSync(freshFile, 'x');
+    setOld(oldFile);
+
+    deleteOldFiles([loc]);
+
+    expect(fs.existsSync(oldFile)).toBe(false);
+    expect(fs.existsSync(freshFile)).toBe(true);
+  });
+
+  it('never removes the location root itself', () => {
+    setOld(root);
+
+    deleteOldFiles([loc]);
+
+    expect(fs.existsSync(root)).toBe(true);
+  });
+});

--- a/src/lib/storage/jobs/helpers/deleteOldFiles.ts
+++ b/src/lib/storage/jobs/helpers/deleteOldFiles.ts
@@ -11,8 +11,14 @@ import { CLEANUP_AGE_SECONDS } from '../../../constants';
  */
 function deleteFile(loc: string) {
   console.time(`finding & removing old ${loc} files`);
+  // `files: '*.*'` only matches extensioned files, so the extensionless UUID
+  // workspace directories under /tmp/workspaces were never swept — 48 dirs /
+  // 335MB accumulated in prod. `dir: '*'` matches every directory, and the
+  // shared `age` filter still gates removal to entries older than
+  // CLEANUP_AGE_SECONDS, so an in-flight conversion's fresh workspace survives.
   findRemoveSync(path.join(os.tmpdir(), loc), {
     files: '*.*',
+    dir: '*',
     age: { seconds: CLEANUP_AGE_SECONDS },
   });
   console.timeEnd(`finding & removing old ${loc} files`);

--- a/src/lib/storage/jobs/helpers/runFileSystemCleanup.ts
+++ b/src/lib/storage/jobs/helpers/runFileSystemCleanup.ts
@@ -6,7 +6,7 @@ import { Knex } from 'knex';
 import deleteOldFiles from './deleteOldFiles';
 import { getDatabase } from '../../../../data_layer';
 
-export const runFileSystemCleanup = (database: Knex) => {
+export const runFileSystemCleanup = async (database: Knex) => {
   console.time('running cleanup');
   const locations = [
     process.env.WORKSPACE_BASE ?? path.join(os.tmpdir(), 'workspaces'),
@@ -14,13 +14,14 @@ export const runFileSystemCleanup = (database: Knex) => {
   ];
 
   deleteOldFiles(locations);
-  database.raw(
+  await database.raw(
     "DELETE FROM jobs WHERE created_at < NOW() - INTERVAL '14 days' AND status = 'failed'"
   );
   console.timeEnd('running cleanup');
 };
 
 if (require.main === module) {
-  runFileSystemCleanup(getDatabase());
-  console.log('Cleanup complete');
+  runFileSystemCleanup(getDatabase())
+    .then(() => console.log('Cleanup complete'))
+    .catch(console.error);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -79,6 +79,7 @@ import ReEngagementRepository from './data_layer/ReEngagementRepository';
 import InactivityEmailRepository from './data_layer/InactivityEmailRepository';
 import UploadRepository from './data_layer/UploadRespository';
 import { updateStripeSubscriptions } from './lib/storage/jobs/helpers/updateStripeSubscriptions';
+import { ScheduleCleanup } from './lib/storage/jobs/ScheduleCleanup';
 import { scheduleReEngagementEmails } from './lib/reengagement/jobs/scheduleReEngagementEmails';
 import { scheduleInactivityWarnings } from './lib/inactivity/jobs/scheduleInactivityWarnings';
 import { schedulePauseResumeWarnings } from './lib/subscriptions/jobs/schedulePauseResumeWarnings';
@@ -328,6 +329,12 @@ const serve = async () => {
   scheduleExportDriftCanary(emailService);
 
   scheduleObservabilityCleanup(new ObservabilityRepository(database));
+
+  try {
+    ScheduleCleanup(database);
+  } catch (error) {
+    console.error('[fs-cleanup] failed to schedule:', error);
+  }
 };
 
 serve().catch((error) => {


### PR DESCRIPTION
## What

Two independent leaks in the conversion pipeline, both verified against prod and
both masked by frequent deploys resetting the process. One process ratcheted RSS
from 317MB to 1.4GB over 20h, and `/tmp/workspaces` held 48 uncleaned directories
totalling 335MB. This PR bounds worker heap growth and makes the temp-file sweep
actually run and actually match the leaking directories.

## The leak (evidence)

- **Memory:** the Piscina conversion pool (`src/lib/conversionPool.ts`) is a
  lifetime singleton — 4 workers, `maxOldGenerationSizeMb: 1024` each, no
  recycling. Per-conversion buffers (Notion blocks, rendered HTML, image/PDF
  bytes) accumulate in worker heaps and only reset on deploy. RSS 317MB -> 1.4GB
  over 20h on a single process.
- **Disk:** `ScheduleCleanup(db)` in `src/lib/storage/jobs/ScheduleCleanup.ts`
  was defined but **never invoked** in `src/server.ts`, so the file sweep never
  ran in prod. And even when run, `deleteOldFiles` matched only `files: '*.*'`,
  which skips the extensionless UUID workspace **directories** under
  `/tmp/workspaces/<uuid>` — 48 dirs / 335MB left behind.

## How the fix works

1. **Bound worker memory via task-count recycling.** After
   `CONVERSION_WORKER_RECYCLE_TASKS` (default 50) completed tasks, the pool is
   drained in the background and a fresh pool is started, so worker heaps reset
   instead of ratcheting for the whole process lifetime. Recycling is re-entry
   guarded (`recyclingPool`) and never drops in-flight conversions — the retiring
   pool's `close()` waits for outstanding tasks up to the drain budget. The
   old-gen cap stays 1024MB deliberately: lowering it risks OOMing the
   comprehensive/big-media path, which would convert a slow leak into failed
   conversions (a behavior regression). Recycling — not a smaller cap — is the
   mechanism that bounds RSS.
2. **Wire `ScheduleCleanup` into startup**, next to the other schedulers, inside
   a try/catch so a scheduling failure logs rather than crashing boot.
3. **`deleteOldFiles` now passes `dir: '*'`** so old workspace directories are
   swept. The shared `age` filter (`CLEANUP_AGE_SECONDS`, 2h) still gates
   removal, so an in-flight conversion's fresh workspace survives — confirmed
   against `find-remove`'s source: the `dir` matcher is AND-ed with the age check.
4. **Await the floating `DELETE FROM jobs` raw query** in `runFileSystemCleanup`
   (now async) so the failed-job prune completes and can't leak an unhandled
   rejection; `ScheduleCleanup`'s interval callback `.catch(console.error)`s it.

The per-conversion `finally` cleanup, the graceful-shutdown drain, and conversion
output are all unchanged.

## New tunable

`CONVERSION_WORKER_RECYCLE_TASKS` — documented in `src/env.example`, default 50,
numeric-guarded (integer >= 1 or falls back to 50). Unset default is the safe
value.

## Regression tests

- `src/lib/conversionPool.test.ts` — pure `shouldRecyclePool` table (below /
  at / above threshold, and suppressed while recycling); integration asserting a
  fresh pool is constructed after N completed `runConversion` calls and not
  before; old-gen cap assertion.
- `src/lib/storage/jobs/helpers/deleteOldFiles.test.ts` — real temp dir: an aged
  workspace directory is removed while a fresh one survives; aged file removed,
  fresh file kept; the location root itself is never removed.
- `src/lib/storage/jobs/ScheduleCleanup.test.ts` — asserts the scheduler runs
  `runFileSystemCleanup(db)` on each `MS_21` tick and `deleteOldUploads(db)` on
  the 24h tick, and swallows a rejected cleanup so the interval keeps running.

## Construction-site check

`runConversion` and `runUploadGeneration` are the only two pool `.run` entry
points (`grep`); both route through `noteTaskCompleted` so recycling counts every
conversion and upload-generation task. `ScheduleCleanup` has a single call site
(now `server.ts`).

## Verification

- `npx tsc -p . --noEmit` clean (typechecks tests too, matching the deploy build).
- New Jest suites green (26 tests); adjacent suites (`gracefulShutdown`,
  `deleteOldUploads`, `performConversion`) green.
- `oxfmt` + `oxlint` clean on touched files.
- Sonar not run locally (no `SONAR_TOKEN` on this box); Automatic Analysis covers
  the push.

## Goal alignment

Internal reliability. A conversion box that never reclaims heap or temp space
degrades and eventually OOMs/fills disk, taking the conversion pipeline down —
broken pipelines lose users. No user-facing behavior change.

No changelog entry — internal reliability (memory + temp-file leak fix), no
user-visible behavior change.

Browser check: not applicable — no `web/src/` changes, server-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs4pvvQ4BKVpvEtGA9GXTn
