### PR TITLE
feat: translate downloads, settings, and upload screens to German

### DIFF
--- a/web/src/components/modals/SettingsModal/SettingsModal.i18n.test.tsx
+++ b/web/src/components/modals/SettingsModal/SettingsModal.i18n.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+import i18n from '../../../lib/i18n';
+import SettingsModal from './SettingsModal';
+
+vi.mock('../../CardOptionsForm/CardOptionsForm', () => ({
+  CardOptionsForm: () => <div data-testid="card-options-form" />,
+}));
+
+function renderModal() {
+  return render(
+    <MemoryRouter>
+      <SettingsModal
+        pageId="page-1"
+        isActive
+        onClickClose={vi.fn()}
+        setError={vi.fn()}
+      />
+    </MemoryRouter>
+  );
+}
+
+describe('SettingsModal in German', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('translates the open-full-page link and close control', () => {
+    renderModal();
+    expect(screen.getByText('Ganze Seite öffnen ↗')).toBeInTheDocument();
+    expect(screen.getByLabelText('schließen')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/modals/SettingsModal/SettingsModal.tsx
+++ b/web/src/components/modals/SettingsModal/SettingsModal.tsx
@@ -1,4 +1,5 @@
 import { SyntheticEvent } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link, useLocation } from 'react-router-dom';
 import { ErrorHandlerType } from '../../errors/helpers/getErrorMessage';
 import { getVisibleText } from '../../../lib/text/getVisibleText';
@@ -22,6 +23,7 @@ function SettingsModal({
   onClickClose,
   setError,
 }: Readonly<Props>) {
+  const { t } = useTranslation();
   const location = useLocation();
   const returnTo = `${location.pathname}${location.search}`;
 
@@ -49,11 +51,11 @@ function SettingsModal({
           </div>
           <div className={styles.headerActions}>
             <Link to={fullPageHref} className={styles.openFullPage}>
-              Open full page ↗
+              {t('settings.openFullPage')}
             </Link>
             <button
               type="button"
-              aria-label="close"
+              aria-label={t('settings.close')}
               onClick={onClickClose}
               className={sharedStyles.modalClose}
             >

--- a/web/src/lib/i18n/locales/de/common.json
+++ b/web/src/lib/i18n/locales/de/common.json
@@ -58,6 +58,43 @@
       "or": "oder",
       "chooseFiles": "Dateien auswählen",
       "csvHint": "Benenne deine Spalten front und back (oder question und answer), damit 2anki sie richtig zuordnet — sonst wird die erste Spalte als Vorderseite und die zweite als Rückseite verwendet."
+    },
+    "form": {
+      "makingDeck": "Dein Stapel wird erstellt",
+      "fetching": "{{filename}} wird von {{source}} geladen",
+      "deckReady": "Dein Stapel ist fertig",
+      "savedToDownloads": "{{deckName}} wurde in deinen Downloads gespeichert",
+      "makeAnother": "Noch einen Stapel erstellen",
+      "fallbackDownload": "Datei nicht erhalten? Lade sie hier herunter.",
+      "feedbackLabel": "Wie war deine Erfahrung?",
+      "multipleChoice": "{{count}} Multiple Choice",
+      "decksReady_one": "{{count}} Stapel fertig",
+      "decksReady_other": "{{count}} Stapel fertig",
+      "download": "Herunterladen",
+      "downloadAll": "Alle herunterladen (zip)",
+      "linksExpire": "Links laufen in 2 Stunden ab — lade jetzt herunter.",
+      "makeMore": "Mehr Stapel erstellen",
+      "noCardsTitle": "Keine Karten in dieser Datei gefunden",
+      "noCardsInFile": "Keine Karten in {{filename}} gefunden",
+      "noCardsBody": "In dieser Datei wurden keine Karten gefunden. Die meisten Dateien brauchen eine Toggle-Liste (Notion) oder ein Frage-Antwort-Paar, um zu Karten zu werden.",
+      "seeCommonProblemsPrefix": "Siehe ",
+      "commonProblems": "häufige Probleme",
+      "seeCommonProblemsSuffix": " für die Formate, die funktionieren.",
+      "downloadEmpty": "Leeren Stapel herunterladen",
+      "tryDifferent": "Eine andere Datei versuchen",
+      "imagesTitle": "Das sehen nach Bildern aus",
+      "imagesBody": "Kein Text zum Lesen, also gab es nichts, woraus Karten werden konnten. Foto zu Stapel liest Bilder mit KI und entwirft Karten, die du vor dem Download prüfst.",
+      "tryPhotoToDeck": "Foto zu Stapel ausprobieren",
+      "errorTitle": "Etwas ist schiefgelaufen",
+      "tryAgain": "Erneut versuchen",
+      "changeSource": "← Quelle ändern",
+      "dropboxPrompt": "Wähle eine Datei aus deiner Dropbox, um sie in einen Stapel zu konvertieren",
+      "chooseFromDropbox": "Aus Dropbox wählen",
+      "openingDropbox": "Dropbox wird geöffnet",
+      "drivePrompt": "Wähle ein Doc, Sheet, Slide oder eine Datei aus deinem Google Drive.",
+      "driveHint": "Docs funktionieren am besten als Aufzählungsgliederung — der oberste Punkt fragt, der eingerückte Punkt antwortet.",
+      "chooseFromDrive": "Aus Google Drive wählen",
+      "openingDrive": "Google Drive wird geöffnet"
     }
   },
   "auth": {
@@ -248,6 +285,114 @@
       "formatsDesc": "PDF, Word, PowerPoint, EPUB, CSV, Markdown und mehr",
       "themesTitle": "Designs",
       "themesDesc": "Hell, dunkel, gold und lila"
+    }
+  },
+  "downloads": {
+    "title": "Meine Stapel",
+    "subtitle": "Saubere Stapel — sauberes Cloze, atomare Karten, keine leeren Rückseiten. Lade sie direkt in Anki.",
+    "emailVerified": "E-Mail bestätigt. Alles bereit.",
+    "makeAnotherDeck": "Noch einen Stapel erstellen",
+    "noMatch": "Kein Stapel passt zu diesem Filter.",
+    "filters": {
+      "all": "Alle",
+      "ready": "Fertig",
+      "inProgress": "In Arbeit",
+      "failed": "Fehlgeschlagen",
+      "fromDropbox": "Aus Dropbox",
+      "fromDrive": "Aus Drive"
+    },
+    "columns": {
+      "name": "Name",
+      "source": "Quelle",
+      "created": "Erstellt",
+      "actions": "Aktionen"
+    },
+    "source": {
+      "notion": "Notion",
+      "upload": "Hochgeladen",
+      "app": "Aus der App",
+      "dropbox": "Dropbox",
+      "drive": "Drive"
+    },
+    "badge": {
+      "writtenWithClaude": "Mit Claude geschrieben",
+      "monthlyLimitReached": "Monatslimit erreicht",
+      "partial": "Teilweise",
+      "shared": "Geteilt",
+      "imageSkipped_one": "{{count}} Bild übersprungen",
+      "imageSkipped_other": "{{count}} Bilder übersprungen"
+    },
+    "done": "Fertig",
+    "openInNotion": "In Notion öffnen",
+    "empty": {
+      "title": "Noch keine Stapel",
+      "body": "Füge einen Notion-Link ein oder lade eine Datei hoch, um deinen ersten Stapel zu erstellen.",
+      "makeDeck": "Stapel erstellen",
+      "needHelp": "Brauchst du Hilfe?",
+      "uploadFile": "Datei hochladen"
+    },
+    "actions": {
+      "download": "Herunterladen",
+      "downloadNamed": "{{name}} herunterladen",
+      "preview": "Vorschau",
+      "previewNamed": "Vorschau von {{name}}",
+      "delete": "Löschen",
+      "deleteNamed": "{{name}} löschen",
+      "cancel": "Abbrechen",
+      "cancelNamed": "{{name}} abbrechen",
+      "remove": "Entfernen",
+      "removeNamed": "{{name}} entfernen",
+      "restart": "Neu starten",
+      "restartJob": "Auftrag neu starten"
+    },
+    "toggle": {
+      "collapseLimit": "Monatslimit-Details einklappen",
+      "showLimit": "Monatslimit-Details anzeigen",
+      "collapseFailure": "Fehlergrund einklappen",
+      "showFailure": "Fehlergrund anzeigen",
+      "collapseNote": "Konvertierungshinweis einklappen",
+      "showNote": "Konvertierungshinweis anzeigen",
+      "collapseImageNote": "Bildhinweis einklappen",
+      "showImageNote": "Bildhinweis anzeigen"
+    }
+  },
+  "status": {
+    "generating": "Karteikarten werden erstellt ({{current}} / {{total}})",
+    "queued": "In Warteschlange",
+    "inProgress": "In Arbeit",
+    "done": "Fertig",
+    "interrupted": "Unterbrochen",
+    "stuck": "Hängt fest",
+    "failed": "Fehlgeschlagen",
+    "cancelled": "Abgebrochen"
+  },
+  "settings": {
+    "openFullPage": "Ganze Seite öffnen ↗",
+    "close": "schließen"
+  },
+  "conversionResult": {
+    "success": {
+      "card_one": "Karte",
+      "card_other": "Karten",
+      "helper": "Keine leeren Rückseiten, keine überflüssigen Zeichen. Bereit für Anki."
+    },
+    "notionExpired": "Notion-Verbindung abgelaufen. Verbinde neu, um weiter Seiten zu konvertieren.",
+    "reconnectNotion": "Notion neu verbinden",
+    "emptyDeckTeaching": "2anki erstellt aus jedem Notion-Toggle eine Karte — der Toggle-Titel wird zur Frage, der Inhalt zur Antwort. Verpacke deine Schlüsselbegriffe in Toggles und konvertiere erneut.",
+    "togglesDocs": "So werden Toggles zu Karten",
+    "ambiguousColumns": "Diese Datenbank hat mehr als zwei Spalten. Wähle, welche Spalte die Vorder- und welche die Rückseite jeder Karte sein soll.",
+    "mapColumns": "Spalten zuordnen",
+    "checkStatusPrefix": "Sieht etwas komisch aus? ",
+    "checkStatus": "Status prüfen.",
+    "paywall": {
+      "headlineReached": "Du hast deine {{limit}} kostenlosen Karten diesen Monat erreicht",
+      "headlineUsed": "Du hast {{cardsUsed}} von {{limit}} kostenlosen Karten diesen Monat genutzt",
+      "bodyNoReset": "Diese Konvertierung würde dein kostenloses Limit überschreiten und wurde deshalb nicht abgeschlossen. Hol dir einen Pass, um jetzt weiter zu konvertieren.",
+      "bodyWithReset": "Diese Konvertierung würde dein kostenloses Limit überschreiten und wurde deshalb nicht abgeschlossen. Deine kostenlosen Karten werden am {{resetDate}} aufgefrischt, oder hol dir einen Pass, um jetzt weiter zu konvertieren.",
+      "openingCheckout": "Checkout wird geöffnet",
+      "getDayPass": "Day Pass holen — {{price}}",
+      "getWeekPass": "Week Pass holen — {{price}}",
+      "upgradeUnlimited": "Auf Unlimited upgraden"
     }
   }
 }

--- a/web/src/lib/i18n/locales/en/common.json
+++ b/web/src/lib/i18n/locales/en/common.json
@@ -58,6 +58,43 @@
       "or": "or",
       "chooseFiles": "Choose files",
       "csvHint": "Name your columns front and back (or question and answer) so 2anki maps them right — otherwise it uses the first column as the front and the second as the back."
+    },
+    "form": {
+      "makingDeck": "Making your deck...",
+      "fetching": "Fetching {{filename}} from {{source}}",
+      "deckReady": "Your deck is ready",
+      "savedToDownloads": "{{deckName}} was saved to your downloads",
+      "makeAnother": "Make another deck",
+      "fallbackDownload": "Didn't get the file? Download it here.",
+      "feedbackLabel": "How was your experience?",
+      "multipleChoice": "{{count}} multiple choice",
+      "decksReady_one": "{{count}} deck ready",
+      "decksReady_other": "{{count}} decks ready",
+      "download": "Download",
+      "downloadAll": "Download all (zip)",
+      "linksExpire": "Links expire in 2 hours — download now.",
+      "makeMore": "Make more decks",
+      "noCardsTitle": "No cards found in this file",
+      "noCardsInFile": "No cards found in {{filename}}",
+      "noCardsBody": "No cards were found in this file. Most files need a toggle-list (Notion) or a question/answer pair to become cards.",
+      "seeCommonProblemsPrefix": "See ",
+      "commonProblems": "common problems",
+      "seeCommonProblemsSuffix": " for the formats that work.",
+      "downloadEmpty": "Download empty deck",
+      "tryDifferent": "Try a different file",
+      "imagesTitle": "These look like images",
+      "imagesBody": "No text to read, so there was nothing to turn into cards. Photo to Deck reads images with AI and drafts cards you review before download.",
+      "tryPhotoToDeck": "Try Photo to Deck",
+      "errorTitle": "Something went wrong",
+      "tryAgain": "Try again",
+      "changeSource": "← Change source",
+      "dropboxPrompt": "Pick a file from your Dropbox to convert it into a deck",
+      "chooseFromDropbox": "Choose from Dropbox",
+      "openingDropbox": "Opening Dropbox",
+      "drivePrompt": "Pick a Doc, Sheet, Slide, or file from your Google Drive.",
+      "driveHint": "Docs work best as a bulleted outline — top bullet asks, indented bullet answers.",
+      "chooseFromDrive": "Choose from Google Drive",
+      "openingDrive": "Opening Google Drive"
     }
   },
   "auth": {
@@ -248,6 +285,114 @@
       "formatsDesc": "PDF, Word, PowerPoint, EPUB, CSV, Markdown, and more",
       "themesTitle": "Themes",
       "themesDesc": "Light, dark, gold, and purple"
+    }
+  },
+  "downloads": {
+    "title": "My decks",
+    "subtitle": "Clean decks — proper cloze, atomic cards, no empty backs. Download straight into Anki.",
+    "emailVerified": "Email verified. You're all set.",
+    "makeAnotherDeck": "Make another deck",
+    "noMatch": "No decks match this filter.",
+    "filters": {
+      "all": "All",
+      "ready": "Ready",
+      "inProgress": "In progress",
+      "failed": "Failed",
+      "fromDropbox": "From Dropbox",
+      "fromDrive": "From Drive"
+    },
+    "columns": {
+      "name": "Name",
+      "source": "Source",
+      "created": "Created",
+      "actions": "Actions"
+    },
+    "source": {
+      "notion": "Notion",
+      "upload": "Upload",
+      "app": "From the app",
+      "dropbox": "Dropbox",
+      "drive": "Drive"
+    },
+    "badge": {
+      "writtenWithClaude": "Written with Claude",
+      "monthlyLimitReached": "Monthly limit reached",
+      "partial": "Partial",
+      "shared": "Shared",
+      "imageSkipped_one": "{{count}} image skipped",
+      "imageSkipped_other": "{{count}} images skipped"
+    },
+    "done": "Done",
+    "openInNotion": "Open in Notion",
+    "empty": {
+      "title": "No decks yet",
+      "body": "Paste a Notion link or upload a file to make your first deck.",
+      "makeDeck": "Make a deck",
+      "needHelp": "Need help?",
+      "uploadFile": "Upload a file"
+    },
+    "actions": {
+      "download": "Download",
+      "downloadNamed": "Download {{name}}",
+      "preview": "Preview",
+      "previewNamed": "Preview {{name}}",
+      "delete": "Delete",
+      "deleteNamed": "Delete {{name}}",
+      "cancel": "Cancel",
+      "cancelNamed": "Cancel {{name}}",
+      "remove": "Remove",
+      "removeNamed": "Remove {{name}}",
+      "restart": "Restart",
+      "restartJob": "Restart job"
+    },
+    "toggle": {
+      "collapseLimit": "Collapse monthly limit details",
+      "showLimit": "Show monthly limit details",
+      "collapseFailure": "Collapse failure reason",
+      "showFailure": "Show failure reason",
+      "collapseNote": "Collapse conversion note",
+      "showNote": "Show conversion note",
+      "collapseImageNote": "Collapse image note",
+      "showImageNote": "Show image note"
+    }
+  },
+  "status": {
+    "generating": "Generating flashcards ({{current}} / {{total}})",
+    "queued": "Queued",
+    "inProgress": "In Progress",
+    "done": "Done",
+    "interrupted": "Interrupted",
+    "stuck": "Stuck",
+    "failed": "Failed",
+    "cancelled": "Cancelled"
+  },
+  "settings": {
+    "openFullPage": "Open full page ↗",
+    "close": "close"
+  },
+  "conversionResult": {
+    "success": {
+      "card_one": "card",
+      "card_other": "cards",
+      "helper": "No empty backs, no stray characters. Ready for Anki."
+    },
+    "notionExpired": "Notion connection expired. Reconnect to keep converting pages.",
+    "reconnectNotion": "Reconnect Notion",
+    "emptyDeckTeaching": "2anki makes a card from every Notion toggle — the toggle title becomes the question, what's inside becomes the answer. Wrap your key terms in toggles, then convert again.",
+    "togglesDocs": "See how toggles become cards",
+    "ambiguousColumns": "This database has more than two columns. Pick which column should be the front and back of each card.",
+    "mapColumns": "Map columns",
+    "checkStatusPrefix": "Something looks off? ",
+    "checkStatus": "Check status.",
+    "paywall": {
+      "headlineReached": "You've reached your {{limit}} free cards this month",
+      "headlineUsed": "You've used {{cardsUsed}} of your {{limit}} free cards this month",
+      "bodyNoReset": "This conversion would go past your free limit, so it didn't finish. Get a pass to keep converting now.",
+      "bodyWithReset": "This conversion would go past your free limit, so it didn't finish. Your free cards refresh on {{resetDate}}, or get a pass to keep converting now.",
+      "openingCheckout": "Opening checkout",
+      "getDayPass": "Get Day Pass — {{price}}",
+      "getWeekPass": "Get Week Pass — {{price}}",
+      "upgradeUnlimited": "Upgrade to Unlimited"
     }
   }
 }

