### PR TITLE
feat: localize transactional emails to German by recipient language

### DIFF
--- a/src/data_layer/UsersRepository.test.ts
+++ b/src/data_layer/UsersRepository.test.ts
@@ -81,6 +81,48 @@ describe('UsersRepository.getByEmail', () => {
   });
 });
 
+describe('UsersRepository.getLanguageByEmail', () => {
+  function buildLanguageKnex(row: { language: string | null } | undefined) {
+    const firstSpy = jest.fn().mockResolvedValue(row);
+    const selectSpy = jest.fn().mockReturnValue({ first: firstSpy });
+    const whereRawSpy = jest.fn().mockReturnValue({ select: selectSpy });
+    const knex = jest
+      .fn()
+      .mockReturnValue({ whereRaw: whereRawSpy }) as unknown as jest.Mock;
+    return { knex, whereRawSpy };
+  }
+
+  it('matches the email case-insensitively and returns the stored language', async () => {
+    const { knex, whereRawSpy } = buildLanguageKnex({ language: 'de' });
+    const repo = new UsersRepository(knex as any);
+
+    const language = await repo.getLanguageByEmail('  User@Example.COM  ');
+
+    expect(whereRawSpy).toHaveBeenCalledWith('LOWER(TRIM(email)) = LOWER(?)', [
+      'User@Example.COM',
+    ]);
+    expect(language).toBe('de');
+  });
+
+  it('returns null when no user row matches', async () => {
+    const { knex } = buildLanguageKnex(undefined);
+    const repo = new UsersRepository(knex as any);
+
+    const language = await repo.getLanguageByEmail('missing@example.com');
+
+    expect(language).toBeNull();
+  });
+
+  it('returns null when the matched user has no language set', async () => {
+    const { knex } = buildLanguageKnex({ language: null });
+    const repo = new UsersRepository(knex as any);
+
+    const language = await repo.getLanguageByEmail('user@example.com');
+
+    expect(language).toBeNull();
+  });
+});
+
 describe('UsersRepository.updatePatreonByEmail', () => {
   it('matches the user by email using TRIM + lowercase so Stripe casing differences still update', async () => {
     const knex = buildKnexMock();

--- a/src/data_layer/UsersRepository.ts
+++ b/src/data_layer/UsersRepository.ts
@@ -96,6 +96,14 @@ class UsersRepository {
       .first();
   }
 
+  async getLanguageByEmail(email: string): Promise<string | null> {
+    const row = await this.database(this.table)
+      .whereRaw('LOWER(TRIM(email)) = LOWER(?)', [email.trim()])
+      .select('language')
+      .first();
+    return row?.language ?? null;
+  }
+
   updateResetToken(id: string, resetToken: string) {
     return this.database(this.table)
       .where({ id })

--- a/src/services/EmailService/EmailService.ts
+++ b/src/services/EmailService/EmailService.ts
@@ -29,6 +29,8 @@ import { SUPPORT_EMAIL_ADDRESS } from '../../lib/constants';
 import { emailHash } from '../../lib/emailHash';
 import { getDatabase } from '../../data_layer';
 import SuppressionEventsRepository from '../../data_layer/SuppressionEventsRepository';
+import UsersRepository from '../../data_layer/UsersRepository';
+import { DeckReadyStrings, getEmailStrings } from './i18n';
 
 type EmailResponse = { didSend: boolean; error?: Error };
 
@@ -110,16 +112,24 @@ export const PRICE_LOCK_IN_SUBJECTS: Record<'a' | 'b', string> = {
 
 type SgMessage = Exclude<Parameters<typeof sgMail.send>[0], unknown[]>;
 type IsEmailSuppressed = (email: string) => Promise<boolean>;
+type GetRecipientLanguage = (email: string) => Promise<string | null>;
 
 const THIN_SPACE = ' ';
 
-function formatCardCount(count: number): string {
-  const label = count === 1 ? 'card' : 'cards';
+function formatCardCount(count: number, strings: DeckReadyStrings): string {
+  const label = count === 1 ? strings.cardSingular : strings.cardPlural;
   const grouped =
     count >= 10000
       ? String(count).replace(/\B(?=(\d{3})+(?!\d))/g, THIN_SPACE)
       : String(count);
   return `${grouped} ${label}`;
+}
+
+function deckReadySuffix(
+  cardCount: number | undefined,
+  strings: DeckReadyStrings
+): string {
+  return cardCount == null ? '' : ` — ${formatCardCount(cardCount, strings)}`;
 }
 
 function resolveDeckName(filename: string): string {
@@ -130,17 +140,25 @@ function resolveDeckName(filename: string): string {
 function renderDeckReadyMarkup(
   template: string,
   deckName: string,
-  cardCount?: number
+  cardCount: number | undefined,
+  strings: DeckReadyStrings
 ): string {
-  const suffix = cardCount == null ? '' : ` — ${formatCardCount(cardCount)}`;
   return template
+    .replace('{{heading}}', strings.heading)
+    .replace('{{bodyAttached}}', strings.bodyAttached)
+    .replace('{{bodyTrouble}}', strings.bodyTrouble)
+    .replace('{{disclaimerPrefix}}', strings.disclaimerPrefix)
+    .replace('{{disclaimerSuffix}}', strings.disclaimerSuffix)
     .replace('{{deckName}}', escapeHtml(deckName))
-    .replace('{{cardCountSuffix}}', suffix);
+    .replace('{{cardCountSuffix}}', deckReadySuffix(cardCount, strings));
 }
 
-function deckReadyText(deckName: string, cardCount?: number): string {
-  const suffix = cardCount == null ? '' : ` — ${formatCardCount(cardCount)}`;
-  return `Your deck is ready: ${deckName}${suffix}`;
+function deckReadyText(
+  deckName: string,
+  cardCount: number | undefined,
+  strings: DeckReadyStrings
+): string {
+  return `${strings.textReadyPrefix}${deckName}${deckReadySuffix(cardCount, strings)}`;
 }
 
 function firstRecipient(to: SgMessage['to']): string | null {
@@ -158,9 +176,19 @@ export class EmailService implements IEmailService {
   constructor(
     apiKey: string,
     readonly defaultSender: string,
-    private readonly isEmailSuppressed: IsEmailSuppressed = async () => false
+    private readonly isEmailSuppressed: IsEmailSuppressed = async () => false,
+    private readonly getRecipientLanguage: GetRecipientLanguage = async () =>
+      null
   ) {
     sgMail.setApiKey(apiKey);
+  }
+
+  private async resolveLanguage(email: string): Promise<string | null> {
+    try {
+      return await this.getRecipientLanguage(email);
+    } catch {
+      return null;
+    }
   }
 
   private async deliver(msg: SgMessage): Promise<[ClientResponse, {}] | null> {
@@ -186,12 +214,22 @@ export class EmailService implements IEmailService {
 
   async sendResetEmail(email: string, token: string): Promise<void> {
     const link = `${process.env.DOMAIN ?? 'https://2anki.net'}/users/r/${token}`;
-    const markup = PASSWORD_RESET_TEMPLATE.replace('{{link}}', link);
+    const strings = getEmailStrings(
+      await this.resolveLanguage(email)
+    ).resetPassword;
+    const markup = PASSWORD_RESET_TEMPLATE.replace(
+      '{{heading}}',
+      strings.heading
+    )
+      .replace('{{body}}', strings.body)
+      .replace('{{cta}}', strings.cta)
+      .replace('{{disclaimer}}', strings.disclaimer)
+      .replace('{{link}}', link);
     const msg = {
       to: email,
       from: this.defaultSender,
-      subject: 'Reset your 2anki.net password',
-      text: `We received your password change request, you can change it here ${link}`,
+      subject: strings.subject,
+      text: strings.text.replace('{{link}}', link),
       html: markup,
       replyTo: 'support@2anki.net',
     };
@@ -204,14 +242,22 @@ export class EmailService implements IEmailService {
     }
   }
 
-  sendConversionEmail(
+  async sendConversionEmail(
     email: string,
     filename: string,
     contents: Buffer,
     cardCount?: number
   ): Promise<[ClientResponse, {}] | null> {
+    const strings = getEmailStrings(
+      await this.resolveLanguage(email)
+    ).deckReady;
     const deckName = resolveDeckName(filename);
-    const markup = renderDeckReadyMarkup(CONVERT_TEMPLATE, deckName, cardCount);
+    const markup = renderDeckReadyMarkup(
+      CONVERT_TEMPLATE,
+      deckName,
+      cardCount,
+      strings
+    );
 
     let attachedFilename = filename;
     if (!isValidDeckName(filename)) {
@@ -220,8 +266,8 @@ export class EmailService implements IEmailService {
     const msg = {
       to: email,
       from: DEFAULT_SENDER,
-      subject: `2anki.net - Your «${filename}» deck is ready`,
-      text: `${deckReadyText(deckName, cardCount)}. It is attached to this email.`,
+      subject: strings.subject.replace('{{filename}}', filename),
+      text: `${deckReadyText(deckName, cardCount, strings)}${strings.textAttached}`,
       html: markup,
       replyTo: 'support@2anki.net',
       attachments: [
@@ -243,17 +289,19 @@ export class EmailService implements IEmailService {
     link: string,
     cardCount?: number
   ) {
+    const strings = getEmailStrings('en').deckReady;
     const deckName = resolveDeckName(filename);
     const markup = renderDeckReadyMarkup(
       CONVERT_LINK_TEMPLATE,
       deckName,
-      cardCount
+      cardCount,
+      strings
     ).replace(/{{link}}/g, link);
     const msg = {
       to: email,
       from: DEFAULT_SENDER,
       subject: `2anki.net - Your «${filename}» deck is ready`,
-      text: `${deckReadyText(deckName, cardCount)}. Download it here: ${link}`,
+      text: `${deckReadyText(deckName, cardCount, strings)}. Download it here: ${link}`,
       html: markup,
       replyTo: 'support@2anki.net',
     };
@@ -318,31 +366,24 @@ export class EmailService implements IEmailService {
   ): Promise<MagicLinkSendResult> {
     const link = `${process.env.DOMAIN ?? 'https://2anki.net'}/auth/magic?token=${token}`;
     const isLogin = purpose === 'login';
-    const subject = isLogin
-      ? 'Your 2anki login link'
-      : 'Reset your 2anki password';
-    const heading = isLogin
-      ? 'Sign in to 2anki.net'
-      : 'Reset your 2anki.net password';
-    const description = isLogin
-      ? 'Click the button below to sign in to your account.'
-      : 'Click the button below to reset your password.';
-    const buttonText = isLogin ? 'Sign in' : 'Reset password';
+    const strings = getEmailStrings(await this.resolveLanguage(email));
+    const variant = isLogin ? strings.magicLinkLogin : strings.magicLinkReset;
+    const shared = strings.magicLinkShared;
 
-    const markup = MAGIC_LINK_TEMPLATE.replace('{{title}}', heading)
-      .replace('{{heading}}', heading)
-      .replace('{{description}}', description)
+    const markup = MAGIC_LINK_TEMPLATE.replace('{{title}}', variant.heading)
+      .replace('{{heading}}', variant.heading)
+      .replace('{{description}}', variant.description)
       .replace('{{link}}', link)
-      .replace('{{buttonText}}', buttonText);
+      .replace('{{buttonText}}', variant.cta)
+      .replace('{{expiry}}', shared.expiry)
+      .replace('{{disclaimer}}', shared.disclaimer);
 
-    const plainText = isLogin
-      ? `Sign in to your 2anki account using this link: ${link}`
-      : `Reset your 2anki password using this link: ${link}`;
+    const plainText = variant.text.replace('{{link}}', link);
 
     const msg = {
       to: email,
       from: this.defaultSender,
-      subject,
+      subject: variant.subject,
       text: plainText,
       html: markup,
       replyTo: 'support@2anki.net',
@@ -953,13 +994,14 @@ export class UnimplementedEmailService implements IEmailService {
 
 export const getDefaultEmailService = () => {
   if (process.env.SENDGRID_API_KEY !== undefined) {
-    const suppressionRepository = new SuppressionEventsRepository(
-      getDatabase()
-    );
+    const database = getDatabase();
+    const suppressionRepository = new SuppressionEventsRepository(database);
+    const usersRepository = new UsersRepository(database);
     return new EmailService(
       process.env.SENDGRID_API_KEY!,
       DEFAULT_SENDER,
-      (email) => suppressionRepository.isSuppressed(emailHash(email))
+      (email) => suppressionRepository.isSuppressed(emailHash(email)),
+      (email) => usersRepository.getLanguageByEmail(email)
     );
   }
   return new UnimplementedEmailService();

--- a/src/services/EmailService/EmailServiceLanguage.test.ts
+++ b/src/services/EmailService/EmailServiceLanguage.test.ts
@@ -1,0 +1,186 @@
+const send = jest.fn().mockResolvedValue([{ statusCode: 202 }, {}]);
+
+jest.mock('@sendgrid/mail', () => ({
+  setApiKey: jest.fn(),
+  send,
+}));
+
+import { EmailService } from './EmailService';
+import { DEFAULT_SENDER } from './constants';
+
+const MASCOT = '2anki.net/mascot/navbar-logo.png';
+const FOOTER = '2anki.net — Turn what you study into Anki flashcards';
+
+function lastMessage() {
+  const calls = send.mock.calls;
+  return calls[calls.length - 1][0] as {
+    to: string;
+    subject: string;
+    html: string;
+    text: string;
+  };
+}
+
+function serviceFor(language: string | null) {
+  return new EmailService(
+    'test-key',
+    DEFAULT_SENDER,
+    undefined,
+    async () => language
+  );
+}
+
+describe('EmailService renders copy in the recipient language', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.DOMAIN = 'https://2anki.net';
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  describe('password reset', () => {
+    it('renders German copy for a de recipient', async () => {
+      await serviceFor('de').sendResetEmail('de-user@example.com', 'tok-1');
+
+      const msg = lastMessage();
+      expect(msg.subject).toBe('Setze dein 2anki.net-Passwort zurück');
+      expect(msg.html).toContain('Passwort zurücksetzen');
+      expect(msg.html).toContain(
+        'Setze dein 2anki.net-Passwort über die Schaltfläche unten zurück.'
+      );
+      expect(msg.html).toContain('https://2anki.net/users/r/tok-1');
+      expect(msg.text).toContain(
+        'Wir haben deine Anfrage zum Ändern des Passworts erhalten'
+      );
+      expect(msg.html).not.toContain('{{heading}}');
+      expect(msg.html).not.toContain('{{link}}');
+    });
+
+    it('renders English copy for a recipient with no stored language', async () => {
+      await serviceFor(null).sendResetEmail('unknown@example.com', 'tok-2');
+
+      const msg = lastMessage();
+      expect(msg.subject).toBe('Reset your 2anki.net password');
+      expect(msg.html).toContain('Reset your 2anki.net password using');
+      expect(msg.text).toContain('We received your password change request');
+    });
+  });
+
+  describe('magic link sign-in', () => {
+    it('renders German login copy for a de recipient', async () => {
+      await serviceFor('de').sendMagicLinkEmail(
+        'de-user@example.com',
+        'tok-3',
+        'login'
+      );
+
+      const msg = lastMessage();
+      expect(msg.subject).toBe('Dein 2anki-Anmeldelink');
+      expect(msg.html).toContain('Bei 2anki.net anmelden');
+      expect(msg.html).toContain('Dieser Link läuft in 15 Minuten ab.');
+      expect(msg.html).toContain('https://2anki.net/auth/magic?token=tok-3');
+      expect(msg.text).toContain('Melde dich mit diesem Link');
+      expect(msg.html).not.toContain('{{expiry}}');
+      expect(msg.html).not.toContain('{{buttonText}}');
+    });
+
+    it('renders English login copy for an unknown recipient', async () => {
+      await serviceFor(null).sendMagicLinkEmail(
+        'unknown@example.com',
+        'tok-4',
+        'login'
+      );
+
+      const msg = lastMessage();
+      expect(msg.subject).toBe('Your 2anki login link');
+      expect(msg.html).toContain('Sign in to 2anki.net');
+      expect(msg.html).toContain('This link expires in 15 minutes.');
+    });
+  });
+
+  describe('deck ready', () => {
+    it('renders German deck-ready copy for a de recipient', async () => {
+      await serviceFor('de').sendConversionEmail(
+        'de-user@example.com',
+        'Organische Chemie',
+        Buffer.from('apkg'),
+        34
+      );
+
+      const msg = lastMessage();
+      expect(msg.subject).toBe(
+        '2anki.net – Dein Stapel «Organische Chemie» ist fertig'
+      );
+      expect(msg.html).toContain('Dein Stapel ist fertig');
+      expect(msg.html).toContain('34 Karten');
+      expect(msg.html).toContain('Organische Chemie');
+      expect(msg.text).toBe(
+        'Dein Stapel ist fertig: Organische Chemie — 34 Karten. Er hängt an dieser E-Mail.'
+      );
+      expect(msg.html).not.toContain('{{deckName}}');
+      expect(msg.html).not.toContain('{{disclaimerPrefix}}');
+    });
+
+    it('renders English deck-ready copy for an unknown recipient', async () => {
+      await serviceFor(null).sendConversionEmail(
+        'unknown@example.com',
+        'Organic Chemistry',
+        Buffer.from('apkg'),
+        34
+      );
+
+      const msg = lastMessage();
+      expect(msg.subject).toBe(
+        '2anki.net - Your «Organic Chemistry» deck is ready'
+      );
+      expect(msg.html).toContain('34 cards');
+      expect(msg.text).toBe(
+        'Your deck is ready: Organic Chemistry — 34 cards. It is attached to this email.'
+      );
+    });
+  });
+
+  describe('required structural blocks survive substitution', () => {
+    it('keeps the mascot header, support address, and footer in German', async () => {
+      await serviceFor('de').sendConversionEmail(
+        'de-user@example.com',
+        'Biologie',
+        Buffer.from('apkg'),
+        12
+      );
+
+      const msg = lastMessage();
+      expect(msg.html).toContain(MASCOT);
+      expect(msg.html).toContain('support@2anki.net');
+      expect(msg.html).toContain(FOOTER);
+    });
+
+    it('keeps the mascot header and footer on the German reset email', async () => {
+      await serviceFor('de').sendResetEmail('de-user@example.com', 'tok-5');
+
+      const msg = lastMessage();
+      expect(msg.html).toContain(MASCOT);
+      expect(msg.html).toContain(FOOTER);
+    });
+  });
+
+  it('defaults to English when the language lookup throws', async () => {
+    const service = new EmailService(
+      'test-key',
+      DEFAULT_SENDER,
+      undefined,
+      async () => {
+        throw new Error('db down');
+      }
+    );
+
+    await service.sendResetEmail('user@example.com', 'tok-6');
+
+    const msg = lastMessage();
+    expect(msg.subject).toBe('Reset your 2anki.net password');
+  });
+});

--- a/src/services/EmailService/i18n/de.ts
+++ b/src/services/EmailService/i18n/de.ts
@@ -1,0 +1,48 @@
+import { DeepPartial, EmailStrings } from './types';
+
+export const de: DeepPartial<EmailStrings> = {
+  resetPassword: {
+    subject: 'Setze dein 2anki.net-Passwort zurück',
+    heading: 'Passwort zurücksetzen',
+    body: 'Setze dein 2anki.net-Passwort über die Schaltfläche unten zurück.',
+    cta: 'Passwort zurücksetzen',
+    disclaimer:
+      'Nicht angefordert? Ignoriere diese Nachricht. Dein Passwort bleibt unverändert.',
+    text: 'Wir haben deine Anfrage zum Ändern des Passworts erhalten. Du kannst es hier ändern: {{link}}',
+  },
+  magicLinkLogin: {
+    subject: 'Dein 2anki-Anmeldelink',
+    heading: 'Bei 2anki.net anmelden',
+    description:
+      'Klicke auf die Schaltfläche unten, um dich bei deinem Konto anzumelden.',
+    cta: 'Anmelden',
+    text: 'Melde dich mit diesem Link bei deinem 2anki-Konto an: {{link}}',
+  },
+  magicLinkReset: {
+    subject: 'Setze dein 2anki-Passwort zurück',
+    heading: 'Setze dein 2anki.net-Passwort zurück',
+    description:
+      'Klicke auf die Schaltfläche unten, um dein Passwort zurückzusetzen.',
+    cta: 'Passwort zurücksetzen',
+    text: 'Setze dein 2anki-Passwort mit diesem Link zurück: {{link}}',
+  },
+  magicLinkShared: {
+    expiry: 'Dieser Link läuft in 15 Minuten ab.',
+    disclaimer:
+      'Nicht angefordert? Ignoriere diese Nachricht. An deinem Konto wird nichts geändert.',
+  },
+  deckReady: {
+    subject: '2anki.net – Dein Stapel «{{filename}}» ist fertig',
+    heading: 'Dein Stapel ist fertig',
+    bodyAttached:
+      'Dein umgewandelter Stapel hängt an dieser E-Mail. Importiere ihn in Anki, um mit dem Lernen zu beginnen.',
+    bodyTrouble: 'Probleme? Antworte einfach auf diese E-Mail.',
+    disclaimerPrefix:
+      'Diese Konvertierung nicht angefordert? Kontaktiere uns unter ',
+    disclaimerSuffix: '.',
+    cardSingular: 'Karte',
+    cardPlural: 'Karten',
+    textReadyPrefix: 'Dein Stapel ist fertig: ',
+    textAttached: '. Er hängt an dieser E-Mail.',
+  },
+};

--- a/src/services/EmailService/i18n/en.ts
+++ b/src/services/EmailService/i18n/en.ts
@@ -1,0 +1,45 @@
+import { EmailStrings } from './types';
+
+export const en: EmailStrings = {
+  resetPassword: {
+    subject: 'Reset your 2anki.net password',
+    heading: 'Reset your password',
+    body: 'Reset your 2anki.net password using the button below.',
+    cta: 'Reset password',
+    disclaimer:
+      'Did not request this? Ignore this message. Your password remains unchanged.',
+    text: 'We received your password change request, you can change it here {{link}}',
+  },
+  magicLinkLogin: {
+    subject: 'Your 2anki login link',
+    heading: 'Sign in to 2anki.net',
+    description: 'Click the button below to sign in to your account.',
+    cta: 'Sign in',
+    text: 'Sign in to your 2anki account using this link: {{link}}',
+  },
+  magicLinkReset: {
+    subject: 'Reset your 2anki password',
+    heading: 'Reset your 2anki.net password',
+    description: 'Click the button below to reset your password.',
+    cta: 'Reset password',
+    text: 'Reset your 2anki password using this link: {{link}}',
+  },
+  magicLinkShared: {
+    expiry: 'This link expires in 15 minutes.',
+    disclaimer:
+      'Did not request this? Ignore this message. No changes will be made to your account.',
+  },
+  deckReady: {
+    subject: '2anki.net - Your «{{filename}}» deck is ready',
+    heading: 'Your deck is ready',
+    bodyAttached:
+      'Your converted deck is attached to this email. Import it into Anki to start studying.',
+    bodyTrouble: 'Having trouble? Reply to this email.',
+    disclaimerPrefix: 'Did not request this conversion? Contact us at ',
+    disclaimerSuffix: '.',
+    cardSingular: 'card',
+    cardPlural: 'cards',
+    textReadyPrefix: 'Your deck is ready: ',
+    textAttached: '. It is attached to this email.',
+  },
+};

--- a/src/services/EmailService/i18n/getEmailStrings.test.ts
+++ b/src/services/EmailService/i18n/getEmailStrings.test.ts
@@ -1,0 +1,62 @@
+import { getEmailStrings, mergeStrings } from './index';
+import { EmailStrings } from './types';
+
+describe('getEmailStrings', () => {
+  it('returns English copy for a null language', () => {
+    const strings = getEmailStrings(null);
+    expect(strings.resetPassword.subject).toBe('Reset your 2anki.net password');
+    expect(strings.deckReady.heading).toBe('Your deck is ready');
+    expect(strings.magicLinkLogin.cta).toBe('Sign in');
+  });
+
+  it('returns English copy for an unsupported language', () => {
+    const strings = getEmailStrings('fr');
+    expect(strings.resetPassword.subject).toBe('Reset your 2anki.net password');
+    expect(strings.deckReady.cardPlural).toBe('cards');
+  });
+
+  it('returns German copy for the de language', () => {
+    const strings = getEmailStrings('de');
+    expect(strings.resetPassword.subject).toBe(
+      'Setze dein 2anki.net-Passwort zurück'
+    );
+    expect(strings.resetPassword.cta).toBe('Passwort zurücksetzen');
+    expect(strings.magicLinkLogin.subject).toBe('Dein 2anki-Anmeldelink');
+    expect(strings.magicLinkLogin.cta).toBe('Anmelden');
+    expect(strings.deckReady.heading).toBe('Dein Stapel ist fertig');
+    expect(strings.deckReady.cardPlural).toBe('Karten');
+    expect(strings.deckReady.cardSingular).toBe('Karte');
+  });
+
+  it('keeps the {{link}} and {{filename}} placeholders in German copy', () => {
+    const strings = getEmailStrings('de');
+    expect(strings.resetPassword.text).toContain('{{link}}');
+    expect(strings.magicLinkReset.text).toContain('{{link}}');
+    expect(strings.deckReady.subject).toContain('{{filename}}');
+  });
+});
+
+describe('mergeStrings per-key English fallback', () => {
+  const base: EmailStrings = getEmailStrings('en');
+
+  it('falls back to English for a key missing from the override', () => {
+    const merged = mergeStrings(base, {
+      resetPassword: { heading: 'Passwort zurücksetzen' },
+    });
+    expect(merged.resetPassword.heading).toBe('Passwort zurücksetzen');
+    expect(merged.resetPassword.subject).toBe('Reset your 2anki.net password');
+    expect(merged.deckReady.heading).toBe('Your deck is ready');
+  });
+
+  it('falls back to English for an empty-string override value', () => {
+    const merged = mergeStrings(base, {
+      magicLinkLogin: { cta: '' },
+    });
+    expect(merged.magicLinkLogin.cta).toBe('Sign in');
+  });
+
+  it('returns the base unchanged when the override is undefined', () => {
+    const merged = mergeStrings(base, undefined);
+    expect(merged).toEqual(base);
+  });
+});

--- a/src/services/EmailService/i18n/index.ts
+++ b/src/services/EmailService/i18n/index.ts
@@ -1,0 +1,42 @@
+import { de } from './de';
+import { en } from './en';
+import { DeepPartial, EmailStrings } from './types';
+
+export * from './types';
+
+export function mergeStrings<T>(
+  base: T,
+  override: DeepPartial<T> | undefined
+): T {
+  if (override === undefined) {
+    return base;
+  }
+  const overrideValue: unknown = override;
+  if (typeof base === 'string') {
+    return typeof overrideValue === 'string' && overrideValue.length > 0
+      ? (overrideValue as T)
+      : base;
+  }
+  const merged = {} as { [K in keyof T]: T[K] };
+  for (const key of Object.keys(base as Record<string, unknown>) as Array<
+    keyof T
+  >) {
+    const overrideChild = (override as { [K in keyof T]?: DeepPartial<T[K]> })[
+      key
+    ];
+    merged[key] = mergeStrings(base[key], overrideChild);
+  }
+  return merged;
+}
+
+const catalogs: Record<'en' | 'de', EmailStrings> = {
+  en,
+  de: mergeStrings(en, de),
+};
+
+export function getEmailStrings(lang: string | null | undefined): EmailStrings {
+  if (lang === 'de') {
+    return catalogs.de;
+  }
+  return catalogs.en;
+}

--- a/src/services/EmailService/i18n/types.ts
+++ b/src/services/EmailService/i18n/types.ts
@@ -1,0 +1,48 @@
+export interface ResetPasswordStrings {
+  subject: string;
+  heading: string;
+  body: string;
+  cta: string;
+  disclaimer: string;
+  text: string;
+}
+
+export interface MagicLinkVariantStrings {
+  subject: string;
+  heading: string;
+  description: string;
+  cta: string;
+  text: string;
+}
+
+export interface MagicLinkSharedStrings {
+  expiry: string;
+  disclaimer: string;
+}
+
+export interface DeckReadyStrings {
+  subject: string;
+  heading: string;
+  bodyAttached: string;
+  bodyTrouble: string;
+  disclaimerPrefix: string;
+  disclaimerSuffix: string;
+  cardSingular: string;
+  cardPlural: string;
+  textReadyPrefix: string;
+  textAttached: string;
+}
+
+export interface EmailStrings {
+  resetPassword: ResetPasswordStrings;
+  magicLinkLogin: MagicLinkVariantStrings;
+  magicLinkReset: MagicLinkVariantStrings;
+  magicLinkShared: MagicLinkSharedStrings;
+  deckReady: DeckReadyStrings;
+}
+
+export type SupportedEmailLanguage = 'en' | 'de';
+
+export type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends string ? T[K] : DeepPartial<T[K]>;
+};

--- a/src/services/EmailService/templates/convert.html
+++ b/src/services/EmailService/templates/convert.html
@@ -36,11 +36,11 @@
           </tr>
           <tr>
             <td class="email-body" style="padding: 32px 24px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px; line-height: 1.6; color: #374151;">
-              <h1 style="margin: 0 0 8px; font-size: 20px; font-weight: 600; color: #1f2937;">Your deck is ready</h1>
+              <h1 style="margin: 0 0 8px; font-size: 20px; font-weight: 600; color: #1f2937;">{{heading}}</h1>
               <p style="margin: 0 0 16px; font-size: 16px;"><span style="font-weight: 500;">{{deckName}}</span>{{cardCountSuffix}}</p>
-              <p style="margin: 0 0 16px;">Your converted deck is attached to this email. Import it into Anki to start studying.</p>
-              <p style="margin: 0 0 16px;">Having trouble? Reply to this email.</p>
-              <p class="email-muted" style="margin: 16px 0 0; font-size: 13px; color: #9ca3af;">Did not request this conversion? Contact us at <a href="mailto:support@2anki.net" class="email-link" style="color: #9ca3af; text-decoration: none;">support@2anki.net</a>.</p>
+              <p style="margin: 0 0 16px;">{{bodyAttached}}</p>
+              <p style="margin: 0 0 16px;">{{bodyTrouble}}</p>
+              <p class="email-muted" style="margin: 16px 0 0; font-size: 13px; color: #9ca3af;">{{disclaimerPrefix}}<a href="mailto:support@2anki.net" class="email-link" style="color: #9ca3af; text-decoration: none;">support@2anki.net</a>{{disclaimerSuffix}}</p>
             </td>
           </tr>
           <tr>

--- a/src/services/EmailService/templates/magic-link.html
+++ b/src/services/EmailService/templates/magic-link.html
@@ -41,8 +41,8 @@
               <div style="text-align: center; margin: 24px 0;" class="email-cta">
                 <a href="{{link}}" style="display: inline-block; padding: 12px 32px; background-color: #3b82f6; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: 600; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px;">{{buttonText}}</a>
               </div>
-              <p style="margin: 0 0 16px;">This link expires in 15 minutes.</p>
-              <p class="email-muted" style="margin: 16px 0 0; font-size: 13px; color: #9ca3af;">Did not request this? Ignore this message. No changes will be made to your account.</p>
+              <p style="margin: 0 0 16px;">{{expiry}}</p>
+              <p class="email-muted" style="margin: 16px 0 0; font-size: 13px; color: #9ca3af;">{{disclaimer}}</p>
             </td>
           </tr>
           <tr>

--- a/src/services/EmailService/templates/reset.html
+++ b/src/services/EmailService/templates/reset.html
@@ -36,12 +36,12 @@
           </tr>
           <tr>
             <td class="email-body" style="padding: 32px 24px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px; line-height: 1.6; color: #374151;">
-              <h1 style="margin: 0 0 16px; font-size: 20px; font-weight: 600; color: #1f2937;">Reset your password</h1>
-              <p style="margin: 0 0 16px;">Reset your 2anki.net password using the button below.</p>
+              <h1 style="margin: 0 0 16px; font-size: 20px; font-weight: 600; color: #1f2937;">{{heading}}</h1>
+              <p style="margin: 0 0 16px;">{{body}}</p>
               <div style="text-align: center; margin: 24px 0;" class="email-cta">
-                <a href="{{link}}" style="display: inline-block; padding: 12px 32px; background-color: #3b82f6; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: 600; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px;">Reset password</a>
+                <a href="{{link}}" style="display: inline-block; padding: 12px 32px; background-color: #3b82f6; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: 600; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px;">{{cta}}</a>
               </div>
-              <p class="email-muted" style="margin: 16px 0 0; font-size: 13px; color: #9ca3af;">Did not request this? Ignore this message. Your password remains unchanged.</p>
+              <p class="email-muted" style="margin: 16px 0 0; font-size: 13px; color: #9ca3af;">{{disclaimer}}</p>
             </td>
           </tr>
           <tr>

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-16-german-emails.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-16-german-emails.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-16-german-emails",
+  "date": "2026-07-16",
+  "type": "feature",
+  "title": "Password reset, sign-in, and deck-ready emails now arrive in German"
+}


### PR DESCRIPTION
## What
Localizes the three highest-value transactional emails — password reset, magic-link sign-in/reset, and deck-ready delivery — into German, driven by the recipient's stored `users.language`. German recipients get German subject + body; everyone else keeps English.

## Why
Phase C wave 1 of the German i18n rollout (follows #3640–#3644 which shipped the UI in German and added `users.language`). Users who chose German in the app were still getting English emails at the two moments that matter most — recovering access and receiving a finished deck.

## How
- **Recipient language resolution:** at send time `EmailService` calls an injected `getRecipientLanguage(email)` lookup (wired to `UsersRepository.getLanguageByEmail` in `getDefaultEmailService`). `de` → German copy; null / unknown recipient / lookup error → English. Nothing about *who* receives an email or any eligibility/suppression logic changes — only which language renders.
- **Server-side string catalog:** new `src/services/EmailService/i18n/` with `en.ts` (exact current copy) + `de.ts` (idiomatic du-form) typed against `EmailStrings`, plus `getEmailStrings(lang)` with per-key English fallback (`mergeStrings`). This is a data catalog, not an HTML partials system.
- **Templates:** the three HTML files keep their structure byte-for-byte (mascot header, dark-mode, responsive, footer). Only the hardcoded English copy blocks became `{{var}}` placeholders fed through the existing `.replace('{{…}}', …)` substitution. No partials, no shared fragments.
- German terminology matches the existing web rollout: deck → Stapel, sign in → Anmelden, reset password → Passwort zurücksetzen.
- `convert-link.html` is out of scope and stays English (its shared render helper is passed English strings explicitly).

## Measuring success
No new metric event in this PR. Confirm behavior in prod by sending a reset to a `users.language = 'de'` account and checking the delivered subject is `Setze dein 2anki.net-Passwort zurück`. Prod log line: none added — the send paths already log failures.

## Testing
- Unit tests added:
  - `i18n/getEmailStrings.test.ts` — `getEmailStrings('de')` vs `('en')`, unsupported-lang fallback, and per-key English fallback via `mergeStrings`.
  - `EmailServiceLanguage.test.ts` — send-path resolution: `de` recipient renders German subject/body for all three emails, null/unknown renders English, lookup-throws defaults to English, required header/footer/support-address blocks survive substitution. SendGrid mocked at the module boundary; no network.
  - `UsersRepository.test.ts` — `getLanguageByEmail` case-insensitive match, null-on-no-row, null-on-no-language.
- `npx tsc -p . --noEmit` clean (includes tests — the deploy build typechecks them). Existing `EmailService.test.ts` still green (English defaults unchanged).

## Browser check
Browser check: not applicable — server-only, no `web/src` changes except the changelog JSON (exempt from the gate).

## Changelog
`Password reset, sign-in, and deck-ready emails now arrive in German`

## Sonar
Sonar not run locally; Automatic Analysis covers the push.

## Risks
- Copy-only surface behind a language flag that defaults to English; a wrong German string is cosmetic, not a delivery failure. `resolveLanguage` swallows lookup errors and falls back to English, so a DB hiccup can't block a transactional email.
- Commercial/marketing templates (re-engagement, inactivity, trial-ended, abandoned-checkout, price-lock-in) are intentionally untouched — they carry unsubscribe/opt-out logic and come in a later wave.

## Goal alignment
Retention/activation lever for the German cohort: the deck-ready email is the payoff of a first conversion and the reset/sign-in emails are re-entry points. German learners seeing German at these moments reduces drop-off between signup → first download and lowers reset-driven support friction. No direct MRR number attached; it compounds the acquisition work already shipped in German.
