### PR TITLE
feat: translate homepage hero and dropzone to German

### DIFF
--- a/web/src/lib/i18n/locales/de/common.json
+++ b/web/src/lib/i18n/locales/de/common.json
@@ -40,5 +40,24 @@
     "picker": "Sprache",
     "english": "English",
     "german": "Deutsch"
+  },
+  "home": {
+    "hero": {
+      "headline": "Karteikarten, die in Anki funktionieren",
+      "subtitle": "Wirf eine Notion-Seite rein und erhalte einen Stapel, den du nicht nachbessern musst — sauberes Cloze, atomare Karten, die richtigen Notiztypen. PDF, Quizlet, Markdown, HTML und CSV ebenfalls.",
+      "aiBadgeIntro": "Saubere Karten, bereit zum Lernen — sauberes Cloze, atomare Vorder- und Rückseite, keine leeren Rückseiten. Lieber KI-Entwürfe?",
+      "createAccount": "Konto erstellen",
+      "cardOptions": "Kartenoptionen",
+      "nativeApps": "Auch auf iPhone, iPad & Mac →"
+    }
+  },
+  "upload": {
+    "dropzone": {
+      "dropActive": "Lass sie genau hier los",
+      "dropIdle": "Zieh deine Dateien hierher",
+      "or": "oder",
+      "chooseFiles": "Dateien auswählen",
+      "csvHint": "Benenne deine Spalten front und back (oder question und answer), damit 2anki sie richtig zuordnet — sonst wird die erste Spalte als Vorderseite und die zweite als Rückseite verwendet."
+    }
   }
 }

--- a/web/src/lib/i18n/locales/en/common.json
+++ b/web/src/lib/i18n/locales/en/common.json
@@ -40,5 +40,24 @@
     "picker": "Language",
     "english": "English",
     "german": "Deutsch"
+  },
+  "home": {
+    "hero": {
+      "headline": "Flashcards that work in Anki",
+      "subtitle": "Drop a Notion page and get a deck you don't have to fix — proper cloze, atomic cards, the right note types. PDF, Quizlet, Markdown, HTML, and CSV too.",
+      "aiBadgeIntro": "Clean cards, ready to study — proper cloze, atomic front and back, no empty backs. Prefer AI drafts?",
+      "createAccount": "Create an account",
+      "cardOptions": "Card options",
+      "nativeApps": "Also on iPhone, iPad & Mac →"
+    }
+  },
+  "upload": {
+    "dropzone": {
+      "dropActive": "Drop it right here",
+      "dropIdle": "Drop your files here",
+      "or": "or",
+      "chooseFiles": "Choose files",
+      "csvHint": "Name your columns front and back (or question and answer) so 2anki maps them right — otherwise it uses the first column as the front and the second as the back."
+    }
   }
 }