--- a/web/src/pages/DownloadsPage/DownloadsPage.i18n.test.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.i18n.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import i18n from '../../lib/i18n';
+import { DownloadsPage } from './DownloadsPage';
+import JobResponse from '../../schemas/public/JobResponse';
+import { JobsId } from '../../schemas/public/Jobs';
+
+let mockJobs: JobResponse[] = [];
+
+vi.mock('./hooks/useJobs', () => ({
+  default: () => ({
+    jobs: mockJobs,
+    deleteJob: vi.fn(),
+    restartJob: vi.fn(),
+    refreshJobs: vi.fn().mockResolvedValue(undefined),
+    lastFetchedAt: new Date('2026-05-18T12:00:00Z'),
+  }),
+}));
+
+vi.mock('./hooks/useUploads', () => ({
+  default: () => ({
+    uploads: [],
+    loading: false,
+    error: null,
+    deleteUpload: vi.fn(),
+    refreshUploads: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('./hooks/useDropboxUploads', () => ({
+  default: () => ({ uploads: [], deleteUpload: vi.fn() }),
+}));
+
+vi.mock('./hooks/useGoogleDriveUploads', () => ({
+  default: () => ({ uploads: [], deleteUpload: vi.fn() }),
+}));
+
+vi.mock('./hooks/useActiveShares', () => ({
+  useActiveShares: () => [],
+}));
+
+vi.mock('../../lib/backend/get2ankiApi', () => ({
+  get2ankiApi: () => ({}),
+}));
+
+vi.mock('../../lib/hooks/useUserLocals', () => ({
+  useUserLocals: () => ({
+    data: { locals: { patreon: false, subscriber: false } },
+  }),
+}));
+
+const buildJob = (overrides: Partial<JobResponse> = {}): JobResponse => ({
+  id: 1 as JobsId,
+  owner: 'owner-1',
+  object_id: 'page-id',
+  status: 'done',
+  created_at: new Date('2026-05-10T11:30:00Z'),
+  last_edited_time: new Date('2026-05-10T11:30:00Z'),
+  title: 'Pharmacology Ch. 4',
+  type: 'page',
+  job_reason_failure: null,
+  restartable: false,
+  download_key: 'deck.apkg',
+  upload_id: null,
+  ...overrides,
+});
+
+function renderPage() {
+  return render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <MemoryRouter initialEntries={['/downloads']}>
+        <DownloadsPage setError={vi.fn()} />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('DownloadsPage in German', () => {
+  beforeEach(async () => {
+    mockJobs = [buildJob()];
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('translates the page header and subtitle', () => {
+    renderPage();
+    expect(screen.getByText('Meine Stapel')).toBeInTheDocument();
+    expect(screen.getByText(/Lade sie direkt in Anki/i)).toBeInTheDocument();
+  });
+
+  it('translates the filter chips and table columns', () => {
+    renderPage();
+    expect(screen.getByText('Alle')).toBeInTheDocument();
+    expect(screen.getByText('In Arbeit')).toBeInTheDocument();
+    expect(screen.getByText('Quelle')).toBeInTheDocument();
+    expect(screen.getByText('Aktionen')).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { DownloadsPage, renderJobStatusCell } from './DownloadsPage';
+import i18n from '../../lib/i18n';
 import JobResponse from '../../schemas/public/JobResponse';
 import { JobsId } from '../../schemas/public/Jobs';
 
@@ -405,7 +406,7 @@ describe('renderJobStatusCell — URL construction', () => {
       download_key: 'abc123.apkg',
       upload_id: 5,
     });
-    const result = renderJobStatusCell(job);
+    const result = renderJobStatusCell(job, i18n.t);
     const { container } = render(<>{result}</>);
     const link = container.querySelector('a');
     expect(link?.getAttribute('href')).toBe('/api/download/u/abc123.apkg');
@@ -418,7 +419,7 @@ describe('renderJobStatusCell — URL construction', () => {
       download_key: null,
       upload_id: null,
     });
-    const result = renderJobStatusCell(job);
+    const result = renderJobStatusCell(job, i18n.t);
     expect(result).toBeNull();
   });
 
@@ -428,7 +429,7 @@ describe('renderJobStatusCell — URL construction', () => {
       download_key: null,
       upload_id: null,
     });
-    const result = renderJobStatusCell(job);
+    const result = renderJobStatusCell(job, i18n.t);
     expect(result).not.toBeNull();
   });
 });

--- a/web/src/pages/DownloadsPage/DownloadsPage.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.tsx
@@ -5,6 +5,8 @@ import {
   useState,
   type ReactNode,
 } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { useSearchParams, Link, useNavigate } from 'react-router-dom';
 
 import useUploads from './hooks/useUploads';
@@ -96,18 +98,18 @@ function isGeneratingStatus(status: string): boolean {
   );
 }
 
-function getSourceLabel(source: DeckRow['source']): string {
+function getSourceLabel(source: DeckRow['source'], t: TFunction): string {
   switch (source) {
     case 'notion':
-      return 'Notion';
+      return t('downloads.source.notion');
     case 'upload':
-      return 'Upload';
+      return t('downloads.source.upload');
     case 'app':
-      return 'From the app';
+      return t('downloads.source.app');
     case 'dropbox':
-      return 'Dropbox';
+      return t('downloads.source.dropbox');
     case 'drive':
-      return 'Drive';
+      return t('downloads.source.drive');
   }
 }
 
@@ -137,7 +139,11 @@ interface RenderJobStatusOptions {
   onToggle: () => void;
 }
 
-export function renderJobStatusCell(j: JobResponse, onDownload?: () => void) {
+export function renderJobStatusCell(
+  j: JobResponse,
+  t: TFunction,
+  onDownload?: () => void
+) {
   if (isDoneJob(j.status)) {
     if (j.type === 'apkg_import') {
       let notionUrl: string | null = null;
@@ -148,7 +154,7 @@ export function renderJobStatusCell(j: JobResponse, onDownload?: () => void) {
         /* not JSON */
       }
       return notionUrl == null ? (
-        <span>Done</span>
+        <span>{t('downloads.done')}</span>
       ) : (
         <a
           href={notionUrl}
@@ -156,7 +162,7 @@ export function renderJobStatusCell(j: JobResponse, onDownload?: () => void) {
           rel="noopener noreferrer"
           className={styles.downloadButton}
         >
-          Open in Notion
+          {t('downloads.openInNotion')}
         </a>
       );
     }
@@ -165,8 +171,10 @@ export function renderJobStatusCell(j: JobResponse, onDownload?: () => void) {
         <a
           href={`/api/download/u/${j.download_key}`}
           className={styles.downloadAction}
-          aria-label={`Download ${j.title ?? 'deck'}`}
-          title="Download"
+          aria-label={t('downloads.actions.downloadNamed', {
+            name: j.title ?? 'deck',
+          })}
+          title={t('downloads.actions.download')}
           onClick={() => {
             onDownload?.();
             fireAnalyticsEvent('deck_downloaded');
@@ -191,21 +199,23 @@ export function renderJobStatusCell(j: JobResponse, onDownload?: () => void) {
 
 function getFailureToggleLabel(
   isMonthlyLimit: boolean,
-  isExpanded: boolean
+  isExpanded: boolean,
+  t: TFunction
 ): string {
   if (isMonthlyLimit) {
     return isExpanded
-      ? 'Collapse monthly limit details'
-      : 'Show monthly limit details';
+      ? t('downloads.toggle.collapseLimit')
+      : t('downloads.toggle.showLimit');
   }
-  return isExpanded ? 'Collapse failure reason' : 'Show failure reason';
+  return isExpanded
+    ? t('downloads.toggle.collapseFailure')
+    : t('downloads.toggle.showFailure');
 }
 
-function renderJobStatusWithToggle({
-  job,
-  isExpanded,
-  onToggle,
-}: RenderJobStatusOptions) {
+function renderJobStatusWithToggle(
+  { job, isExpanded, onToggle }: RenderJobStatusOptions,
+  t: TFunction
+) {
   if (isFailedJob(job.status)) {
     const isMonthlyLimit =
       parseMonthlyLimitPayload(job.job_reason_failure) != null;
@@ -214,11 +224,13 @@ function renderJobStatusWithToggle({
         type="button"
         className={styles.statusToggle}
         onClick={onToggle}
-        aria-label={getFailureToggleLabel(isMonthlyLimit, isExpanded)}
+        aria-label={getFailureToggleLabel(isMonthlyLimit, isExpanded, t)}
         aria-expanded={isExpanded}
       >
         {isMonthlyLimit ? (
-          <span className={sharedStyles.badge}>Monthly limit reached</span>
+          <span className={sharedStyles.badge}>
+            {t('downloads.badge.monthlyLimitReached')}
+          </span>
         ) : (
           <StatusTag status={job.status as JobStatus} />
         )}
@@ -230,7 +242,7 @@ function renderJobStatusWithToggle({
       </button>
     );
   }
-  return renderJobStatusCell(job);
+  return renderJobStatusCell(job, t);
 }
 
 const NOTION_TOKEN_EXPIRED_REASON = 'notion_token_expired';
@@ -305,6 +317,7 @@ function FilterChip({
 }
 
 export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
+  const { t } = useTranslation();
   const backend = get2ankiApi();
   const { deleteUpload, loading, uploads, error, refreshUploads } =
     useUploads(backend);
@@ -460,15 +473,12 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
           role="status"
           aria-live="polite"
         >
-          Email verified. You&apos;re all set.
+          {t('downloads.emailVerified')}
         </div>
       )}
       <div className={sharedStyles.pageHeader}>
-        <h1 className={sharedStyles.title}>My decks</h1>
-        <p className={sharedStyles.subtitle}>
-          Clean decks — proper cloze, atomic cards, no empty backs. Download
-          straight into Anki.
-        </p>
+        <h1 className={sharedStyles.title}>{t('downloads.title')}</h1>
+        <p className={sharedStyles.subtitle}>{t('downloads.subtitle')}</p>
       </div>
 
       {loading ? (
@@ -490,37 +500,37 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                 style={{ marginBottom: '1rem' }}
               >
                 <FilterChip
-                  label="All"
+                  label={t('downloads.filters.all')}
                   value="all"
                   active={activeFilter === 'all'}
                   onSelect={setFilter}
                 />
                 <FilterChip
-                  label="Ready"
+                  label={t('downloads.filters.ready')}
                   value="ready"
                   active={activeFilter === 'ready'}
                   onSelect={setFilter}
                 />
                 <FilterChip
-                  label="In progress"
+                  label={t('downloads.filters.inProgress')}
                   value="in-progress"
                   active={activeFilter === 'in-progress'}
                   onSelect={setFilter}
                 />
                 <FilterChip
-                  label="Failed"
+                  label={t('downloads.filters.failed')}
                   value="failed"
                   active={activeFilter === 'failed'}
                   onSelect={setFilter}
                 />
                 <FilterChip
-                  label="From Dropbox"
+                  label={t('downloads.filters.fromDropbox')}
                   value="dropbox"
                   active={activeFilter === 'dropbox'}
                   onSelect={setFilter}
                 />
                 <FilterChip
-                  label="From Drive"
+                  label={t('downloads.filters.fromDrive')}
                   value="drive"
                   active={activeFilter === 'drive'}
                   onSelect={setFilter}
@@ -532,11 +542,11 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                   <table className={styles.table}>
                     <thead>
                       <tr>
-                        <th>Name</th>
-                        <th>Source</th>
-                        <th>Created</th>
+                        <th>{t('downloads.columns.name')}</th>
+                        <th>{t('downloads.columns.source')}</th>
+                        <th>{t('downloads.columns.created')}</th>
                         <th className={sharedStyles.actionColumnWide}>
-                          Actions
+                          {t('downloads.columns.actions')}
                         </th>
                       </tr>
                     </thead>
@@ -551,7 +561,7 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                               padding: '2rem 1rem',
                             }}
                           >
-                            No decks match this filter.
+                            {t('downloads.noMatch')}
                           </td>
                         </tr>
                       )}
@@ -599,8 +609,8 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                   <span className={sharedStyles.badge}>
                                     {row.source === 'upload' &&
                                     row.job.type === 'claude'
-                                      ? 'Written with Claude'
-                                      : getSourceLabel(row.source)}
+                                      ? t('downloads.badge.writtenWithClaude')
+                                      : getSourceLabel(row.source, t)}
                                   </span>
                                 </td>
                                 <td>
@@ -613,14 +623,17 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                 <td>
                                   <div className={styles.actions}>
                                     {isFailed ? (
-                                      renderJobStatusWithToggle({
-                                        job: row.job,
-                                        isExpanded,
-                                        onToggle: toggleFailurePanel,
-                                      })
+                                      renderJobStatusWithToggle(
+                                        {
+                                          job: row.job,
+                                          isExpanded,
+                                          onToggle: toggleFailurePanel,
+                                        },
+                                        t
+                                      )
                                     ) : (
                                       <>
-                                        {renderJobStatusCell(row.job, () =>
+                                        {renderJobStatusCell(row.job, t, () =>
                                           setHasDownloaded(true)
                                         )}
                                         {truncation != null && (
@@ -630,15 +643,17 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                             onClick={toggleFailurePanel}
                                             aria-label={
                                               isExpanded
-                                                ? 'Collapse conversion note'
-                                                : 'Show conversion note'
+                                                ? t(
+                                                    'downloads.toggle.collapseNote'
+                                                  )
+                                                : t('downloads.toggle.showNote')
                                             }
                                             aria-expanded={isExpanded}
                                           >
                                             <span
                                               className={sharedStyles.badge}
                                             >
-                                              Partial
+                                              {t('downloads.badge.partial')}
                                             </span>
                                             <span
                                               className={`${styles.statusChevron} ${isExpanded ? styles.statusChevronExpanded : ''}`}
@@ -654,8 +669,12 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                             onClick={toggleFailurePanel}
                                             aria-label={
                                               isExpanded
-                                                ? 'Collapse image note'
-                                                : 'Show image note'
+                                                ? t(
+                                                    'downloads.toggle.collapseImageNote'
+                                                  )
+                                                : t(
+                                                    'downloads.toggle.showImageNote'
+                                                  )
                                             }
                                             aria-expanded={isExpanded}
                                           >
@@ -664,9 +683,12 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                                 sharedStyles.badgeWarning
                                               }
                                             >
-                                              {droppedAssets === 1
-                                                ? '1 image skipped'
-                                                : `${droppedAssets} images skipped`}
+                                              {t(
+                                                'downloads.badge.imageSkipped',
+                                                {
+                                                  count: droppedAssets,
+                                                }
+                                              )}
                                             </span>
                                             <span
                                               className={`${styles.statusChevron} ${isExpanded ? styles.statusChevronExpanded : ''}`}
@@ -686,8 +708,13 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                           <Link
                                             to={`/preview/apkg/${encodeURIComponent(row.job.download_key)}`}
                                             className={styles.iconButton}
-                                            aria-label={`Preview ${row.job.title ?? 'deck'}`}
-                                            title="Preview"
+                                            aria-label={t(
+                                              'downloads.actions.previewNamed',
+                                              { name: row.job.title ?? 'deck' }
+                                            )}
+                                            title={t(
+                                              'downloads.actions.preview'
+                                            )}
                                           >
                                             <EyeIcon width={16} height={16} />
                                           </Link>
@@ -710,8 +737,12 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                             type="button"
                                             onClick={() => restartJob(row.job)}
                                             className={styles.iconButton}
-                                            aria-label="Restart job"
-                                            title="Restart"
+                                            aria-label={t(
+                                              'downloads.actions.restartJob'
+                                            )}
+                                            title={t(
+                                              'downloads.actions.restart'
+                                            )}
                                           >
                                             ↺
                                           </button>
@@ -724,10 +755,24 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                         className={`${styles.iconButton} ${styles.iconButtonDanger}`}
                                         aria-label={
                                           isFailed || isDoneJob(row.job.status)
-                                            ? `Delete ${row.job.title}`
-                                            : `Cancel ${row.job.title}`
+                                            ? t(
+                                                'downloads.actions.deleteNamed',
+                                                {
+                                                  name: row.job.title,
+                                                }
+                                              )
+                                            : t(
+                                                'downloads.actions.cancelNamed',
+                                                {
+                                                  name: row.job.title,
+                                                }
+                                              )
                                         }
-                                        title={isFailed ? 'Delete' : 'Cancel'}
+                                        title={
+                                          isFailed
+                                            ? t('downloads.actions.delete')
+                                            : t('downloads.actions.cancel')
+                                        }
                                       >
                                         <TrashIcon width={16} height={16} />
                                       </button>
@@ -825,13 +870,13 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                     }}
                                     title="Shared — click to open preview"
                                   >
-                                    Shared
+                                    {t('downloads.badge.shared')}
                                   </Link>
                                 )}
                               </td>
                               <td>
                                 <span className={sharedStyles.badge}>
-                                  {getSourceLabel(row.source)}
+                                  {getSourceLabel(row.source, t)}
                                 </span>
                               </td>
                               <td>
@@ -846,8 +891,11 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                   <a
                                     href={`/api/download/u/${u.key}`}
                                     className={styles.downloadAction}
-                                    aria-label={`Download ${u.filename}`}
-                                    title="Download"
+                                    aria-label={t(
+                                      'downloads.actions.downloadNamed',
+                                      { name: u.filename }
+                                    )}
+                                    title={t('downloads.actions.download')}
                                     onClick={() => {
                                       setHasDownloaded(true);
                                       fireAnalyticsEvent('deck_downloaded');
@@ -861,8 +909,11 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                       <Link
                                         to={`/preview/apkg/${encodeURIComponent(u.key)}`}
                                         className={styles.iconButton}
-                                        aria-label={`Preview ${u.filename}`}
-                                        title="Preview"
+                                        aria-label={t(
+                                          'downloads.actions.previewNamed',
+                                          { name: u.filename }
+                                        )}
+                                        title={t('downloads.actions.preview')}
                                       >
                                         <EyeIcon width={16} height={16} />
                                       </Link>
@@ -877,8 +928,11 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                       type="button"
                                       onClick={() => handleDeleteUpload(u.key)}
                                       className={`${styles.iconButton} ${styles.iconButtonDanger}`}
-                                      aria-label={`Delete ${u.filename}`}
-                                      title="Delete"
+                                      aria-label={t(
+                                        'downloads.actions.deleteNamed',
+                                        { name: u.filename }
+                                      )}
+                                      title={t('downloads.actions.delete')}
                                     >
                                       <TrashIcon width={16} height={16} />
                                     </button>
@@ -906,7 +960,7 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                               </td>
                               <td>
                                 <span className={sharedStyles.badge}>
-                                  Dropbox
+                                  {t('downloads.source.dropbox')}
                                 </span>
                               </td>
                               <td>
@@ -923,8 +977,11 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                       type="button"
                                       className={`${styles.iconButton} ${styles.iconButtonDanger}`}
                                       onClick={() => deleteDropboxUpload(d.id)}
-                                      aria-label={`Remove ${d.name}`}
-                                      title="Remove"
+                                      aria-label={t(
+                                        'downloads.actions.removeNamed',
+                                        { name: d.name }
+                                      )}
+                                      title={t('downloads.actions.remove')}
                                     >
                                       <TrashIcon width={16} height={16} />
                                     </button>
@@ -952,7 +1009,7 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                               </td>
                               <td>
                                 <span className={sharedStyles.badge}>
-                                  Drive
+                                  {t('downloads.source.drive')}
                                 </span>
                               </td>
                               <td>
@@ -971,8 +1028,11 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                       onClick={() =>
                                         deleteGoogleDriveUpload(g.id)
                                       }
-                                      aria-label={`Remove ${g.name}`}
-                                      title="Remove"
+                                      aria-label={t(
+                                        'downloads.actions.removeNamed',
+                                        { name: g.name }
+                                      )}
+                                      title={t('downloads.actions.remove')}
                                     >
                                       <TrashIcon width={16} height={16} />
                                     </button>
@@ -1006,7 +1066,7 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                       navigate('/upload');
                     }}
                   >
-                    Make another deck
+                    {t('downloads.makeAnotherDeck')}
                   </button>
                 </div>
               )}

--- a/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.i18n.test.tsx
+++ b/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.i18n.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+import i18n from '../../../../lib/i18n';
+import { ConversionResult } from './ConversionResult';
+
+vi.mock('../../../../lib/analytics/track', () => ({
+  track: vi.fn(),
+}));
+
+function renderResult(node: React.ReactElement) {
+  return render(<MemoryRouter>{node}</MemoryRouter>);
+}
+
+describe('ConversionResult in German', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('translates the success card count and helper', () => {
+    renderResult(<ConversionResult variant="success" count={5} />);
+    expect(screen.getByText('Karten')).toBeInTheDocument();
+    expect(screen.getByText(/Bereit für Anki/i)).toBeInTheDocument();
+  });
+
+  it('translates the expired-Notion failure message', () => {
+    renderResult(
+      <ConversionResult
+        variant="failed"
+        title={null}
+        failureReason="notion_token_expired"
+        source="notion"
+        onMapColumns={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByText(/Notion-Verbindung abgelaufen/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText('Notion neu verbinden')).toBeInTheDocument();
+  });
+
+  it('translates the paywall headline for an exhausted free limit', () => {
+    renderResult(
+      <ConversionResult
+        variant="paywalled"
+        title={null}
+        limit={100}
+        cardsUsed={100}
+      />
+    );
+    expect(
+      screen.getByText(
+        'Du hast deine 100 kostenlosen Karten diesen Monat erreicht'
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.tsx
+++ b/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.tsx
@@ -5,6 +5,7 @@ import {
   type MouseEvent,
   type ReactNode,
 } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { classifyUploadError } from '../../../../components/errors/helpers/getErrorMessage';
 import { parseAmbiguousColumnsPayload } from '../../../../lib/fieldMapping/types';
@@ -25,10 +26,7 @@ type Source = 'notion' | 'upload' | 'dropbox' | 'drive';
 
 const NOTION_TOKEN_EXPIRED_REASON = 'notion_token_expired';
 const EMPTY_DECK_REASON_PREFIX = 'No cards in this deck yet.';
-const TOGGLES_DOCS_LABEL = 'See how toggles become cards';
 const TOGGLES_DOCS_HREF = '/documentation/cards/notion-blocks';
-const EMPTY_DECK_TEACHING_COPY =
-  "2anki makes a card from every Notion toggle — the toggle title becomes the question, what's inside becomes the answer. Wrap your key terms in toggles, then convert again.";
 
 interface ProcessingProps {
   variant: 'processing';
@@ -63,26 +61,13 @@ type ConversionResultProps =
   | FailedProps
   | SuccessProps;
 
-function buildPaywallHeadline(cardsUsed: number, limit: number): string {
-  if (cardsUsed >= limit) {
-    return `You've reached your ${limit} free cards this month`;
-  }
-  return `You've used ${cardsUsed} of your ${limit} free cards this month`;
-}
-
-function buildPaywallBody(resetDate: string | null): string {
-  if (resetDate == null) {
-    return "This conversion would go past your free limit, so it didn't finish. Get a pass to keep converting now.";
-  }
-  return `This conversion would go past your free limit, so it didn't finish. Your free cards refresh on ${resetDate}, or get a pass to keep converting now.`;
-}
-
 function PaywalledVariant({
   limit,
   cardsUsed,
   resetOn,
   email,
 }: Omit<PaywalledProps, 'variant' | 'title'>) {
+  const { t } = useTranslation();
   const shownFiredRef = useRef(false);
   const [pendingKind, setPendingKind] = useState<'24h' | '7d' | null>(null);
   const upgradeHref = getSubscribeLink(email);
@@ -126,9 +111,15 @@ function PaywalledVariant({
   return (
     <div className={styles.paywalled}>
       <p className={styles.paywallHeadline}>
-        {buildPaywallHeadline(cardsUsed, limit)}
+        {cardsUsed >= limit
+          ? t('conversionResult.paywall.headlineReached', { limit })
+          : t('conversionResult.paywall.headlineUsed', { cardsUsed, limit })}
       </p>
-      <p className={styles.paywallBody}>{buildPaywallBody(resetDate)}</p>
+      <p className={styles.paywallBody}>
+        {resetDate == null
+          ? t('conversionResult.paywall.bodyNoReset')
+          : t('conversionResult.paywall.bodyWithReset', { resetDate })}
+      </p>
       <div className={styles.paywallActions}>
         <button
           type="button"
@@ -137,8 +128,10 @@ function PaywalledVariant({
           disabled={pendingKind != null}
         >
           {pendingKind === '24h'
-            ? 'Opening checkout'
-            : `Get Day Pass — ${PASS_PRICES['24h']}`}
+            ? t('conversionResult.paywall.openingCheckout')
+            : t('conversionResult.paywall.getDayPass', {
+                price: PASS_PRICES['24h'],
+              })}
         </button>
         <button
           type="button"
@@ -147,8 +140,10 @@ function PaywalledVariant({
           disabled={pendingKind != null}
         >
           {pendingKind === '7d'
-            ? 'Opening checkout'
-            : `Get Week Pass — ${PASS_PRICES['7d']}`}
+            ? t('conversionResult.paywall.openingCheckout')
+            : t('conversionResult.paywall.getWeekPass', {
+                price: PASS_PRICES['7d'],
+              })}
         </button>
         <a
           href={upgradeHref}
@@ -157,7 +152,7 @@ function PaywalledVariant({
           aria-disabled={pendingKind != null}
           tabIndex={pendingKind == null ? undefined : -1}
         >
-          Upgrade to Unlimited
+          {t('conversionResult.paywall.upgradeUnlimited')}
         </a>
       </div>
     </div>
@@ -169,12 +164,13 @@ function FailedVariant({
   source,
   onMapColumns,
 }: Omit<FailedProps, 'variant' | 'title'>) {
+  const { t } = useTranslation();
   if (source === 'notion' && failureReason === NOTION_TOKEN_EXPIRED_REASON) {
     return (
       <div>
-        <p>Notion connection expired. Reconnect to keep converting pages.</p>
+        <p>{t('conversionResult.notionExpired')}</p>
         <a href="/notion" className={sharedStyles.btnPrimary}>
-          Reconnect Notion
+          {t('conversionResult.reconnectNotion')}
         </a>
       </div>
     );
@@ -183,12 +179,12 @@ function FailedVariant({
   if (failureReason.startsWith(EMPTY_DECK_REASON_PREFIX)) {
     return (
       <div>
-        <p>{EMPTY_DECK_TEACHING_COPY}</p>
+        <p>{t('conversionResult.emptyDeckTeaching')}</p>
         <Link
           to={TOGGLES_DOCS_HREF}
           className={`${sharedStyles.btnPrimary} ${sharedStyles.btnInline}`}
         >
-          {TOGGLES_DOCS_LABEL}
+          {t('conversionResult.togglesDocs')}
         </Link>
       </div>
     );
@@ -197,16 +193,13 @@ function FailedVariant({
   if (parseAmbiguousColumnsPayload(failureReason) != null) {
     return (
       <div>
-        <p>
-          This database has more than two columns. Pick which column should be
-          the front and back of each card.
-        </p>
+        <p>{t('conversionResult.ambiguousColumns')}</p>
         <button
           type="button"
           className={sharedStyles.btnPrimary}
           onClick={onMapColumns}
         >
-          Map columns
+          {t('conversionResult.mapColumns')}
         </button>
       </div>
     );
@@ -229,22 +222,25 @@ function FailedVariant({
           : friendly.title}
       </p>
       <p>
-        Something looks off? <Link to="/status">Check status.</Link>
+        {t('conversionResult.checkStatusPrefix')}
+        <Link to="/status">{t('conversionResult.checkStatus')}</Link>
       </p>
     </>
   );
 }
 
 function SuccessVariant({ count }: Omit<SuccessProps, 'variant'>) {
-  const noun = count === 1 ? 'card' : 'cards';
+  const { t } = useTranslation();
   return (
     <div className={styles.success}>
       <span className={styles.cardCount}>
         <span className={styles.cardCountNumber}>{count}</span>
-        <span className={styles.cardCountLabel}>{noun}</span>
+        <span className={styles.cardCountLabel}>
+          {t('conversionResult.success.card', { count })}
+        </span>
       </span>
       <span className={styles.helperText}>
-        No empty backs, no stray characters. Ready for Anki.
+        {t('conversionResult.success.helper')}
       </span>
     </div>
   );

--- a/web/src/pages/DownloadsPage/components/EmptyDownloadsSection.i18n.test.tsx
+++ b/web/src/pages/DownloadsPage/components/EmptyDownloadsSection.i18n.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+import i18n from '../../../lib/i18n';
+import { EmptyDownloadsSection } from './EmptyDownloadsSection';
+
+function renderEmpty() {
+  return render(
+    <MemoryRouter>
+      <EmptyDownloadsSection isEmpty />
+    </MemoryRouter>
+  );
+}
+
+describe('EmptyDownloadsSection in German', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('renders the empty-state heading and body in German', () => {
+    renderEmpty();
+    expect(screen.getByText('Noch keine Stapel')).toBeInTheDocument();
+    expect(
+      screen.getByText(/um deinen ersten Stapel zu erstellen/i)
+    ).toBeInTheDocument();
+  });
+
+  it('translates the empty-state actions', () => {
+    renderEmpty();
+    expect(screen.getByText('Stapel erstellen')).toBeInTheDocument();
+    expect(screen.getByText('Datei hochladen')).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/DownloadsPage/components/EmptyDownloadsSection.tsx
+++ b/web/src/pages/DownloadsPage/components/EmptyDownloadsSection.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import sharedStyles from '../../../styles/shared.module.css';
 import styles from './EmptyDownloadsSection.module.css';
@@ -7,6 +8,7 @@ interface Props {
 }
 
 export function EmptyDownloadsSection({ isEmpty }: Readonly<Props>) {
+  const { t } = useTranslation();
   if (!isEmpty) {
     return null;
   }
@@ -14,7 +16,9 @@ export function EmptyDownloadsSection({ isEmpty }: Readonly<Props>) {
     <>
       <div className={sharedStyles.card}>
         <div className={sharedStyles.emptyState}>
-          <p className={sharedStyles.sectionTitle}>No decks yet</p>
+          <p className={sharedStyles.sectionTitle}>
+            {t('downloads.empty.title')}
+          </p>
           <p
             style={{
               fontSize: 'var(--text-sm)',
@@ -22,23 +26,23 @@ export function EmptyDownloadsSection({ isEmpty }: Readonly<Props>) {
               margin: '0.5rem 0 1.5rem',
             }}
           >
-            Paste a Notion link or upload a file to make your first deck.
+            {t('downloads.empty.body')}
           </p>
           <Link
             to="/notion"
             className={`${sharedStyles.btnPrimary} ${sharedStyles.btnInline}`}
           >
-            Make a deck
+            {t('downloads.empty.makeDeck')}
           </Link>
         </div>
       </div>
       <p className={styles.emptyHint}>
-        Need help?{' '}
+        {t('downloads.empty.needHelp')}{' '}
         <Link
           to="/"
           style={{ color: 'var(--color-primary)', textDecoration: 'none' }}
         >
-          Upload a file
+          {t('downloads.empty.uploadFile')}
         </Link>
       </p>
     </>

--- a/web/src/pages/DownloadsPage/components/ListJobs/StatusTag.i18n.test.tsx
+++ b/web/src/pages/DownloadsPage/components/ListJobs/StatusTag.i18n.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import i18n from '../../../../lib/i18n';
+import { StatusTag } from './StatusTag';
+
+describe('StatusTag in German', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('translates the done and failed labels', () => {
+    const { rerender } = render(<StatusTag status="done" />);
+    expect(screen.getByText('Fertig')).toBeInTheDocument();
+    rerender(<StatusTag status="failed" />);
+    expect(screen.getByText('Fehlgeschlagen')).toBeInTheDocument();
+  });
+
+  it('translates the Claude chunk progress label', () => {
+    render(<StatusTag status={'claude:chunk:2:5' as never} />);
+    expect(
+      screen.getByText('Karteikarten werden erstellt (2 / 5)')
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/DownloadsPage/components/ListJobs/StatusTag.tsx
+++ b/web/src/pages/DownloadsPage/components/ListJobs/StatusTag.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import listStyles from './ListJobs.module.css';
 import styles from '../../../../styles/shared.module.css';
 
@@ -53,34 +54,36 @@ function getStatusStyle(status: JobStatus): {
   }
 }
 
-function getStatusText(status: JobStatus): string {
-  const chunk = parseClaudeChunk(status);
-  if (chunk) return `Generating flashcards (${chunk.current} / ${chunk.total})`;
+function getStatusKey(status: JobStatus): string {
   switch (status) {
     case 'started':
-      return 'Queued';
+      return 'status.queued';
     case 'step1_create_workspace':
     case 'step2_creating_flashcards':
     case 'step3_building_deck':
-      return 'In Progress';
+      return 'status.inProgress';
     case 'done':
-      return 'Done';
+      return 'status.done';
     case 'interrupted':
-      return 'Interrupted';
+      return 'status.interrupted';
     case 'stale':
-      return 'Stuck';
+      return 'status.stuck';
     case 'failed':
-      return 'Failed';
+      return 'status.failed';
     case 'cancelled':
-      return 'Cancelled';
+      return 'status.cancelled';
     default:
-      return 'In Progress';
+      return 'status.inProgress';
   }
 }
 
 export function StatusTag({ status }: Prop) {
+  const { t } = useTranslation();
   const { className, dotClassName } = getStatusStyle(status);
-  const displayText = getStatusText(status);
+  const chunk = parseClaudeChunk(status);
+  const displayText = chunk
+    ? t('status.generating', { current: chunk.current, total: chunk.total })
+    : t(getStatusKey(status));
 
   return (
     <span className={`${listStyles.status} ${className}`}>

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.i18n.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.i18n.test.tsx
@@ -72,4 +72,13 @@ describe('UploadForm dropzone in German', () => {
     expect(screen.getAllByText('.zip').length).toBeGreaterThan(0);
     expect(screen.getAllByText('.csv').length).toBeGreaterThan(0);
   });
+
+  it('translates the Dropbox source chip prompt in German', () => {
+    renderUploadForm();
+    expect(
+      screen.getByText(
+        'Wähle eine Datei aus deiner Dropbox, um sie in einen Stapel zu konvertieren'
+      )
+    ).toBeInTheDocument();
+  });
 });

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -841,8 +841,11 @@ function UploadForm({
         </div>
         <p className={formStyles.statusText}>
           {remoteFilename && remoteSource
-            ? `Fetching ${remoteFilename} from ${remoteSource}`
-            : 'Making your deck...'}
+            ? t('upload.form.fetching', {
+                filename: remoteFilename,
+                source: remoteSource,
+              })
+            : t('upload.form.makingDeck')}
         </p>
       </div>
     );
@@ -896,7 +899,9 @@ function UploadForm({
     <div className={formStyles.stateContent}>
       <CheckCircleIcon className={formStyles.iconSuccess} />
       {cardCount == null ? (
-        <p className={formStyles.successPrimary}>Your deck is ready</p>
+        <p className={formStyles.successPrimary}>
+          {t('upload.form.deckReady')}
+        </p>
       ) : (
         <ConversionResult variant="success" count={cardCount} />
       )}
@@ -908,7 +913,7 @@ function UploadForm({
             onClick={() => setMcqDrawerOpen((prev) => !prev)}
             aria-expanded={mcqDrawerOpen}
           >
-            {mcqCount} multiple choice
+            {t('upload.form.multipleChoice', { count: mcqCount })}
             {mcqSkippedCount > 0 && (
               <span
                 className={formStyles.mcqSkipped}
@@ -922,7 +927,7 @@ function UploadForm({
         </>
       )}
       <p className={formStyles.successSecondary} data-hj-suppress>
-        {deckName} was saved to your downloads
+        {t('upload.form.savedToDownloads', { deckName })}
       </p>
       {warningMessage && (
         <p className={formStyles.warningInline}>{warningMessage}</p>
@@ -943,7 +948,7 @@ function UploadForm({
           className={formStyles.fallbackLink}
           onClick={() => downloadRef.current?.click()}
         >
-          Didn't get the file? Download it here.
+          {t('upload.form.fallbackDownload')}
         </button>
       )}
       {successOffer === 'anon_signup' && <CreateAccountNotice />}
@@ -960,10 +965,12 @@ function UploadForm({
           resetForm();
         }}
       >
-        Make another deck
+        {t('upload.form.makeAnother')}
       </button>
       <div className={formStyles.feedbackPrompt}>
-        <p className={formStyles.feedbackLabel}>How was your experience?</p>
+        <p className={formStyles.feedbackLabel}>
+          {t('upload.form.feedbackLabel')}
+        </p>
         <FeedbackWidget page="/upload" compact />
       </div>
     </div>
@@ -980,7 +987,7 @@ function UploadForm({
       <div className={formStyles.stateContent}>
         <CheckCircleIcon className={formStyles.iconSuccess} />
         <p className={formStyles.successPrimary}>
-          {deckCount} {deckCount === 1 ? 'deck' : 'decks'} ready
+          {t('upload.form.decksReady', { count: deckCount })}
         </p>
         {warning && <p className={formStyles.warningInline}>{warning}</p>}
         {droppedImageCount > 0 && (
@@ -1006,10 +1013,12 @@ function UploadForm({
                 href={deck.downloadUrl}
                 download
                 className={formStyles.deckRowDownload}
-                aria-label={`Download ${deck.name}`}
+                aria-label={t('downloads.actions.downloadNamed', {
+                  name: deck.name,
+                })}
                 onClick={onDeckDownload}
               >
-                Download
+                {t('upload.form.download')}
               </a>
             </li>
           ))}
@@ -1020,17 +1029,17 @@ function UploadForm({
           className={formStyles.actionButton}
           onClick={onDeckDownload}
         >
-          Download all (zip)
+          {t('upload.form.downloadAll')}
         </a>
         <p className={formStyles.successSecondary}>
-          Links expire in 2 hours — download now.
+          {t('upload.form.linksExpire')}
         </p>
         <button
           type="button"
           className={formStyles.resetLink}
           onClick={resetForm}
         >
-          Make more decks
+          {t('upload.form.makeMore')}
         </button>
       </div>
     );
@@ -1086,10 +1095,12 @@ function UploadForm({
     }
     return (
       <p className={formStyles.emptyBody}>
-        No cards were found in this file. Most files need a toggle-list (Notion)
-        or a question/answer pair to become cards. See{' '}
-        <a href="/documentation/help/common-problems">common problems</a> for
-        the formats that work.
+        {t('upload.form.noCardsBody')}{' '}
+        {t('upload.form.seeCommonProblemsPrefix')}
+        <a href="/documentation/help/common-problems">
+          {t('upload.form.commonProblems')}
+        </a>
+        {t('upload.form.seeCommonProblemsSuffix')}
       </p>
     );
   };
@@ -1101,8 +1112,10 @@ function UploadForm({
     const isGoogleDriveFile =
       driveMimeType?.startsWith('application/vnd.google-apps.') ?? false;
     const emptyTitle = isGoogleDriveFile
-      ? `No cards found in ${driveFilename ?? 'your file'}`
-      : 'No cards found in this file';
+      ? t('upload.form.noCardsInFile', {
+          filename: driveFilename ?? 'your file',
+        })
+      : t('upload.form.noCardsTitle');
 
     return (
       <div className={formStyles.stateContent}>
@@ -1116,7 +1129,7 @@ function UploadForm({
               className={formStyles.emptyDownloadButton}
               onClick={() => downloadRef.current?.click()}
             >
-              Download empty deck
+              {t('upload.form.downloadEmpty')}
             </button>
           )}
           <button
@@ -1124,7 +1137,7 @@ function UploadForm({
             className={formStyles.resetLink}
             onClick={resetForm}
           >
-            Try a different file
+            {t('upload.form.tryDifferent')}
           </button>
         </div>
       </div>
@@ -1262,17 +1275,18 @@ function UploadForm({
     return (
       <div className={formStyles.stateContent}>
         <WarningIcon className={formStyles.iconError} />
-        <p className={formStyles.errorTitle}>Something went wrong</p>
+        <p className={formStyles.errorTitle}>{t('upload.form.errorTitle')}</p>
         <p className={formStyles.errorBody}>{errorText}</p>
         <p className={formStyles.statusLink}>
-          Something looks off? <Link to="/status">Check status.</Link>
+          {t('conversionResult.checkStatusPrefix')}
+          <Link to="/status">{t('conversionResult.checkStatus')}</Link>
         </p>
         <button
           type="button"
           className={formStyles.actionButton}
           onClick={resetForm}
         >
-          Try again
+          {t('upload.form.tryAgain')}
         </button>
       </div>
     );
@@ -1479,25 +1493,22 @@ function UploadForm({
   const renderImageOnlyState = () => (
     <div className={formStyles.stateContent}>
       <WarningIcon className={formStyles.iconWarning} />
-      <p className={formStyles.emptyTitle}>These look like images</p>
-      <p className={formStyles.emptyBody}>
-        No text to read, so there was nothing to turn into cards. Photo to Deck
-        reads images with AI and drafts cards you review before download.
-      </p>
+      <p className={formStyles.emptyTitle}>{t('upload.form.imagesTitle')}</p>
+      <p className={formStyles.emptyBody}>{t('upload.form.imagesBody')}</p>
       <div className={formStyles.emptyActions}>
         <Link
           to="/photo-to-deck"
           className={formStyles.actionButton}
           onClick={() => track('image_only_photo_deck_clicked')}
         >
-          Try Photo to Deck
+          {t('upload.form.tryPhotoToDeck')}
         </Link>
         <button
           type="button"
           className={formStyles.resetLink}
           onClick={resetForm}
         >
-          Try a different file
+          {t('upload.form.tryDifferent')}
         </button>
       </div>
     </div>
@@ -1688,11 +1699,11 @@ function UploadForm({
               aria-label="Change upload source"
               onClick={() => handleSourceChange('local')}
             >
-              ← Change source
+              {t('upload.form.changeSource')}
             </button>
             <DropboxIcon className={formStyles.dropboxIconLarge} />
             <span className={formStyles.dropText}>
-              Pick a file from your Dropbox to convert it into a deck
+              {t('upload.form.dropboxPrompt')}
             </span>
             <button
               type="button"
@@ -1701,7 +1712,9 @@ function UploadForm({
               disabled={dropboxPending}
               aria-label="Choose from Dropbox"
             >
-              {dropboxPending ? 'Opening Dropbox' : 'Choose from Dropbox'}
+              {dropboxPending
+                ? t('upload.form.openingDropbox')
+                : t('upload.form.chooseFromDropbox')}
             </button>
             <div className={formStyles.formatList}>
               {FORMATS.map((fmt) => (
@@ -1731,15 +1744,14 @@ function UploadForm({
               aria-label="Change upload source"
               onClick={() => handleSourceChange('local')}
             >
-              ← Change source
+              {t('upload.form.changeSource')}
             </button>
             <GoogleDriveIcon className={formStyles.dropboxIconLarge} />
             <span className={formStyles.dropText}>
-              Pick a Doc, Sheet, Slide, or file from your Google Drive.
+              {t('upload.form.drivePrompt')}
             </span>
             <span className={formStyles.shapeHint}>
-              Docs work best as a bulleted outline — top bullet asks, indented
-              bullet answers.
+              {t('upload.form.driveHint')}
             </span>
             <button
               type="button"
@@ -1749,8 +1761,8 @@ function UploadForm({
               aria-label="Choose from Google Drive"
             >
               {drivePending
-                ? 'Opening Google Drive'
-                : 'Choose from Google Drive'}
+                ? t('upload.form.openingDrive')
+                : t('upload.form.chooseFromDrive')}
             </button>
             <div className={formStyles.formatList}>
               {FORMATS.map((fmt) => (

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-16-app-surfaces-german.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-16-app-surfaces-german.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-16-app-surfaces-german",
+  "date": "2026-07-16",
+  "type": "feature",
+  "title": "Downloads, settings, and upload screens now available in German"
+}


### PR DESCRIPTION
## What
Continues the German i18n rollout (#3640–#3643) into the core logged-in app surfaces: the Downloads / conversion-results page, the conversion status tags, the settings-modal chrome, and the remaining upload-flow result, progress, and error states. English is unchanged; a user on `de` now sees these screens in idiomatic du-form German.

## Why
Wave 2 of full-app German i18n. The homepage, auth, and pricing pages already ship in German; the logged-in surfaces a returning German user actually works in (downloads, upload results, settings) were still English.

## How
- New locale keys under `downloads`, `status`, `settings`, `conversionResult`, and `upload.form` in both `en/common.json` and `de/common.json` — every referenced key exists in both locales.
- Components consume `useTranslation()` matching the established pattern. Pure render helpers that emit user-facing text (`renderJobStatusCell`, `getSourceLabel`, `getFailureToggleLabel`, `getStatusText`) take a `TFunction` / resolve to a key so translation happens in the component.
- i18next plural forms (`_one`/`_other`) for card and deck counts; `{{count}}`/`{{name}}`/`{{filename}}` interpolation for dynamic values.

## Protected strings — left verbatim in both locales
Brand and product nouns (Anki, AnkiWeb, Notion, Quizlet, 2anki, Claude), format names (PDF/CSV/HTML/Markdown/.apkg/zip), Google product names (Doc, Sheet, Slide, Google Drive, Dropbox), and Stripe plan names (Day Pass, Week Pass, Unlimited) are untranslated. User-generated content (deck names, filenames) is never translated — only the chrome around it.

## Strings left English pending approval / follow-up (flagged, not decided)
- **Business-controlled limit copy** in `UploadForm` (`renderLimitState`, `renderLockedState`, `getLimitDescription`, day-pass "$4" walls) — touches the "100 cards"/monthly-limit business strings and pricing. Left English pending approval per VOICE.md protected strings.
- **`classifyUploadError` error bodies** — shared helper with its own English copy; out of scope for this surface pass.
- **`getDistance` relative timestamps** ("5 minutes ago", "Updated … ago") — the shared helper is not localized; wrapping it would produce half-German output. Left as-is.
- **`CardOptionsForm` settings fields** — the settings *modal chrome* is translated, but the form's field labels flow through the separate `lib/text/getVisibleText` (app.document.json) system, not react-i18next. Migrating that system is out of scope; flagged for a dedicated pass.
- Smaller Downloads notice components (`TruncationNotice`, `ImageDropNotice`, `ColumnsGuessedNotice`, `ProducerPrompt`, `DeckFeedbackPrompt`, `PaywallBanner`), the sr-only live-status text, the MCQ drawer, the locked-PDF panel, and the Google-Doc-specific empty-deck bodies — deferred to keep this PR reviewable.

## Measuring success
i18next logs a missing-key warning to the console for any referenced key absent from a locale; the golden-path spec fails on console errors, so a missing German key would redden CI. Post-merge, watch for a drop in `de`-locale users bouncing off the Downloads/upload result screens.

## Testing
- Unit tests added (all forced to `de`): `EmptyDownloadsSection.i18n`, `StatusTag.i18n`, `ConversionResult.i18n`, `SettingsModal.i18n`, `DownloadsPage.i18n`; extended `UploadForm.i18n`.
- Full web suite green: 2280 passed. Web typecheck green. `pnpm --filter 2anki-web lint` clean (warnings only, all pre-existing). `oxfmt --check web/src` clean.
- Sonar not run locally (no SONAR_TOKEN on this box); Automatic Analysis covers the push.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: `pnpm --filter 2anki-web test:golden-path` — 2 passed, no console errors at 375px.

## Changelog
`Downloads, settings, and upload screens now available in German` (`web/src/pages/WhatsNewPage/changelog/2026-07-16-app-surfaces-german.json`).

## Risks
Locale-only + presentational. If a key were missing in one locale, i18next falls back to English (no crash). No API, data, or business-logic change. Rollback = revert.

## Goal alignment
Acquisition/retention: a fully-German logged-in experience lowers friction for the EU-leaning user base past signup, supporting the 300K-user goal. No direct MRR metric; read as reduced bounce on Downloads/upload result screens for `de`-locale sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs4pvvQ4BKVpvEtGA9GXTn
