### PR TITLE
feat: persist UI language on the user for cross-device sync

### DIFF
--- a/migrations/20260920000000_add_language_to_users.js
+++ b/migrations/20260920000000_add_language_to_users.js
@@ -1,0 +1,11 @@
+module.exports.up = async function (knex) {
+  await knex.schema.alterTable('users', (table) => {
+    table.string('language', 8).nullable();
+  });
+};
+
+module.exports.down = async function (knex) {
+  await knex.schema.alterTable('users', (table) => {
+    table.dropColumn('language');
+  });
+};

--- a/src/controllers/StripeController/StripeController.test.ts
+++ b/src/controllers/StripeController/StripeController.test.ts
@@ -55,6 +55,7 @@ function buildUser(overrides: Partial<UserWithOwner> = {}): UserWithOwner {
     ankify_welcome_seen: false,
     card_options: null,
     theme: null,
+    language: null,
     anki_web_acknowledged_at: null,
     onboarded_at: null,
     email_verified: false,

--- a/src/controllers/UserPreferencesController.test.ts
+++ b/src/controllers/UserPreferencesController.test.ts
@@ -25,6 +25,7 @@ describe('UserPreferencesController.get', () => {
     expect(res.json).toHaveBeenCalledWith({
       cardOptions: null,
       theme: null,
+      language: null,
       ankiWebAcknowledgedAt: null,
     });
   });
@@ -82,6 +83,50 @@ describe('UserPreferencesController.patch', () => {
   it('returns 400 when theme is not a string', async () => {
     const { controller, res } = buildMocks(1);
     const req = { body: { theme: 42 } } as unknown as Request;
+
+    await controller.patch(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('updates language and round-trips it through get', async () => {
+    const { repo, controller, res } = buildMocks(20);
+    const req = { body: { language: 'de' } } as unknown as Request;
+
+    await controller.patch(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ language: 'de' })
+    );
+    const stored = await repo.get(20);
+    expect(stored.language).toBe('de');
+  });
+
+  it('accepts a BCP-47 region code for language', async () => {
+    const { controller, res } = buildMocks(21);
+    const req = { body: { language: 'en-US' } } as unknown as Request;
+
+    await controller.patch(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ language: 'en-US' })
+    );
+  });
+
+  it('returns 400 when language is not a valid code', async () => {
+    const { controller, res } = buildMocks(1);
+    const req = { body: { language: 'english' } } as unknown as Request;
+
+    await controller.patch(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 400 when language is not a string', async () => {
+    const { controller, res } = buildMocks(1);
+    const req = { body: { language: 42 } } as unknown as Request;
 
     await controller.patch(req, res);
 

--- a/src/controllers/UserPreferencesController.ts
+++ b/src/controllers/UserPreferencesController.ts
@@ -14,9 +14,20 @@ function isValidTimestamp(value: unknown): value is string {
   return typeof value === 'string' && !Number.isNaN(Date.parse(value));
 }
 
+const LANGUAGE_PATTERN = /^[a-z]{2}(-[A-Z]{2})?$/;
+
+function isValidLanguage(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length <= 8 &&
+    LANGUAGE_PATTERN.test(value)
+  );
+}
+
 interface PrefsBody {
   cardOptions?: unknown;
   theme?: unknown;
+  language?: unknown;
   ankiWebAcknowledgedAt?: unknown;
 }
 
@@ -27,6 +38,12 @@ function validatePrefsBody(body: PrefsBody, res: Response): boolean {
   }
   if (body.theme !== undefined && typeof body.theme !== 'string') {
     res.status(400).json({ message: 'theme must be a string.' });
+    return false;
+  }
+  if (body.language !== undefined && !isValidLanguage(body.language)) {
+    res.status(400).json({
+      message: 'language must be a short BCP-47 code such as en or de.',
+    });
     return false;
   }
   if (
@@ -63,28 +80,40 @@ export class UserPreferencesController {
   }
 
   async patch(req: Request, res: Response): Promise<void> {
-    const { cardOptions, theme, ankiWebAcknowledgedAt } = req.body;
-    if (!validatePrefsBody({ cardOptions, theme, ankiWebAcknowledgedAt }, res))
+    const { cardOptions, theme, language, ankiWebAcknowledgedAt } = req.body;
+    if (
+      !validatePrefsBody(
+        { cardOptions, theme, language, ankiWebAcknowledgedAt },
+        res
+      )
+    )
       return;
     const userId = res.locals.owner as number;
     const prefs = await this.patchUseCase.execute({
       userId,
       cardOptions,
       theme,
+      language,
       ankiWebAcknowledgedAt,
     });
     res.status(200).json(prefs);
   }
 
   async migrate(req: Request, res: Response): Promise<void> {
-    const { cardOptions, theme, ankiWebAcknowledgedAt } = req.body;
-    if (!validatePrefsBody({ cardOptions, theme, ankiWebAcknowledgedAt }, res))
+    const { cardOptions, theme, language, ankiWebAcknowledgedAt } = req.body;
+    if (
+      !validatePrefsBody(
+        { cardOptions, theme, language, ankiWebAcknowledgedAt },
+        res
+      )
+    )
       return;
     const userId = res.locals.owner as number;
     const prefs = await this.migrateUseCase.execute({
       userId,
       cardOptions,
       theme,
+      language,
       ankiWebAcknowledgedAt,
     });
     res.status(200).json(prefs);

--- a/src/data_layer/UserPreferencesRepository.ts
+++ b/src/data_layer/UserPreferencesRepository.ts
@@ -60,6 +60,7 @@ export type CardOptions = Partial<{
 export interface UserPreferences {
   cardOptions: CardOptions | null;
   theme: string | null;
+  language: string | null;
   ankiWebAcknowledgedAt: string | null;
 }
 
@@ -150,12 +151,13 @@ export class UserPreferencesRepository implements IUserPreferencesRepository {
 
   async get(userId: number): Promise<UserPreferences> {
     const row = await this.database('users')
-      .select('card_options', 'theme', 'anki_web_acknowledged_at')
+      .select('card_options', 'theme', 'language', 'anki_web_acknowledged_at')
       .where({ id: userId })
       .first();
     return {
       cardOptions: row?.card_options ?? null,
       theme: row?.theme ?? null,
+      language: row?.language ?? null,
       ankiWebAcknowledgedAt:
         row?.anki_web_acknowledged_at?.toISOString() ?? null,
     };
@@ -171,6 +173,9 @@ export class UserPreferencesRepository implements IUserPreferencesRepository {
     }
     if (prefs.theme != null) {
       update.theme = prefs.theme;
+    }
+    if (prefs.language != null) {
+      update.language = prefs.language;
     }
     if (prefs.ankiWebAcknowledgedAt != null) {
       update.anki_web_acknowledged_at = this.database.raw(
@@ -195,6 +200,9 @@ export class UserPreferencesRepository implements IUserPreferencesRepository {
     }
     if (prefs.theme != null && current.theme == null) {
       update.theme = prefs.theme;
+    }
+    if (prefs.language != null && current.language == null) {
+      update.language = prefs.language;
     }
     if (
       prefs.ankiWebAcknowledgedAt != null &&
@@ -229,6 +237,7 @@ export class InMemoryUserPreferencesRepository implements IUserPreferencesReposi
       this.store.get(userId) ?? {
         cardOptions: null,
         theme: null,
+        language: null,
         ankiWebAcknowledgedAt: null,
       }
     );
@@ -242,6 +251,7 @@ export class InMemoryUserPreferencesRepository implements IUserPreferencesReposi
     const next: UserPreferences = {
       cardOptions: prefs.cardOptions ?? current.cardOptions,
       theme: prefs.theme ?? current.theme,
+      language: prefs.language ?? current.language,
       ankiWebAcknowledgedAt:
         prefs.ankiWebAcknowledgedAt == null
           ? current.ankiWebAcknowledgedAt
@@ -259,6 +269,7 @@ export class InMemoryUserPreferencesRepository implements IUserPreferencesReposi
     const next: UserPreferences = {
       cardOptions: current.cardOptions ?? prefs.cardOptions ?? null,
       theme: current.theme ?? prefs.theme ?? null,
+      language: current.language ?? prefs.language ?? null,
       ankiWebAcknowledgedAt:
         current.ankiWebAcknowledgedAt ?? prefs.ankiWebAcknowledgedAt ?? null,
     };

--- a/src/data_layer/addLanguageToUsersMigration.sql.test.ts
+++ b/src/data_layer/addLanguageToUsersMigration.sql.test.ts
@@ -1,0 +1,52 @@
+import knex, { Knex } from 'knex';
+
+const migration = require('../../migrations/20260920000000_add_language_to_users.js');
+
+describe('20260920000000 add language to users DDL shape', () => {
+  let db: ReturnType<typeof knex>;
+  let capturedSql: string[];
+
+  beforeAll(() => {
+    db = knex({ client: 'pg' });
+  });
+
+  afterAll(async () => {
+    await db.destroy();
+  });
+
+  beforeEach(() => {
+    capturedSql = [];
+  });
+
+  const recordingKnex = () => ({
+    schema: {
+      alterTable: (
+        table: string,
+        builder: (t: Knex.CreateTableBuilder) => void
+      ) => {
+        const compiled = db.schema.alterTable(table, builder).toSQL();
+        for (const statement of compiled) {
+          capturedSql.push(statement.sql);
+        }
+        return Promise.resolve();
+      },
+    },
+  });
+
+  it('adds a nullable varchar language column without a default', async () => {
+    await migration.up(recordingKnex());
+
+    const joined = capturedSql.join('\n');
+    expect(joined).toContain('alter table "users"');
+    expect(joined).toContain('add column "language" varchar(8)');
+    expect(joined).not.toMatch(/not null/i);
+    expect(joined).not.toMatch(/default/i);
+  });
+
+  it('drops the language column on rollback', async () => {
+    await migration.down(recordingKnex());
+
+    const joined = capturedSql.join('\n');
+    expect(joined).toContain('drop column "language"');
+  });
+});

--- a/src/data_layer/public/Users.ts
+++ b/src/data_layer/public/Users.ts
@@ -59,6 +59,8 @@ export default interface Users {
   prints_month_started_at: Date;
 
   ankify_access: boolean;
+
+  language: string | null;
 }
 
 /** Represents the initializer for the table public.users */
@@ -129,6 +131,8 @@ export interface UsersInitializer {
 
   /** Default value: false */
   ankify_access?: boolean;
+
+  language?: string | null;
 }
 
 /** Represents the mutator for the table public.users */
@@ -186,4 +190,6 @@ export interface UsersMutator {
   prints_month_started_at?: Date;
 
   ankify_access?: boolean;
+
+  language?: string | null;
 }

--- a/src/usecases/MigrateUserPreferencesUseCase.ts
+++ b/src/usecases/MigrateUserPreferencesUseCase.ts
@@ -8,6 +8,7 @@ export interface MigrateUserPreferencesInput {
   userId: number;
   cardOptions?: CardOptions;
   theme?: string;
+  language?: string;
   ankiWebAcknowledgedAt?: string;
 }
 
@@ -18,6 +19,7 @@ export class MigrateUserPreferencesUseCase {
     return this.repo.migrate(input.userId, {
       cardOptions: input.cardOptions,
       theme: input.theme,
+      language: input.language,
       ankiWebAcknowledgedAt: input.ankiWebAcknowledgedAt,
     });
   }

--- a/src/usecases/PatchUserPreferencesUseCase.ts
+++ b/src/usecases/PatchUserPreferencesUseCase.ts
@@ -8,6 +8,7 @@ export interface PatchUserPreferencesInput {
   userId: number;
   cardOptions?: CardOptions;
   theme?: string;
+  language?: string;
   ankiWebAcknowledgedAt?: string;
 }
 
@@ -18,6 +19,7 @@ export class PatchUserPreferencesUseCase {
     return this.repo.patch(input.userId, {
       cardOptions: input.cardOptions,
       theme: input.theme,
+      language: input.language,
       ankiWebAcknowledgedAt: input.ankiWebAcknowledgedAt,
     });
   }

--- a/web/src/components/LanguagePicker/LanguagePicker.tsx
+++ b/web/src/components/LanguagePicker/LanguagePicker.tsx
@@ -2,6 +2,7 @@ import { type ChangeEvent, useId } from 'react';
 import { useTranslation } from 'react-i18next';
 import { track } from '../../lib/analytics/track';
 import { SUPPORTED_LANGUAGES, type SupportedLanguage } from '../../lib/i18n';
+import { scheduleSync } from '../../lib/data_layer/userPreferencesSync';
 import styles from './LanguagePicker.module.css';
 
 interface LanguagePickerProps {
@@ -24,6 +25,7 @@ export function LanguagePicker({ variant = 'compact' }: LanguagePickerProps) {
       return;
     }
     i18n.changeLanguage(next);
+    scheduleSync();
     track('language_changed', { language: next });
   }
 

--- a/web/src/lib/data_layer/userPreferencesSync.test.ts
+++ b/web/src/lib/data_layer/userPreferencesSync.test.ts
@@ -8,6 +8,7 @@ import {
   migrateToServer,
   scheduleSync,
 } from './userPreferencesSync';
+import i18n from '../i18n';
 
 const setCookie = (value: string) => {
   Object.defineProperty(document, 'cookie', {
@@ -117,6 +118,18 @@ describe('userPreferencesSync — authenticated user (token cookie present)', ()
       'field-mapping': '{"front":"Term"}',
     });
   });
+
+  it('scheduleSync includes the stored language in the PATCH body', async () => {
+    localStorage.setItem('2anki-language', 'de');
+
+    scheduleSync();
+    await flushDebounce();
+
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0][1] as { body: string }).body
+    );
+    expect(body.language).toBe('de');
+  });
 });
 
 describe('userPreferencesSync — hydrate (authenticated)', () => {
@@ -127,9 +140,10 @@ describe('userPreferencesSync — hydrate (authenticated)', () => {
     localStorage.clear();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     fetchSpy.mockRestore();
     localStorage.clear();
+    await i18n.changeLanguage('en');
   });
 
   it('writes boolean toggle keys from the server back to localStorage', async () => {
@@ -148,5 +162,24 @@ describe('userPreferencesSync — hydrate (authenticated)', () => {
 
     expect(localStorage.getItem('basic-reversed')).toBe('true');
     expect(localStorage.getItem('cherry')).toBe('true');
+  });
+
+  it('applies a server language to i18n and localStorage', async () => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          cardOptions: null,
+          theme: null,
+          language: 'de',
+          ankiWebAcknowledgedAt: null,
+        }),
+        { status: 200 }
+      )
+    );
+
+    await hydrateFromServer();
+
+    expect(localStorage.getItem('2anki-language')).toBe('de');
+    expect(i18n.resolvedLanguage).toBe('de');
   });
 });

--- a/web/src/lib/data_layer/userPreferencesSync.ts
+++ b/web/src/lib/data_layer/userPreferencesSync.ts
@@ -1,3 +1,5 @@
+import i18n, { LANGUAGE_STORAGE_KEY } from '../i18n';
+
 export const CARD_OPTION_KEYS = [
   'deckName',
   'font-size',
@@ -91,12 +93,16 @@ export function scheduleSync(): void {
     if (!isAuthed()) return;
     const cardOptions = collectCardOptions();
     const theme = localStorage.getItem('2anki-theme');
+    const language = localStorage.getItem(LANGUAGE_STORAGE_KEY);
     const body: Record<string, unknown> = {};
     if (Object.keys(cardOptions).length > 0) {
       body.cardOptions = cardOptions;
     }
     if (theme != null) {
       body.theme = theme;
+    }
+    if (language != null) {
+      body.language = language;
     }
     if (Object.keys(body).length === 0) return;
     try {
@@ -132,6 +138,7 @@ export async function acknowledgeAnkiWeb(): Promise<void> {
 export interface ServerUserPreferences {
   cardOptions: Record<string, string> | null;
   theme: string | null;
+  language: string | null;
   ankiWebAcknowledgedAt: string | null;
 }
 
@@ -151,7 +158,8 @@ export async function hydrateFromServer(): Promise<void> {
   try {
     const res = await fetch(PREFERENCES_URL, { credentials: 'include' });
     if (!res.ok) return;
-    const { cardOptions, theme, ankiWebAcknowledgedAt } = await res.json();
+    const { cardOptions, theme, language, ankiWebAcknowledgedAt } =
+      await res.json();
     if (cardOptions != null && typeof cardOptions === 'object') {
       for (const [key, value] of Object.entries(cardOptions)) {
         if (typeof value === 'string') {
@@ -161,6 +169,10 @@ export async function hydrateFromServer(): Promise<void> {
     }
     if (typeof theme === 'string') {
       localStorage.setItem('2anki-theme', theme);
+    }
+    if (typeof language === 'string') {
+      localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
+      i18n.changeLanguage(language);
     }
     if (typeof ankiWebAcknowledgedAt === 'string') {
       try {
@@ -176,12 +188,16 @@ export async function migrateToServer(): Promise<void> {
   if (!isAuthed()) return;
   const cardOptions = collectCardOptions();
   const theme = localStorage.getItem('2anki-theme');
+  const language = localStorage.getItem(LANGUAGE_STORAGE_KEY);
   const body: Record<string, unknown> = {};
   if (Object.keys(cardOptions).length > 0) {
     body.cardOptions = cardOptions;
   }
   if (theme != null) {
     body.theme = theme;
+  }
+  if (language != null) {
+    body.language = language;
   }
   try {
     if (localStorage.getItem(ANKI_WEB_ACK_KEY) === 'true') {

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-16-language-sync.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-16-language-sync.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-16-language-sync",
+  "date": "2026-07-16",
+  "type": "feature",
+  "title": "Your language choice now follows you across devices"
+}


### PR DESCRIPTION
## What
Adds a `users.language` column and syncs the user's UI language through the existing `/api/users/me/preferences` endpoint, mirroring how `theme` already flows. When a logged-in user picks a language it PATCHes to the server; on load on any device the server value hydrates and applies to i18n. Anonymous users keep the localStorage + browser-detect behavior unchanged.

## Why
#3640 shipped the English/German picker but persisted the choice only in localStorage, so it didn't follow a logged-in user across devices and wasn't available server-side. This is the fast-follow that #3640's body named: DB persistence of the language preference, which also unblocks later email localization.

## How
- Nullable `varchar(8)` column on `users` (holds `en`/`de` and BCP-47 short codes; null = not set, client falls back to browser detection).
- Server: `language` threaded through the generic preferences chain — `UserPreferences` type, repo `get`/`patch`/`migrate` (+ in-memory), both use cases, and the controller. `validatePrefsBody` rejects anything that isn't a short code matching `/^[a-z]{2}(-[A-Z]{2})?$/` (≤8 chars) with a 400. The response is the already-mapped typed `UserPreferences` shape, not a raw row.
- Client: `scheduleSync` includes the stored language; `hydrateFromServer` applies a server language to i18n and localStorage; the `<LanguagePicker>` now calls `scheduleSync()` on change, exactly like `applyTheme` does. No parallel sync path.
- kanel regenerated `src/data_layer/public/Users.ts` against the applied migration (ran from the main checkout against local Postgres; only `Users.ts` taken).

## Measuring success
`language_changed` (already added in #3640, read at `/api/ops/metrics`) still fires on switch. Server-side, `SELECT count(*) FROM users WHERE language IS NOT NULL` (and `WHERE language = 'de'`) confirms the column is being written; a value appearing there for a user who switched on one device and loading on another is the cross-device signal.

## Testing
- Server (Jest): `UserPreferencesController` — language PATCH → get round-trip, BCP-47 region code accepted, 400 on a bad code and on a non-string; migration DDL shape test asserting a nullable `varchar(8)` add-column with no default/not-null and the rollback drop. `tsc -p . --noEmit` green (deploy typechecks tests; the one full `Users`-shape literal in `StripeController.test.ts` got `language: null`).
- Web (Vitest): `scheduleSync` includes `language` in the PATCH body; `hydrateFromServer` applies a server `language` to i18n + localStorage. Mocked at the fetch boundary.
- Web typecheck + lint green (lint warnings are all pre-existing, none in changed files).
- Sonar not run locally; Automatic Analysis covers the push.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: `pnpm --filter 2anki-web test:golden-path` — 2 passed.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-07-16-language-sync.json` — "Your language choice now follows you across devices"

## Risks
Migration is a nullable ADD COLUMN with no default and no backfill — a fast, non-locking change on Postgres. `down` drops the column. Low blast radius: the language field is additive across the whole preferences chain and null-safe at every layer.

## Goal alignment
Retention/quality lever for the German market (7.5% of users per #3640): a persisted language choice removes the re-pick friction on every new device and lays the groundwork for localized transactional email. Not a direct funnel mover — internal foundation for the localization bet whose adoption signal is the `language_changed` rate at `/api/ops/metrics`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs4pvvQ4BKVpvEtGA9GXTn