--- a/web/src/pages/HomePage/HomePage.i18n.test.tsx
+++ b/web/src/pages/HomePage/HomePage.i18n.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import i18n from '../../lib/i18n';
+import { HomePage } from './HomePage';
+
+vi.mock('../../lib/analytics/track', () => ({
+  track: vi.fn(),
+}));
+
+function renderHome() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <HomePage setErrorMessage={vi.fn()} isLoggedIn={false} />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('HomePage in German', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('renders the hero headline in German', () => {
+    renderHome();
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: 'Karteikarten, die in Anki funktionieren',
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('translates the AI badge and its create-account link', () => {
+    renderHome();
+    expect(
+      screen.getByText(/Saubere Karten, bereit zum Lernen/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Konto erstellen' })
+    ).toBeInTheDocument();
+  });
+
+  it('translates the card-options footer link', () => {
+    renderHome();
+    expect(
+      screen.getByRole('link', { name: 'Kartenoptionen' })
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link, Navigate } from 'react-router-dom';
 import UploadForm from '../UploadPage/components/UploadForm/UploadForm';
 import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
@@ -181,6 +182,7 @@ export function HomePage({
   isLoggedIn,
 }: Readonly<HomePageProps>) {
   useSettingsCardsOptions(null);
+  const { t } = useTranslation();
   const mascotSrc = useMemo(
     () => MASCOTS[Math.floor(Math.random() * MASCOTS.length)],
     []
@@ -206,21 +208,16 @@ export function HomePage({
     <div className={styles.page}>
       <section className={styles.hero}>
         <img src={mascotSrc} alt="" className={styles.mascot} />
-        <h1 className={styles.heroTitle}>Flashcards that work in Anki</h1>
-        <p className={styles.heroSubtitle}>
-          Drop a Notion page and get a deck you don&apos;t have to fix — proper
-          cloze, atomic cards, the right note types. PDF, Quizlet, Markdown,
-          HTML, and CSV too.
-        </p>
+        <h1 className={styles.heroTitle}>{t('home.hero.headline')}</h1>
+        <p className={styles.heroSubtitle}>{t('home.hero.subtitle')}</p>
         <div className={styles.heroControls}>
           <p className={`${sharedStyles.aiOffBadgeBody} ${styles.heroAiBadge}`}>
-            Clean cards, ready to study — proper cloze, atomic front and back,
-            no empty backs. Prefer AI drafts?{' '}
+            {t('home.hero.aiBadgeIntro')}{' '}
             <Link
               to="/register?redirect=/card-options"
               onClick={() => track('home_ai_anon_badge_clicked')}
             >
-              Create an account
+              {t('home.hero.createAccount')}
             </Link>
             .
           </p>
@@ -232,7 +229,7 @@ export function HomePage({
             className={styles.cardOptionsLink}
             onClick={() => track('home_card_options_link_clicked')}
           >
-            Card options
+            {t('home.hero.cardOptions')}
           </Link>
           <span className={styles.footerDot} aria-hidden="true" />
           <Link
@@ -240,7 +237,7 @@ export function HomePage({
             className={styles.cardOptionsLink}
             onClick={() => track('home_native_app_link_clicked')}
           >
-            Also on iPhone, iPad &amp; Mac →
+            {t('home.hero.nativeApps')}
           </Link>
         </div>
       </section>

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.i18n.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.i18n.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+import i18n from '../../../../lib/i18n';
+import UploadForm from './UploadForm';
+
+vi.mock('../../../../lib/analytics/track', () => ({
+  track: vi.fn(),
+}));
+
+vi.mock('../../../../lib/hooks/useUserLocals', () => ({
+  useUserLocals: vi.fn(() => ({
+    data: undefined,
+    isLoading: false,
+    error: null,
+    isError: false,
+    refetch: vi.fn(),
+  })),
+}));
+
+vi.mock('../../../../lib/backend/get2ankiApi', () => ({
+  get2ankiApi: vi.fn(() => ({
+    startPassCheckout: vi.fn().mockResolvedValue({ status: 'error' }),
+  })),
+}));
+
+vi.mock('../../../../lib/hooks/useCardUsage', () => ({
+  useCardUsage: vi.fn(() => null),
+  CARD_USAGE_QUERY_KEY: ['cardUsage'],
+}));
+
+function renderUploadForm() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <UploadForm setErrorMessage={vi.fn()} />
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('UploadForm dropzone in German', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('renders the idle drop prompt in German', () => {
+    renderUploadForm();
+    expect(screen.getByText('Zieh deine Dateien hierher')).toBeInTheDocument();
+  });
+
+  it('translates the choose-files button and column hint', () => {
+    renderUploadForm();
+    expect(screen.getByText('Dateien auswählen')).toBeInTheDocument();
+    expect(
+      screen.getByText(/damit 2anki sie richtig zuordnet/i)
+    ).toBeInTheDocument();
+  });
+
+  it('keeps the format pills untranslated', () => {
+    renderUploadForm();
+    expect(screen.getAllByText('.zip').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('.csv').length).toBeGreaterThan(0);
+  });
+});

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -1,4 +1,5 @@
 import { type SyntheticEvent, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import {
@@ -251,6 +252,7 @@ function UploadForm({
   aiOn = false,
   passLadderShownOnPage = false,
 }: Readonly<UploadFormProps>) {
+  const { t } = useTranslation();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const convertRef = useRef<HTMLButtonElement>(null);
   const downloadRef = useRef<HTMLAnchorElement>(null);
@@ -1280,12 +1282,16 @@ function UploadForm({
     <div className={formStyles.stateContent}>
       <UploadCloudIcon className={formStyles.icon} />
       <span className={formStyles.dropText}>
-        {dropHover ? 'Drop it right here' : 'Drop your files here'}
+        {dropHover
+          ? t('upload.dropzone.dropActive')
+          : t('upload.dropzone.dropIdle')}
       </span>
       {!dropHover && (
         <>
-          <span className={formStyles.dropHint}>or</span>
-          <span className={formStyles.chooseButton}>Choose files</span>
+          <span className={formStyles.dropHint}>{t('upload.dropzone.or')}</span>
+          <span className={formStyles.chooseButton}>
+            {t('upload.dropzone.chooseFiles')}
+          </span>
           <div className={formStyles.formatList}>
             {FORMATS.map((fmt) => (
               <span key={fmt} className={formStyles.formatPill}>
@@ -1294,9 +1300,7 @@ function UploadForm({
             ))}
           </div>
           <span className={formStyles.shapeHint}>
-            Name your columns front and back (or question and answer) so 2anki
-            maps them right — otherwise it uses the first column as the front
-            and the second as the back.
+            {t('upload.dropzone.csvHint')}
           </span>
         </>
       )}

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-16-homepage-german.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-16-homepage-german.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-16-homepage-german",
+  "date": "2026-07-16",
+  "type": "feature",
+  "title": "Homepage now shows in German when you pick Deutsch"
+}


### PR DESCRIPTION
## What
Wires the homepage hero and the upload dropzone through `useTranslation` and adds the matching German/English catalog keys, so the front page at route `/` renders in German when a visitor picks Deutsch.

## Why
PR #3640 shipped the language picker plus navbar and account German, but the homepage hero and dropzone were still hardcoded English — switching to Deutsch left the most-visited page untranslated. This closes that gap.

## How
- New `home.hero.*` and `upload.dropzone.*` keys in `en/common.json` (exact current English) and `de/common.json` (idiomatic du-form German).
- `HomePage.tsx`: headline, subtitle, AI badge intro + create-account link, card-options link, native-apps link now use `t()`.
- `UploadForm.tsx`: idle drop prompt, choose-files button, and CSV column hint now use `t()`. The `FORMATS` pills (`.zip`, `.csv`, …) are untouched — file extensions are not translatable copy.
- Protected brand/format names (Anki, Notion, Quizlet, PDF, Markdown, HTML, CSV, iPhone, iPad, Mac) kept verbatim in both locales.
- No new dependencies — i18next/react-i18next were already present from #3640.

## Measuring success
Client `track('landing_page_viewed')` continues to fire on `/`; the language toggle already persists to `localStorage` (`2anki-language`). A German-locale visitor now sees the German hero — confirm via the picker on `/` and by the What's New entry.

## Testing
- Unit tests added: `HomePage.i18n.test.tsx` (hero headline, AI badge + create-account link, card-options link in German) and `UploadForm.i18n.test.tsx` (drop prompt, choose-files + column hint in German, format pills stay untranslated). Both force `i18n.changeLanguage('de')` and reset to `en`.
- Full worktree run: `pnpm --filter 2anki-web test` — 123 passed. Typecheck exit 0, lint exit 0. `test:golden-path` — 2 passed, no console errors.
- Sonar not run locally; Automatic Analysis covers the push (no SONAR_TOKEN on this box).

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: backed by `pnpm --filter 2anki-web test:golden-path` (2 passed at 375px, only the pre-existing Hotjar-over-HTTPS warn).

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-07-16-homepage-german.json` — "Homepage now shows in German when you pick Deutsch"

## Risks
Low. Copy-only + i18n wiring; no logic or data changes. A missing key would surface as a raw key string and log a warning — every referenced key exists in both locales, and the golden-path (which fails on console errors) is green. Rollback is a revert.

## Goal alignment
Acquisition-facing: the homepage is the top of the signup funnel and German is a large EU-leaning segment. A fully-translated landing page should lift landing → signup conversion for German-locale visitors (read at `track('landing_page_viewed')` → signup rate in the funnel). Directly serves the weekly acquisition-lane allocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs4pvvQ4BKVpvEtGA9GXTn
