### PR TITLE
feat: translate remaining app surfaces and relative times to German

### DIFF
--- a/web/src/components/CardOptionsForm/CardOptionsForm.i18n.test.tsx
+++ b/web/src/components/CardOptionsForm/CardOptionsForm.i18n.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import i18n from '../../lib/i18n';
+import { CardOptionsForm } from './CardOptionsForm';
+
+const mockGetSettingsCardOptions = vi.fn();
+const mockUseUserLocals = vi.fn();
+
+vi.mock('../../lib/backend/get2ankiApi', () => ({
+  get2ankiApi: () => ({
+    resetUserCardOptions: vi.fn().mockResolvedValue(undefined),
+    deleteSettings: vi.fn().mockResolvedValue(undefined),
+    saveSettings: vi.fn().mockResolvedValue(undefined),
+    getSettings: vi.fn().mockResolvedValue(null),
+  }),
+}));
+
+vi.mock('../../lib/backend/getSettingsCardOptions', () => ({
+  getSettingsCardOptions: () => mockGetSettingsCardOptions(),
+}));
+
+vi.mock('../../lib/hooks/useUserLocals', () => ({
+  useUserLocals: () => mockUseUserLocals(),
+}));
+
+vi.mock('../../lib/backend/templates', () => ({
+  getUserTemplates: vi.fn().mockResolvedValue({ templates: [], hiddenIds: [] }),
+  getOfficialNoteTypes: vi.fn().mockResolvedValue([]),
+  getDefaultNoteTypes: vi.fn().mockResolvedValue([]),
+}));
+
+function renderForm() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <CardOptionsForm pageId={null} isLoggedIn setError={vi.fn()} />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('CardOptionsForm in German', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockGetSettingsCardOptions.mockResolvedValue([]);
+    mockUseUserLocals.mockReturnValue({
+      data: { locals: { patreon: false, subscriber: false } },
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    localStorage.clear();
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('translates section headings and the deck name field', async () => {
+    renderForm();
+    expect(await screen.findByText('Stapel & Struktur')).toBeInTheDocument();
+    expect(screen.getByText('Stapelname')).toBeInTheDocument();
+    expect(screen.getByText('Vorlagen')).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText('Stapelnamen eingeben (optional)')
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/components/CardOptionsForm/CardOptionsForm.tsx
+++ b/web/src/components/CardOptionsForm/CardOptionsForm.tsx
@@ -9,6 +9,7 @@ import React, {
   useState,
 } from 'react';
 import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { useUserLocals } from '../../lib/hooks/useUserLocals';
 import { isPayingUser } from '../NavigationBar/helpers/getPlanLabel';
 import { get2ankiApi } from '../../lib/backend/get2ankiApi';
@@ -61,9 +62,9 @@ const DEFAULT_MCQ_TTS_LANG = '';
 const DEFAULT_TTS_MANUAL_LANG = '';
 const DEFAULT_TTS_MANUAL_SIDE = 'front';
 const TTS_MANUAL_SIDE_OPTIONS = [
-  { label: 'Front', value: 'front' },
-  { label: 'Back', value: 'back' },
-  { label: 'Both', value: 'both' },
+  { labelKey: 'cardOptions.audio.sideFront', value: 'front' },
+  { labelKey: 'cardOptions.audio.sideBack', value: 'back' },
+  { labelKey: 'cardOptions.audio.sideBoth', value: 'both' },
 ] as const;
 const DEFAULT_CARD_SIZE = 'medium';
 const DEFAULT_OVERLAPPING_CLOZE = 'off';
@@ -102,17 +103,20 @@ const DEFAULT_USER_INSTRUCTIONS = `Some extra rules and explanations:
 - Do not make up any questions and use the questions in the document!
 - Create a ul for every question pair, not one ul for all of them with li!`;
 
-const OPTION_GROUPS: Array<{ label: string; keys: string[] }> = [
+const OPTION_GROUPS: Array<{ id: string; labelKey: string; keys: string[] }> = [
   {
-    label: 'Content',
+    id: 'content',
+    labelKey: 'cardOptions.groups.content',
     keys: ['all', 'paragraph', 'max-one-toggle-per-card', 'perserve-newlines'],
   },
   {
-    label: 'Card types',
+    id: 'cardTypes',
+    labelKey: 'cardOptions.groups.cardTypes',
     keys: ['cloze', 'enable-input', 'basic-reversed', 'reversed'],
   },
   {
-    label: 'Filtering',
+    id: 'filtering',
+    labelKey: 'cardOptions.groups.filtering',
     keys: [
       'cherry',
       'avocado',
@@ -122,11 +126,13 @@ const OPTION_GROUPS: Array<{ label: string; keys: string[] }> = [
     ],
   },
   {
-    label: 'Links & formatting',
+    id: 'linksFormatting',
+    labelKey: 'cardOptions.groups.linksFormatting',
     keys: ['add-notion-link', 'no-underline', 'markdown-nested-bullet-points'],
   },
   {
-    label: 'PDF & AI',
+    id: 'pdfAi',
+    labelKey: 'cardOptions.groups.pdfAi',
     keys: [
       'process-pdfs',
       'pdf-extract-text',
@@ -137,15 +143,18 @@ const OPTION_GROUPS: Array<{ label: string; keys: string[] }> = [
     ],
   },
   {
-    label: 'Media',
+    id: 'media',
+    labelKey: 'cardOptions.groups.media',
     keys: ['embed-images'],
   },
   {
-    label: 'Image quizzes',
+    id: 'imageQuizzes',
+    labelKey: 'cardOptions.groups.imageQuizzes',
     keys: ['image-quiz-html-to-anki'],
   },
   {
-    label: 'Debugging',
+    id: 'debugging',
+    labelKey: 'cardOptions.groups.debugging',
     keys: ['share-files-for-debugging'],
   },
 ];
@@ -250,9 +259,6 @@ function GatedToggleRow({
   );
 }
 
-const CLOZE_PREREQUISITE_HELP = 'Turn on Cloze deletion cards first.';
-const CHERRY_PREREQUISITE_HELP = 'Turn on Cherry-pick first.';
-
 export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
   function CardOptionsForm(
     {
@@ -266,6 +272,7 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
     }: Readonly<Props>,
     ref
   ) {
+    const { t } = useTranslation();
     const { isLoading, isError, options, loadingDefaultsError } =
       useSettingsCardsOptions(pageId);
     const { data: userLocals } = useUserLocals();
@@ -599,7 +606,7 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
         try {
           await get2ankiApi().resetUserCardOptions();
         } catch {
-          setError(new Error("Couldn't reset card options. Try again."));
+          setError(new Error(t('cardOptions.resetError')));
           return;
         }
       }
@@ -734,7 +741,7 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
       <div className={fieldStyles.section}>
         <details>
           <summary className={fieldStyles.detailsSummary}>
-            User instructions for PDF conversion
+            {t('cardOptions.userInstructions.summary')}
           </summary>
           <textarea
             className={fieldStyles.instructionsTextarea}
@@ -748,7 +755,7 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
               );
             }}
             rows={4}
-            placeholder="Instructions for PDF conversion..."
+            placeholder={t('cardOptions.userInstructions.placeholder')}
           />
         </details>
       </div>
@@ -768,7 +775,7 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
           <div className={fieldStyles.saveBar}>
             {showSaveError && (
               <span role="alert" className={fieldStyles.saveError}>
-                Couldn&apos;t save your defaults. Try again.
+                {t('cardOptions.saveBar.saveError')}
               </span>
             )}
             {showSavedStatus && (
@@ -777,7 +784,7 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
                 aria-live="polite"
                 className={fieldStyles.savedStatus}
               >
-                Defaults saved
+                {t('cardOptions.saveBar.saved')}
               </span>
             )}
             {showResetButton && (
@@ -787,7 +794,7 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
                 onClick={resetStore}
                 disabled={isSaving}
               >
-                Reset to defaults
+                {t('cardOptions.saveBar.reset')}
               </button>
             )}
             {showSaveButton && (
@@ -801,27 +808,31 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
                 {isSaving && (
                   <span className={sharedStyles.spinnerSmall} aria-hidden />
                 )}
-                {isSaving ? 'Saving' : 'Save defaults'}
+                {isSaving
+                  ? t('cardOptions.saveBar.saving')
+                  : t('cardOptions.saveBar.save')}
               </button>
             )}
           </div>
         )}
 
         <div className={fieldStyles.optionGroup}>
-          <h3 className={fieldStyles.groupHeading}>Deck &amp; structure</h3>
+          <h3 className={fieldStyles.groupHeading}>
+            {t('cardOptions.deck.structureHeading')}
+          </h3>
 
           <div className={fieldStyles.section}>
             <div className={fieldStyles.labelRow}>
               <label htmlFor="deck-name" className={fieldStyles.sectionLabel}>
-                Deck name
+                {t('cardOptions.deck.nameLabel')}
               </label>
-              <FieldHint text="Customize the deck name. Leave it empty if you use subpages." />
+              <FieldHint text={t('cardOptions.deck.nameHint')} />
             </div>
             <input
               id="deck-name"
               name="deck-name"
               className={fieldStyles.deckInput}
-              placeholder="Enter deck name (optional)"
+              placeholder={t('cardOptions.deck.namePlaceholder')}
               value={deckName}
               onChange={(e) => {
                 const newName = e.target.value;
@@ -833,15 +844,26 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
 
           <div className={fieldStyles.section}>
             <div className={fieldStyles.labelRow}>
-              <label className={fieldStyles.sectionLabel}>Page icon</label>
-              <FieldHint text="Whether to include the Notion page icon and where to place it." />
+              <label className={fieldStyles.sectionLabel}>
+                {t('cardOptions.deck.iconLabel')}
+              </label>
+              <FieldHint text={t('cardOptions.deck.iconHint')} />
             </div>
             <div className={fieldStyles.segmented}>
               {(
                 [
-                  { label: 'Icon first', value: 'first_emoji' },
-                  { label: 'Icon last', value: 'last_emoji' },
-                  { label: 'Disable', value: 'disable_emoji' },
+                  {
+                    label: t('cardOptions.deck.iconFirst'),
+                    value: 'first_emoji',
+                  },
+                  {
+                    label: t('cardOptions.deck.iconLast'),
+                    value: 'last_emoji',
+                  },
+                  {
+                    label: t('cardOptions.deck.iconDisable'),
+                    value: 'disable_emoji',
+                  },
                 ] as const
               ).map(({ label, value }) => (
                 <button
@@ -861,14 +883,22 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
 
           <div className={fieldStyles.section}>
             <div className={fieldStyles.labelRow}>
-              <label className={fieldStyles.sectionLabel}>Toggle mode</label>
-              <FieldHint text="Toggle header = card front; contents = card back. Nested toggles become their own cards. Open expands nested contents; Close keeps them collapsed for step-by-step review." />
+              <label className={fieldStyles.sectionLabel}>
+                {t('cardOptions.deck.toggleModeLabel')}
+              </label>
+              <FieldHint text={t('cardOptions.deck.toggleModeHint')} />
             </div>
             <div className={fieldStyles.segmented}>
               {(
                 [
-                  { label: 'Open nested toggles', value: 'open_toggle' },
-                  { label: 'Close nested toggles', value: 'close_toggle' },
+                  {
+                    label: t('cardOptions.deck.toggleOpen'),
+                    value: 'open_toggle',
+                  },
+                  {
+                    label: t('cardOptions.deck.toggleClose'),
+                    value: 'close_toggle',
+                  },
                 ] as const
               ).map(({ label, value }) => (
                 <button
@@ -889,7 +919,9 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
 
         {generalOptions.length > 0 && (
           <div className={fieldStyles.optionGroup}>
-            <h3 className={fieldStyles.groupHeading}>General</h3>
+            <h3 className={fieldStyles.groupHeading}>
+              {t('cardOptions.general')}
+            </h3>
             <div className={fieldStyles.groupOptions}>
               {generalOptions.map((o: CardOption) => (
                 <LocalCheckbox
@@ -912,22 +944,24 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
             .filter((o: CardOption) => isPaying || !PAID_ONLY_KEYS.has(o.key));
           if (groupOptions.length === 0) return null;
 
-          const isPdfAiGroup = group.label === 'PDF & AI';
-          const isCardTypesGroup = group.label === 'Card types';
-          const isLinksFormattingGroup = group.label === 'Links & formatting';
-          const isFilteringGroup = group.label === 'Filtering';
+          const isPdfAiGroup = group.id === 'pdfAi';
+          const isCardTypesGroup = group.id === 'cardTypes';
+          const isLinksFormattingGroup = group.id === 'linksFormatting';
+          const isFilteringGroup = group.id === 'filtering';
           const sectionTagsOption = optionsByKey['section-tags'];
           const inlineOptions = groupOptions.filter(
             (o: CardOption) => o.key !== 'section-tags'
           );
 
           return (
-            <React.Fragment key={group.label}>
+            <React.Fragment key={group.id}>
               <div
                 className={fieldStyles.optionGroup}
                 id={isPdfAiGroup ? 'pdf-ai' : undefined}
               >
-                <h3 className={fieldStyles.groupHeading}>{group.label}</h3>
+                <h3 className={fieldStyles.groupHeading}>
+                  {t(group.labelKey)}
+                </h3>
                 <div className={fieldStyles.groupOptions}>
                   {inlineOptions.map((o: CardOption) => (
                     <LocalCheckbox
@@ -948,7 +982,7 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
                   heading={sectionTagsOption.label}
                   label={sectionTagsOption.label}
                   helperText={sectionTagsOption.description}
-                  prerequisiteHelperText={CHERRY_PREREQUISITE_HELP}
+                  prerequisiteHelperText={t('cardOptions.prereq.cherry')}
                   checked={checkboxValues['section-tags'] ?? false}
                   enabled={checkboxValues['cherry'] ?? false}
                   onChange={(checked) =>
@@ -958,10 +992,11 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
               )}
               {isLinksFormattingGroup && (
                 <div className={fieldStyles.optionGroup} id="code-blocks">
-                  <h3 className={fieldStyles.groupHeading}>Code blocks</h3>
+                  <h3 className={fieldStyles.groupHeading}>
+                    {t('cardOptions.codeBlocks.heading')}
+                  </h3>
                   <p className={fieldStyles.groupIntro}>
-                    Code from your notes keeps its colors in Anki. Pick the
-                    look.
+                    {t('cardOptions.codeBlocks.intro')}
                   </p>
                   <div className={fieldStyles.section}>
                     <div className={fieldStyles.labelRow}>
@@ -969,9 +1004,9 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
                         htmlFor="code-theme"
                         className={fieldStyles.sectionLabel}
                       >
-                        Code theme
+                        {t('cardOptions.codeBlocks.themeLabel')}
                       </label>
-                      <FieldHint text="Colors for code from your notes. Switches between light and dark to match your Anki theme." />
+                      <FieldHint text={t('cardOptions.codeBlocks.themeHint')} />
                     </div>
                     <select
                       id="code-theme"
@@ -998,17 +1033,28 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
               {isCardTypesGroup && (
                 <div className={fieldStyles.optionGroup} id="card-size">
                   <div className={fieldStyles.groupHeader}>
-                    <h3 className={fieldStyles.groupHeading}>Card size</h3>
+                    <h3 className={fieldStyles.groupHeading}>
+                      {t('cardOptions.cardSize.heading')}
+                    </h3>
                     <div
                       className={fieldStyles.segmented}
                       role="group"
-                      aria-label="Card size"
+                      aria-label={t('cardOptions.cardSize.heading')}
                     >
                       {(
                         [
-                          { label: 'Short', value: 'short' },
-                          { label: 'Medium', value: 'medium' },
-                          { label: 'Detailed', value: 'detailed' },
+                          {
+                            label: t('cardOptions.cardSize.short'),
+                            value: 'short',
+                          },
+                          {
+                            label: t('cardOptions.cardSize.medium'),
+                            value: 'medium',
+                          },
+                          {
+                            label: t('cardOptions.cardSize.detailed'),
+                            value: 'detailed',
+                          },
                         ] as const
                       ).map(({ label, value }) => (
                         <button
@@ -1027,22 +1073,20 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
                     </div>
                   </div>
                   <p className={fieldStyles.groupIntro}>
-                    AI conversion uses this to decide how much fits on each
-                    card.
+                    {t('cardOptions.cardSize.intro')}
                   </p>
                   <ul className={fieldStyles.bulletList}>
                     <li>
-                      <strong>Short</strong> — 1 fact per card, ~80 characters
-                      per answer. Best for vocabulary, dates, formulas.
+                      <strong>{t('cardOptions.cardSize.short')}</strong> —{' '}
+                      {t('cardOptions.cardSize.shortDesc')}
                     </li>
                     <li>
-                      <strong>Medium</strong> — 1–2 facts per card, ~160
-                      characters per answer. Good default for most notes.
+                      <strong>{t('cardOptions.cardSize.medium')}</strong> —{' '}
+                      {t('cardOptions.cardSize.mediumDesc')}
                     </li>
                     <li>
-                      <strong>Detailed</strong> — 3–4 facts per card, ~320
-                      characters per answer. Better for tightly grouped concepts
-                      you want to review together.
+                      <strong>{t('cardOptions.cardSize.detailed')}</strong> —{' '}
+                      {t('cardOptions.cardSize.detailedDesc')}
                     </li>
                   </ul>
                 </div>
@@ -1051,17 +1095,17 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
                 <div className={fieldStyles.optionGroup} id="mcq">
                   <div className={fieldStyles.groupHeader}>
                     <h3 className={fieldStyles.groupHeading}>
-                      Multiple choice questions (MCQ)
+                      {t('cardOptions.mcq.heading')}
                     </h3>
                     <div
                       className={fieldStyles.segmented}
                       role="group"
-                      aria-label="Enable multiple choice questions"
+                      aria-label={t('cardOptions.mcq.aria')}
                     >
                       {(
                         [
-                          { label: 'Off', value: false },
-                          { label: 'On', value: true },
+                          { label: t('cardOptions.mcq.off'), value: false },
+                          { label: t('cardOptions.mcq.on'), value: true },
                         ] as const
                       ).map(({ label, value }) => (
                         <button
@@ -1083,43 +1127,42 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
                     </div>
                   </div>
                   <p className={fieldStyles.groupIntro}>
-                    Photo to deck and the AI chat generate MCQ when this is on.
-                    You can also write them yourself with the MCQ syntax — see
-                    the{' '}
+                    {t('cardOptions.mcq.introPrefix')}
                     <Link
                       to="/documentation/cards/mcq"
                       className={fieldStyles.groupIntroLink}
                     >
-                      docs
+                      {t('cardOptions.mcq.introDocs')}
                     </Link>
-                    .
+                    {t('cardOptions.mcq.introSuffix')}
                   </p>
 
                   {mcqEnabled && (
                     <>
                       <div className={fieldStyles.section}>
-                        <p className={fieldStyles.sectionLabel}>Read aloud</p>
+                        <p className={fieldStyles.sectionLabel}>
+                          {t('cardOptions.mcq.readAloud')}
+                        </p>
                         <p className={fieldStyles.sectionHint}>
-                          Pick a voice for each field. Anki will speak it on the
-                          card.
+                          {t('cardOptions.mcq.readAloudHint')}
                         </p>
 
                         {(
                           [
                             {
-                              label: 'Question',
+                              label: t('cardOptions.mcq.question'),
                               key: 'mcq-tts-question',
                               value: mcqTtsQuestion,
                               setter: setMcqTtsQuestion,
                             },
                             {
-                              label: 'Correct answer',
+                              label: t('cardOptions.mcq.correctAnswer'),
                               key: 'mcq-tts-correct-answer',
                               value: mcqTtsCorrectAnswer,
                               setter: setMcqTtsCorrectAnswer,
                             },
                             {
-                              label: 'Extra',
+                              label: t('cardOptions.mcq.extra'),
                               key: 'mcq-tts-extra',
                               value: mcqTtsExtra,
                               setter: setMcqTtsExtra,
@@ -1150,7 +1193,9 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
                             >
                               {MCQ_TTS_LANGUAGE_OPTIONS.map((opt) => (
                                 <option key={opt.value} value={opt.value}>
-                                  {opt.label}
+                                  {opt.value === ''
+                                    ? t('cardOptions.tts.dontSpeak')
+                                    : opt.label}
                                 </option>
                               ))}
                             </select>
@@ -1158,15 +1203,14 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
                         ))}
 
                         <p className={fieldStyles.sectionHint}>
-                          If your Anki device has no installed voice for the
-                          picked language, the audio stays silent.
+                          {t('cardOptions.mcq.noVoiceHint')}
                         </p>
                         <p className={fieldStyles.sectionHint}>
-                          Missing a language? Email{' '}
+                          {t('cardOptions.mcq.missingLangPrefix')}
                           <a href="mailto:support@2anki.net">
                             support@2anki.net
-                          </a>{' '}
-                          and we&apos;ll add it.
+                          </a>
+                          {t('cardOptions.mcq.missingLangSuffix')}
                         </p>
                       </div>
                     </>
@@ -1177,19 +1221,25 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
                 <div className={fieldStyles.optionGroup} id="overlapping-cloze">
                   <div className={fieldStyles.groupHeader}>
                     <h3 className={fieldStyles.groupHeading}>
-                      Overlapping cloze
+                      {t('cardOptions.overlappingCloze.heading')}
                     </h3>
                     <div
                       className={fieldStyles.segmented}
                       role="group"
-                      aria-label="Overlapping cloze"
+                      aria-label={t('cardOptions.overlappingCloze.heading')}
                     >
                       {(
                         [
-                          { label: 'Off', value: 'off' },
-                          { label: 'Show the whole list', value: 'show-all' },
                           {
-                            label: 'Show nearby lines only',
+                            label: t('cardOptions.overlappingCloze.off'),
+                            value: 'off',
+                          },
+                          {
+                            label: t('cardOptions.overlappingCloze.showAll'),
+                            value: 'show-all',
+                          },
+                          {
+                            label: t('cardOptions.overlappingCloze.windowed'),
                             value: 'windowed',
                           },
                         ] as const
@@ -1215,21 +1265,22 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
                     </div>
                   </div>
                   <p className={fieldStyles.groupIntro}>
-                    Turn a list, poem, or quote into a set of cards that hide
-                    one line at a time. Best for ordered things you recite —
-                    steps, lyrics, or a passage you're learning by heart.
+                    {t('cardOptions.overlappingCloze.intro')}
                   </p>
                   {(checkboxValues['cloze'] ?? true) ? (
                     <>
                       <ul className={fieldStyles.bulletList}>
                         <li>
-                          <strong>Show the whole list</strong> — each card hides
-                          one item; the rest stays visible as context.
+                          <strong>
+                            {t('cardOptions.overlappingCloze.showAll')}
+                          </strong>{' '}
+                          — {t('cardOptions.overlappingCloze.showAllDesc')}
                         </li>
                         <li>
-                          <strong>Show nearby lines only</strong> — each card
-                          hides one item; only the lines just before and after
-                          stay visible.
+                          <strong>
+                            {t('cardOptions.overlappingCloze.windowed')}
+                          </strong>{' '}
+                          — {t('cardOptions.overlappingCloze.windowedDesc')}
                         </li>
                       </ul>
                       {overlappingCloze !== 'off' && (
@@ -1240,7 +1291,7 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
                     </>
                   ) : (
                     <p className={fieldStyles.sectionHint}>
-                      Turn on Cloze deletion cards first.
+                      {t('cardOptions.prereq.cloze')}
                     </p>
                   )}
                 </div>
@@ -1248,10 +1299,10 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
               {isCardTypesGroup && (
                 <GatedToggleRow
                   id="group-cloze-per-toggle"
-                  heading="Group cloze blanks per toggle"
-                  label="Group cloze blanks per toggle"
-                  helperText="When one Notion toggle holds several :: blanks, put them all on a single card and reveal them together. Off by default — each :: makes its own card."
-                  prerequisiteHelperText={CLOZE_PREREQUISITE_HELP}
+                  heading={t('cardOptions.gated.groupClozeHeading')}
+                  label={t('cardOptions.gated.groupClozeHeading')}
+                  helperText={t('cardOptions.gated.groupClozeHelp')}
+                  prerequisiteHelperText={t('cardOptions.prereq.cloze')}
                   checked={checkboxValues['group-cloze-per-toggle'] ?? false}
                   enabled={checkboxValues['cloze'] ?? true}
                   onChange={(checked) =>
@@ -1262,10 +1313,10 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
               {isCardTypesGroup && (
                 <GatedToggleRow
                   id="cloze-from-toggle-content"
-                  heading="Inline code toggles become cloze"
-                  label="Inline code toggles become cloze"
-                  helperText="When a toggle's contents contain inline code, hide the code as a cloze and use the toggle header as the hint. Works only when Cloze deletion is on."
-                  prerequisiteHelperText={CLOZE_PREREQUISITE_HELP}
+                  heading={t('cardOptions.gated.inlineCodeHeading')}
+                  label={t('cardOptions.gated.inlineCodeHeading')}
+                  helperText={t('cardOptions.gated.inlineCodeHelp')}
+                  prerequisiteHelperText={t('cardOptions.prereq.cloze')}
                   checked={checkboxValues['cloze-from-toggle-content'] ?? false}
                   enabled={checkboxValues['cloze'] ?? true}
                   onChange={(checked) =>
@@ -1275,11 +1326,11 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
               )}
               {isCardTypesGroup && (
                 <div className={fieldStyles.optionGroup} id="audio">
-                  <h3 className={fieldStyles.groupHeading}>Audio</h3>
+                  <h3 className={fieldStyles.groupHeading}>
+                    {t('cardOptions.audio.heading')}
+                  </h3>
                   <p className={fieldStyles.groupIntro}>
-                    Two settings, opposite effects. One adds Anki&apos;s
-                    built-in voice to your cards. The other hides raw MP3 URLs
-                    your source may carry.
+                    {t('cardOptions.audio.intro')}
                   </p>
 
                   <div className={fieldStyles.section}>
@@ -1304,24 +1355,20 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
                         />
                       </span>
                       <span className={fieldStyles.toggleLabel}>
-                        Read cards aloud
+                        {t('cardOptions.audio.readAloud')}
                       </span>
                     </label>
                     <p className={fieldStyles.sectionHint}>
-                      Adds Anki&apos;s on-device voice to each card. Japanese,
-                      Korean, and Chinese are detected automatically; everything
-                      else reads in English. No audio file is added to your
-                      deck.
+                      {t('cardOptions.audio.readAloudHint')}
                     </p>
                   </div>
 
                   <div className={fieldStyles.section}>
                     <p className={fieldStyles.sectionLabel}>
-                      Pick a voice yourself
+                      {t('cardOptions.audio.pickVoice')}
                     </p>
                     <p className={fieldStyles.sectionHint}>
-                      Choose a language and which side Anki reads. A pick here
-                      takes precedence over the automatic detection above.
+                      {t('cardOptions.audio.pickVoiceHint')}
                     </p>
                     <div className={fieldStyles.section}>
                       <div className={fieldStyles.labelRow}>
@@ -1329,7 +1376,7 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
                           htmlFor="tts-manual-lang"
                           className={fieldStyles.sectionLabel}
                         >
-                          Language
+                          {t('cardOptions.audio.language')}
                         </label>
                       </div>
                       <select
@@ -1354,36 +1401,39 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
                     </div>
                     {ttsManualLang && (
                       <div className={fieldStyles.section}>
-                        <p className={fieldStyles.sectionLabel}>Read</p>
+                        <p className={fieldStyles.sectionLabel}>
+                          {t('cardOptions.audio.read')}
+                        </p>
                         <div
                           className={fieldStyles.segmented}
                           role="group"
-                          aria-label="Read aloud side"
+                          aria-label={t('cardOptions.audio.readAria')}
                         >
-                          {TTS_MANUAL_SIDE_OPTIONS.map(({ label, value }) => (
-                            <button
-                              key={value}
-                              type="button"
-                              className={`${fieldStyles.segment} ${ttsManualSide === value ? fieldStyles.segmentActive : ''}`}
-                              aria-pressed={ttsManualSide === value}
-                              onClick={() => {
-                                setTtsManualSide(value);
-                                saveValueInLocalStorage(
-                                  'tts-manual-side',
-                                  value,
-                                  pageId
-                                );
-                              }}
-                            >
-                              {label}
-                            </button>
-                          ))}
+                          {TTS_MANUAL_SIDE_OPTIONS.map(
+                            ({ labelKey, value }) => (
+                              <button
+                                key={value}
+                                type="button"
+                                className={`${fieldStyles.segment} ${ttsManualSide === value ? fieldStyles.segmentActive : ''}`}
+                                aria-pressed={ttsManualSide === value}
+                                onClick={() => {
+                                  setTtsManualSide(value);
+                                  saveValueInLocalStorage(
+                                    'tts-manual-side',
+                                    value,
+                                    pageId
+                                  );
+                                }}
+                              >
+                                {t(labelKey)}
+                              </button>
+                            )
+                          )}
                         </div>
                       </div>
                     )}
                     <p className={fieldStyles.sectionHint}>
-                      If your Anki device has no installed voice for the picked
-                      language, the audio stays silent.
+                      {t('cardOptions.audio.noVoiceHint')}
                     </p>
                   </div>
 
@@ -1410,13 +1460,11 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
                           />
                         </span>
                         <span className={fieldStyles.toggleLabel}>
-                          Remove MP3 links from audio files
+                          {t('cardOptions.audio.removeMp3')}
                         </span>
                       </label>
                       <p className={fieldStyles.sectionHint}>
-                        Hides raw MP3 URLs that appear as visible text on cards.
-                        Embedded audio still plays — only the visible link is
-                        stripped.
+                        {t('cardOptions.audio.removeMp3Hint')}
                       </p>
                     </div>
                   )}
@@ -1427,22 +1475,25 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
         })}
 
         <div className={fieldStyles.optionGroup}>
-          <h3 className={fieldStyles.groupHeading}>Templates</h3>
+          <h3 className={fieldStyles.groupHeading}>
+            {t('cardOptions.templates.heading')}
+          </h3>
           <p className={fieldStyles.groupIntro}>
-            Pick the look of your generated cards and the names 2anki gives the
-            Anki note types it creates. Saved note types from{' '}
+            {t('cardOptions.templates.introPrefix')}
             <Link to="/templates" className={fieldStyles.groupIntroLink}>
-              Note types
-            </Link>{' '}
-            show up under <strong>My note types</strong>.
+              {t('cardOptions.templates.introLink')}
+            </Link>
+            {t('cardOptions.templates.introMiddle')}
+            <strong>{t('cardOptions.templates.introStrong')}</strong>
+            {t('cardOptions.templates.introSuffix')}
           </p>
           <div className={fieldStyles.section}>
             <TemplateSelect
               values={availableTemplates}
               value={template}
               name="template"
-              label="Card style"
-              hint="Pick the visual style applied during Notion → Anki conversion. Choose 'My note types' to use templates you saved in the Note types editor."
+              label={t('cardOptions.templates.cardStyleLabel')}
+              hint={t('cardOptions.templates.cardStyleHint')}
               pickedTemplate={(t) => {
                 setTemplate(t);
                 saveValueInLocalStorage('template', t, pageId);
@@ -1462,9 +1513,9 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
               <div className={fieldStyles.section}>
                 <NoteTypePicker
                   name="basic_model_name"
-                  label="Basic note type"
-                  placeholder="Defaults to n2a-basic"
-                  hint="Which of your saved note types to use for Basic (front/back) cards in this conversion."
+                  label={t('cardOptions.templates.basicNoteType')}
+                  placeholder={t('cardOptions.templates.basicPlaceholder')}
+                  hint={t('cardOptions.templates.basicNoteHint')}
                   value={basicName}
                   options={availableNoteTypes.basic}
                   loading={noteTypesLoading}
@@ -1477,9 +1528,9 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
               <div className={fieldStyles.section}>
                 <NoteTypePicker
                   name="cloze_model_name"
-                  label="Cloze note type"
-                  placeholder="Defaults to n2a-cloze"
-                  hint="Which of your saved note types to use for Cloze deletion cards in this conversion."
+                  label={t('cardOptions.templates.clozeNoteType')}
+                  placeholder={t('cardOptions.templates.clozePlaceholder')}
+                  hint={t('cardOptions.templates.clozeNoteHint')}
                   value={clozeName}
                   options={availableNoteTypes.cloze}
                   loading={noteTypesLoading}
@@ -1492,9 +1543,9 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
               <div className={fieldStyles.section}>
                 <NoteTypePicker
                   name="input_model_name"
-                  label="Input note type"
-                  placeholder="Defaults to n2a-input"
-                  hint="Which of your saved note types to use for Type-the-answer cards in this conversion."
+                  label={t('cardOptions.templates.inputNoteType')}
+                  placeholder={t('cardOptions.templates.inputPlaceholder')}
+                  hint={t('cardOptions.templates.inputNoteHint')}
                   value={inputName}
                   options={availableNoteTypes.input}
                   loading={noteTypesLoading}
@@ -1511,9 +1562,9 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
                 <TemplateName
                   name="basic_model_name"
                   value={basicName}
-                  placeholder="Defaults to n2a-basic"
-                  label="Basic template name"
-                  hint="Name 2anki will give the Basic note type in Anki. Leave blank to use n2a-basic."
+                  placeholder={t('cardOptions.templates.basicPlaceholder')}
+                  label={t('cardOptions.templates.basicTemplateName')}
+                  hint={t('cardOptions.templates.basicTemplateHint')}
                   pickedName={(name) => {
                     setBasicName(name);
                     saveValueInLocalStorage('basic_model_name', name, pageId);
@@ -1524,9 +1575,9 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
                 <TemplateName
                   name="cloze_model_name"
                   value={clozeName}
-                  placeholder="Defaults to n2a-cloze"
-                  label="Cloze template name"
-                  hint="Name 2anki will give the Cloze note type in Anki. Leave blank to use n2a-cloze."
+                  placeholder={t('cardOptions.templates.clozePlaceholder')}
+                  label={t('cardOptions.templates.clozeTemplateName')}
+                  hint={t('cardOptions.templates.clozeTemplateHint')}
                   pickedName={(name) => {
                     setClozeName(name);
                     saveValueInLocalStorage('cloze_model_name', name, pageId);
@@ -1537,9 +1588,9 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
                 <TemplateName
                   name="input_model_name"
                   value={inputName}
-                  placeholder="Defaults to n2a-input"
-                  label="Input template name"
-                  hint="Name 2anki will give the Type-the-answer note type in Anki. Leave blank to use n2a-input."
+                  placeholder={t('cardOptions.templates.inputPlaceholder')}
+                  label={t('cardOptions.templates.inputTemplateName')}
+                  hint={t('cardOptions.templates.inputTemplateHint')}
                   pickedName={(name) => {
                     setInputName(name);
                     saveValueInLocalStorage('input_model_name', name, pageId);

--- a/web/src/components/ConsentModal/ConsentModal.i18n.test.tsx
+++ b/web/src/components/ConsentModal/ConsentModal.i18n.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+import i18n from '../../lib/i18n';
+import ConsentModal from './ConsentModal';
+
+describe('ConsentModal in German', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('translates the heading and action buttons', () => {
+    render(
+      <MemoryRouter>
+        <ConsentModal onAccept={vi.fn()} onDismiss={vi.fn()} />
+      </MemoryRouter>
+    );
+    expect(
+      screen.getByText('Der Chat sendet deine Nachrichten an Anthropic')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Chat starten' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Nicht jetzt' })
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/components/ConsentModal/ConsentModal.tsx
+++ b/web/src/components/ConsentModal/ConsentModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { post } from '../../lib/backend/api';
 import sharedStyles from '../../styles/shared.module.css';
@@ -13,6 +14,7 @@ export default function ConsentModal({
   onAccept,
   onDismiss,
 }: Readonly<ConsentModalProps>) {
+  const { t } = useTranslation();
   const [pending, setPending] = useState(false);
   const [needsSignIn, setNeedsSignIn] = useState(false);
 
@@ -41,18 +43,15 @@ export default function ConsentModal({
       <div className={sharedStyles.modalCardNarrow}>
         <div className={sharedStyles.modalHeader}>
           <h2 id="consent-heading" className={sharedStyles.modalHeaderTitle}>
-            Chat sends your messages to Anthropic
+            {t('modals.consent.title')}
           </h2>
         </div>
         <div className={sharedStyles.modalBody}>
-          <p className={styles.body}>
-            Your messages and any files you attach go to Anthropic to generate
-            replies. They aren't used to train models. 20 messages a month on
-            the free plan.
-          </p>
+          <p className={styles.body}>{t('modals.consent.body')}</p>
           {needsSignIn && (
             <p className={styles.body}>
-              <Link to="/login">Sign in</Link> to chat.
+              <Link to="/login">{t('modals.consent.signIn')}</Link>
+              {t('modals.consent.toChat')}
             </p>
           )}
           <div className={styles.actions}>
@@ -62,7 +61,7 @@ export default function ConsentModal({
               onClick={handleAccept}
               disabled={pending}
             >
-              Start chatting
+              {t('modals.consent.start')}
             </button>
             <button
               type="button"
@@ -70,7 +69,7 @@ export default function ConsentModal({
               onClick={onDismiss}
               disabled={pending}
             >
-              Not now
+              {t('modals.consent.notNow')}
             </button>
           </div>
         </div>

--- a/web/src/components/NotionColumnMappingModal/NotionColumnMappingModal.i18n.test.tsx
+++ b/web/src/components/NotionColumnMappingModal/NotionColumnMappingModal.i18n.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import i18n from '../../lib/i18n';
+import { NotionColumnMappingModal } from './NotionColumnMappingModal';
+
+describe('NotionColumnMappingModal in German', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('translates the title, field labels, and submit button', () => {
+    render(
+      <NotionColumnMappingModal
+        isOpen
+        columns={['Term', 'Definition']}
+        suggested={{ frontField: 'Term', backField: 'Definition' }}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    expect(screen.getByText('Ordne deine Spalten zu')).toBeInTheDocument();
+    expect(screen.getByText('Vorderseite')).toBeInTheDocument();
+    expect(screen.getByText('Rückseite')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Mit dieser Zuordnung konvertieren' })
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/components/NotionColumnMappingModal/NotionColumnMappingModal.tsx
+++ b/web/src/components/NotionColumnMappingModal/NotionColumnMappingModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useDialog } from '../../lib/hooks/useDialog';
 import type {
   AmbiguousColumnsPayload,
@@ -22,6 +23,7 @@ export function NotionColumnMappingModal({
   onSubmit,
   onCancel,
 }: Readonly<Props>) {
+  const { t } = useTranslation();
   const [frontField, setFrontField] = useState<string>(
     suggested.frontField ?? columns[0] ?? ''
   );
@@ -53,11 +55,11 @@ export function NotionColumnMappingModal({
             id="column-mapping-title"
             className={sharedStyles.modalHeaderTitle}
           >
-            Map your columns
+            {t('modals.columnMapping.title')}
           </span>
           <button
             type="button"
-            aria-label="Cancel"
+            aria-label={t('modals.columnMapping.cancel')}
             className={sharedStyles.modalClose}
             onClick={onCancel}
           >
@@ -69,7 +71,7 @@ export function NotionColumnMappingModal({
           <div className={styles.form}>
             <div className={styles.fieldRow}>
               <label htmlFor="column-mapping-front" className={styles.label}>
-                Front
+                {t('modals.columnMapping.front')}
               </label>
               <select
                 id="column-mapping-front"
@@ -87,7 +89,7 @@ export function NotionColumnMappingModal({
 
             <div className={styles.fieldRow}>
               <label htmlFor="column-mapping-back" className={styles.label}>
-                Back
+                {t('modals.columnMapping.back')}
               </label>
               <select
                 id="column-mapping-back"
@@ -105,7 +107,7 @@ export function NotionColumnMappingModal({
 
             {sameColumn && (
               <p className={styles.validationError} role="alert">
-                Front and back must be different columns.
+                {t('modals.columnMapping.differentColumns')}
               </p>
             )}
           </div>
@@ -117,7 +119,7 @@ export function NotionColumnMappingModal({
             className={sharedStyles.btnSecondary}
             onClick={onCancel}
           >
-            Cancel
+            {t('modals.columnMapping.cancel')}
           </button>
           <button
             type="button"
@@ -125,7 +127,7 @@ export function NotionColumnMappingModal({
             onClick={handleSubmit}
             disabled={sameColumn}
           >
-            Convert with this mapping
+            {t('modals.columnMapping.convert')}
           </button>
         </div>
       </div>

--- a/web/src/components/ProducerCaptureModal/ProducerCaptureModal.i18n.test.tsx
+++ b/web/src/components/ProducerCaptureModal/ProducerCaptureModal.i18n.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import i18n from '../../lib/i18n';
+import { ProducerCaptureModal } from './ProducerCaptureModal';
+
+describe('ProducerCaptureModal in German', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('translates the title, lead, and submit button', () => {
+    render(
+      <ProducerCaptureModal isOpen source="pricing_page" onClose={vi.fn()} />
+    );
+    expect(screen.getByText('Sag uns, was du brauchst')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Auf die Early-Access-Liste' })
+    ).toBeInTheDocument();
+  });
+
+  it('keeps the analytics team-size value stable while translating the label', () => {
+    render(
+      <ProducerCaptureModal isOpen source="pricing_page" onClose={vi.fn()} />
+    );
+    const option = screen.getByRole('option', { name: 'Nur ich' });
+    expect(option).toHaveValue('Just me');
+  });
+});

--- a/web/src/components/ProducerCaptureModal/ProducerCaptureModal.tsx
+++ b/web/src/components/ProducerCaptureModal/ProducerCaptureModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useDialog } from '../../lib/hooks/useDialog';
 import { track } from '../../lib/analytics/track';
 import sharedStyles from '../../styles/shared.module.css';
@@ -6,24 +7,14 @@ import styles from './ProducerCaptureModal.module.css';
 
 export type ProducerSource = 'pricing_page' | 'heavy_uploader_prompt';
 
-const TEAM_SIZES = ['Just me', '2–10', '11–50', 'More than 50'] as const;
+const TEAM_SIZES = [
+  { value: 'Just me', labelKey: 'modals.producer.teamJustMe' },
+  { value: '2–10', labelKey: 'modals.producer.team2to10' },
+  { value: '11–50', labelKey: 'modals.producer.team11to50' },
+  { value: 'More than 50', labelKey: 'modals.producer.teamMoreThan50' },
+] as const;
 
 const PURPOSE_MAX_LENGTH = 200;
-
-const FORM_TITLE = 'Tell us what you need';
-const FORM_LEAD =
-  "We're exploring tools for people who make Anki decks for others. There's nothing to buy yet — answer two questions and we'll come to you first if we build it.";
-const PURPOSE_LABEL = 'What are you making decks for?';
-const PURPOSE_PLACEHOLDER =
-  'e.g. MCAT tutoring, a Spanish course I sell, my biology class';
-const TEAM_LABEL = 'How many people will use them?';
-const SUBMIT_LABEL = 'Join the early-access list';
-const THANKS_TITLE = "You're on the list";
-const THANKS_BODY =
-  "Thanks. There's no teams product yet — we're still deciding whether to build it. If we do, you'll be among the first to try it.";
-const DONE_LABEL = 'Done';
-const ERR_SUBMIT_FAILED =
-  "Couldn't save that — check your connection and try again.";
 
 interface Props {
   isOpen: boolean;
@@ -38,6 +29,7 @@ export function ProducerCaptureModal({
   onClose,
   onSubmit,
 }: Readonly<Props>) {
+  const { t } = useTranslation();
   const fieldId = useId();
   const [purpose, setPurpose] = useState('');
   const [teamSize, setTeamSize] = useState('');
@@ -97,11 +89,13 @@ export function ProducerCaptureModal({
             id={`${fieldId}-title`}
             className={sharedStyles.modalHeaderTitle}
           >
-            {submitted ? THANKS_TITLE : FORM_TITLE}
+            {submitted
+              ? t('modals.producer.thanksTitle')
+              : t('modals.producer.title')}
           </span>
           <button
             type="button"
-            aria-label="Close"
+            aria-label={t('modals.producer.close')}
             className={sharedStyles.modalClose}
             onClick={onClose}
           >
@@ -112,7 +106,7 @@ export function ProducerCaptureModal({
         {submitted ? (
           <>
             <div className={sharedStyles.modalBody}>
-              <p className={styles.lead}>{THANKS_BODY}</p>
+              <p className={styles.lead}>{t('modals.producer.thanksBody')}</p>
             </div>
             <div className={sharedStyles.modalFooter}>
               <button
@@ -120,18 +114,18 @@ export function ProducerCaptureModal({
                 className={sharedStyles.btnSecondary}
                 onClick={onClose}
               >
-                {DONE_LABEL}
+                {t('modals.producer.done')}
               </button>
             </div>
           </>
         ) : (
           <>
             <div className={sharedStyles.modalBody}>
-              <p className={styles.lead}>{FORM_LEAD}</p>
+              <p className={styles.lead}>{t('modals.producer.lead')}</p>
 
               <div className={styles.field}>
                 <label htmlFor={`${fieldId}-purpose`} className={styles.label}>
-                  {PURPOSE_LABEL}
+                  {t('modals.producer.purposeLabel')}
                 </label>
                 <textarea
                   id={`${fieldId}-purpose`}
@@ -139,14 +133,14 @@ export function ProducerCaptureModal({
                   value={purpose}
                   maxLength={PURPOSE_MAX_LENGTH}
                   rows={3}
-                  placeholder={PURPOSE_PLACEHOLDER}
+                  placeholder={t('modals.producer.purposePlaceholder')}
                   onChange={(e) => setPurpose(e.target.value)}
                 />
               </div>
 
               <div className={styles.field}>
                 <label htmlFor={`${fieldId}-team`} className={styles.label}>
-                  {TEAM_LABEL}
+                  {t('modals.producer.teamLabel')}
                 </label>
                 <select
                   id={`${fieldId}-team`}
@@ -155,11 +149,11 @@ export function ProducerCaptureModal({
                   onChange={(e) => setTeamSize(e.target.value)}
                 >
                   <option value="" disabled>
-                    Choose one
+                    {t('modals.producer.chooseOne')}
                   </option>
                   {TEAM_SIZES.map((size) => (
-                    <option key={size} value={size}>
-                      {size}
+                    <option key={size.value} value={size.value}>
+                      {t(size.labelKey)}
                     </option>
                   ))}
                 </select>
@@ -167,7 +161,7 @@ export function ProducerCaptureModal({
 
               {submitFailed && (
                 <p className={styles.fieldError} role="alert">
-                  {ERR_SUBMIT_FAILED}
+                  {t('modals.producer.errSubmit')}
                 </p>
               )}
             </div>
@@ -181,7 +175,7 @@ export function ProducerCaptureModal({
                 {submitting ? (
                   <span className={sharedStyles.spinnerSmall} aria-hidden />
                 ) : (
-                  SUBMIT_LABEL
+                  t('modals.producer.submit')
                 )}
               </button>
             </div>

--- a/web/src/lib/getDistance.test.ts
+++ b/web/src/lib/getDistance.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import i18n from './i18n';
+import { getDistance } from './getDistance';
+
+const TWO_MINUTES_AGO = new Date(Date.now() - 2 * 60 * 1000);
+
+describe('getDistance', () => {
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('renders an English relative phrase with a suffix', async () => {
+    await i18n.changeLanguage('en');
+    expect(getDistance(TWO_MINUTES_AGO)).toBe('2 minutes ago');
+  });
+
+  it('renders a German relative phrase when the language is German', async () => {
+    await i18n.changeLanguage('de');
+    expect(getDistance(TWO_MINUTES_AGO)).toBe('vor 2 Minuten');
+  });
+});

--- a/web/src/lib/getDistance.ts
+++ b/web/src/lib/getDistance.ts
@@ -1,4 +1,9 @@
 import { formatDistance } from 'date-fns';
+import { de } from 'date-fns/locale';
+import i18n from './i18n';
 
 export const getDistance = (date: Date | string): string =>
-  formatDistance(new Date(date), new Date());
+  formatDistance(new Date(date), new Date(), {
+    addSuffix: true,
+    locale: i18n.language?.startsWith('de') ? de : undefined,
+  });

--- a/web/src/lib/i18n/locales/de/common.json
+++ b/web/src/lib/i18n/locales/de/common.json
@@ -293,6 +293,7 @@
     "emailVerified": "E-Mail bestätigt. Alles bereit.",
     "makeAnotherDeck": "Noch einen Stapel erstellen",
     "noMatch": "Kein Stapel passt zu diesem Filter.",
+    "updatedRelative": "Aktualisiert {{time}}",
     "filters": {
       "all": "Alle",
       "ready": "Fertig",
@@ -393,6 +394,179 @@
       "getDayPass": "Day Pass holen — {{price}}",
       "getWeekPass": "Week Pass holen — {{price}}",
       "upgradeUnlimited": "Auf Unlimited upgraden"
+    }
+  },
+  "modals": {
+    "consent": {
+      "title": "Der Chat sendet deine Nachrichten an Anthropic",
+      "body": "Deine Nachrichten und alle angehängten Dateien gehen an Anthropic, um Antworten zu generieren. Sie werden nicht zum Trainieren von Modellen verwendet. 20 Nachrichten pro Monat im kostenlosen Tarif.",
+      "signIn": "Anmelden",
+      "toChat": ", um zu chatten.",
+      "start": "Chat starten",
+      "notNow": "Nicht jetzt"
+    },
+    "columnMapping": {
+      "title": "Ordne deine Spalten zu",
+      "cancel": "Abbrechen",
+      "front": "Vorderseite",
+      "back": "Rückseite",
+      "differentColumns": "Vorder- und Rückseite müssen unterschiedliche Spalten sein.",
+      "convert": "Mit dieser Zuordnung konvertieren"
+    },
+    "producer": {
+      "title": "Sag uns, was du brauchst",
+      "lead": "Wir erproben Werkzeuge für Menschen, die Anki-Stapel für andere erstellen. Es gibt noch nichts zu kaufen — beantworte zwei Fragen und wir kommen zuerst auf dich zu, falls wir es bauen.",
+      "purposeLabel": "Wofür erstellst du Stapel?",
+      "purposePlaceholder": "z. B. MCAT-Nachhilfe, ein Spanischkurs, den ich verkaufe, meine Biologieklasse",
+      "teamLabel": "Wie viele Personen werden sie nutzen?",
+      "submit": "Auf die Early-Access-Liste",
+      "thanksTitle": "Du bist auf der Liste",
+      "thanksBody": "Danke. Es gibt noch kein Team-Produkt — wir entscheiden noch, ob wir es bauen. Falls ja, gehörst du zu den Ersten, die es ausprobieren.",
+      "done": "Fertig",
+      "errSubmit": "Das konnte nicht gespeichert werden — prüfe deine Verbindung und versuch es erneut.",
+      "close": "Schließen",
+      "chooseOne": "Wähle eine Option",
+      "teamJustMe": "Nur ich",
+      "team2to10": "2–10",
+      "team11to50": "11–50",
+      "teamMoreThan50": "Mehr als 50"
+    }
+  },
+  "cardOptions": {
+    "resetError": "Die Kartenoptionen konnten nicht zurückgesetzt werden. Versuch es erneut.",
+    "general": "Allgemein",
+    "prereq": {
+      "cloze": "Aktiviere zuerst Cloze-Lückenkarten.",
+      "cherry": "Aktiviere zuerst Cherry-Pick."
+    },
+    "saveBar": {
+      "saveError": "Deine Voreinstellungen konnten nicht gespeichert werden. Versuch es erneut.",
+      "saved": "Voreinstellungen gespeichert",
+      "reset": "Auf Voreinstellungen zurücksetzen",
+      "saving": "Wird gespeichert",
+      "save": "Voreinstellungen speichern"
+    },
+    "userInstructions": {
+      "summary": "Nutzeranweisungen für die PDF-Konvertierung",
+      "placeholder": "Anweisungen für die PDF-Konvertierung..."
+    },
+    "deck": {
+      "structureHeading": "Stapel & Struktur",
+      "nameLabel": "Stapelname",
+      "nameHint": "Passe den Stapelnamen an. Lass ihn leer, wenn du Unterseiten verwendest.",
+      "namePlaceholder": "Stapelnamen eingeben (optional)",
+      "iconLabel": "Seitensymbol",
+      "iconHint": "Ob das Notion-Seitensymbol enthalten sein soll und wo es platziert wird.",
+      "iconFirst": "Symbol zuerst",
+      "iconLast": "Symbol zuletzt",
+      "iconDisable": "Aus",
+      "toggleModeLabel": "Toggle-Modus",
+      "toggleModeHint": "Toggle-Überschrift = Kartenvorderseite; Inhalt = Kartenrückseite. Verschachtelte Toggles werden zu eigenen Karten. Offen klappt verschachtelte Inhalte auf; Geschlossen hält sie eingeklappt für schrittweises Wiederholen.",
+      "toggleOpen": "Verschachtelte Toggles öffnen",
+      "toggleClose": "Verschachtelte Toggles schließen"
+    },
+    "groups": {
+      "content": "Inhalt",
+      "cardTypes": "Kartentypen",
+      "filtering": "Filtern",
+      "linksFormatting": "Links & Formatierung",
+      "pdfAi": "PDF & KI",
+      "media": "Medien",
+      "imageQuizzes": "Bildquizze",
+      "debugging": "Fehlersuche"
+    },
+    "codeBlocks": {
+      "heading": "Codeblöcke",
+      "intro": "Code aus deinen Notizen behält seine Farben in Anki. Wähle den Look.",
+      "themeLabel": "Code-Design",
+      "themeHint": "Farben für Code aus deinen Notizen. Wechselt zwischen hell und dunkel passend zu deinem Anki-Design."
+    },
+    "cardSize": {
+      "heading": "Kartengröße",
+      "short": "Kurz",
+      "medium": "Mittel",
+      "detailed": "Ausführlich",
+      "intro": "Die KI-Konvertierung entscheidet damit, wie viel auf jede Karte passt.",
+      "shortDesc": "1 Fakt pro Karte, ~80 Zeichen pro Antwort. Am besten für Vokabeln, Daten, Formeln.",
+      "mediumDesc": "1–2 Fakten pro Karte, ~160 Zeichen pro Antwort. Gute Voreinstellung für die meisten Notizen.",
+      "detailedDesc": "3–4 Fakten pro Karte, ~320 Zeichen pro Antwort. Besser für eng zusammenhängende Konzepte, die du gemeinsam wiederholen willst."
+    },
+    "mcq": {
+      "heading": "Multiple-Choice-Fragen (MCQ)",
+      "aria": "Multiple-Choice-Fragen aktivieren",
+      "off": "Aus",
+      "on": "An",
+      "introPrefix": "Foto zu Stapel und der KI-Chat erzeugen MCQ, wenn dies aktiviert ist. Du kannst sie auch selbst mit der MCQ-Syntax schreiben — siehe die ",
+      "introDocs": "Doku",
+      "introSuffix": ".",
+      "readAloud": "Vorlesen",
+      "readAloudHint": "Wähle für jedes Feld eine Stimme. Anki spricht es auf der Karte.",
+      "question": "Frage",
+      "correctAnswer": "Richtige Antwort",
+      "extra": "Extra",
+      "noVoiceHint": "Wenn auf deinem Anki-Gerät keine Stimme für die gewählte Sprache installiert ist, bleibt der Ton stumm.",
+      "missingLangPrefix": "Fehlt eine Sprache? Schreib an ",
+      "missingLangSuffix": " und wir fügen sie hinzu."
+    },
+    "overlappingCloze": {
+      "heading": "Überlappendes Cloze",
+      "off": "Aus",
+      "showAll": "Ganze Liste zeigen",
+      "windowed": "Nur nahe Zeilen zeigen",
+      "intro": "Verwandle eine Liste, ein Gedicht oder ein Zitat in Karten, die eine Zeile nach der anderen verdecken. Am besten für geordnete Dinge, die du aufsagst — Schritte, Liedtexte oder eine Passage, die du auswendig lernst.",
+      "showAllDesc": "Jede Karte verdeckt ein Element; der Rest bleibt als Kontext sichtbar.",
+      "windowedDesc": "Jede Karte verdeckt ein Element; nur die Zeilen direkt davor und danach bleiben sichtbar."
+    },
+    "gated": {
+      "groupClozeHeading": "Cloze-Lücken pro Toggle gruppieren",
+      "groupClozeHelp": "Wenn ein Notion-Toggle mehrere ::-Lücken enthält, packe sie alle auf eine Karte und decke sie zusammen auf. Standardmäßig aus — jedes :: erzeugt eine eigene Karte.",
+      "inlineCodeHeading": "Inline-Code-Toggles werden zu Cloze",
+      "inlineCodeHelp": "Wenn der Inhalt eines Toggles Inline-Code enthält, verdecke den Code als Cloze und nutze die Toggle-Überschrift als Hinweis. Funktioniert nur, wenn Cloze-Löschung aktiv ist."
+    },
+    "audio": {
+      "heading": "Audio",
+      "intro": "Zwei Einstellungen, gegensätzliche Wirkung. Eine fügt deinen Karten Ankis eingebaute Stimme hinzu. Die andere verbirgt rohe MP3-URLs, die deine Quelle enthalten kann.",
+      "readAloud": "Karten vorlesen",
+      "readAloudHint": "Fügt jeder Karte Ankis Stimme auf dem Gerät hinzu. Japanisch, Koreanisch und Chinesisch werden automatisch erkannt; alles andere wird auf Englisch gelesen. Deinem Stapel wird keine Audiodatei hinzugefügt.",
+      "pickVoice": "Stimme selbst wählen",
+      "pickVoiceHint": "Wähle eine Sprache und welche Seite Anki liest. Eine Wahl hier hat Vorrang vor der automatischen Erkennung oben.",
+      "language": "Sprache",
+      "read": "Lesen",
+      "readAria": "Vorlese-Seite",
+      "sideFront": "Vorderseite",
+      "sideBack": "Rückseite",
+      "sideBoth": "Beide",
+      "noVoiceHint": "Wenn auf deinem Anki-Gerät keine Stimme für die gewählte Sprache installiert ist, bleibt der Ton stumm.",
+      "removeMp3": "MP3-Links aus Audiodateien entfernen",
+      "removeMp3Hint": "Verbirgt rohe MP3-URLs, die als sichtbarer Text auf Karten erscheinen. Eingebettetes Audio wird weiterhin abgespielt — nur der sichtbare Link wird entfernt."
+    },
+    "tts": {
+      "dontSpeak": "Nicht sprechen"
+    },
+    "templates": {
+      "heading": "Vorlagen",
+      "introPrefix": "Wähle den Look deiner erzeugten Karten und die Namen, die 2anki den erstellten Anki-Notiztypen gibt. Gespeicherte Notiztypen aus ",
+      "introLink": "Notiztypen",
+      "introMiddle": " erscheinen unter ",
+      "introStrong": "Meine Notiztypen",
+      "introSuffix": ".",
+      "cardStyleLabel": "Kartenstil",
+      "cardStyleHint": "Wähle den visuellen Stil, der bei der Notion → Anki-Konvertierung angewendet wird. Wähle 'Meine Notiztypen', um Vorlagen zu nutzen, die du im Notiztypen-Editor gespeichert hast.",
+      "basicNoteType": "Basic-Notiztyp",
+      "basicNoteHint": "Welchen deiner gespeicherten Notiztypen für Basic-Karten (Vorder-/Rückseite) in dieser Konvertierung verwendet werden soll.",
+      "clozeNoteType": "Cloze-Notiztyp",
+      "clozeNoteHint": "Welchen deiner gespeicherten Notiztypen für Cloze-Lückenkarten in dieser Konvertierung verwendet werden soll.",
+      "inputNoteType": "Input-Notiztyp",
+      "inputNoteHint": "Welchen deiner gespeicherten Notiztypen für Antwort-eingeben-Karten in dieser Konvertierung verwendet werden soll.",
+      "basicTemplateName": "Basic-Vorlagenname",
+      "basicTemplateHint": "Name, den 2anki dem Basic-Notiztyp in Anki gibt. Leer lassen, um n2a-basic zu verwenden.",
+      "clozeTemplateName": "Cloze-Vorlagenname",
+      "clozeTemplateHint": "Name, den 2anki dem Cloze-Notiztyp in Anki gibt. Leer lassen, um n2a-cloze zu verwenden.",
+      "inputTemplateName": "Input-Vorlagenname",
+      "inputTemplateHint": "Name, den 2anki dem Antwort-eingeben-Notiztyp in Anki gibt. Leer lassen, um n2a-input zu verwenden.",
+      "basicPlaceholder": "Standard: n2a-basic",
+      "clozePlaceholder": "Standard: n2a-cloze",
+      "inputPlaceholder": "Standard: n2a-input"
     }
   }
 }

--- a/web/src/lib/i18n/locales/en/common.json
+++ b/web/src/lib/i18n/locales/en/common.json
@@ -293,6 +293,7 @@
     "emailVerified": "Email verified. You're all set.",
     "makeAnotherDeck": "Make another deck",
     "noMatch": "No decks match this filter.",
+    "updatedRelative": "Updated {{time}}",
     "filters": {
       "all": "All",
       "ready": "Ready",
@@ -393,6 +394,179 @@
       "getDayPass": "Get Day Pass — {{price}}",
       "getWeekPass": "Get Week Pass — {{price}}",
       "upgradeUnlimited": "Upgrade to Unlimited"
+    }
+  },
+  "modals": {
+    "consent": {
+      "title": "Chat sends your messages to Anthropic",
+      "body": "Your messages and any files you attach go to Anthropic to generate replies. They aren't used to train models. 20 messages a month on the free plan.",
+      "signIn": "Sign in",
+      "toChat": " to chat.",
+      "start": "Start chatting",
+      "notNow": "Not now"
+    },
+    "columnMapping": {
+      "title": "Map your columns",
+      "cancel": "Cancel",
+      "front": "Front",
+      "back": "Back",
+      "differentColumns": "Front and back must be different columns.",
+      "convert": "Convert with this mapping"
+    },
+    "producer": {
+      "title": "Tell us what you need",
+      "lead": "We're exploring tools for people who make Anki decks for others. There's nothing to buy yet — answer two questions and we'll come to you first if we build it.",
+      "purposeLabel": "What are you making decks for?",
+      "purposePlaceholder": "e.g. MCAT tutoring, a Spanish course I sell, my biology class",
+      "teamLabel": "How many people will use them?",
+      "submit": "Join the early-access list",
+      "thanksTitle": "You're on the list",
+      "thanksBody": "Thanks. There's no teams product yet — we're still deciding whether to build it. If we do, you'll be among the first to try it.",
+      "done": "Done",
+      "errSubmit": "Couldn't save that — check your connection and try again.",
+      "close": "Close",
+      "chooseOne": "Choose one",
+      "teamJustMe": "Just me",
+      "team2to10": "2–10",
+      "team11to50": "11–50",
+      "teamMoreThan50": "More than 50"
+    }
+  },
+  "cardOptions": {
+    "resetError": "Couldn't reset card options. Try again.",
+    "general": "General",
+    "prereq": {
+      "cloze": "Turn on Cloze deletion cards first.",
+      "cherry": "Turn on Cherry-pick first."
+    },
+    "saveBar": {
+      "saveError": "Couldn't save your defaults. Try again.",
+      "saved": "Defaults saved",
+      "reset": "Reset to defaults",
+      "saving": "Saving",
+      "save": "Save defaults"
+    },
+    "userInstructions": {
+      "summary": "User instructions for PDF conversion",
+      "placeholder": "Instructions for PDF conversion..."
+    },
+    "deck": {
+      "structureHeading": "Deck & structure",
+      "nameLabel": "Deck name",
+      "nameHint": "Customize the deck name. Leave it empty if you use subpages.",
+      "namePlaceholder": "Enter deck name (optional)",
+      "iconLabel": "Page icon",
+      "iconHint": "Whether to include the Notion page icon and where to place it.",
+      "iconFirst": "Icon first",
+      "iconLast": "Icon last",
+      "iconDisable": "Disable",
+      "toggleModeLabel": "Toggle mode",
+      "toggleModeHint": "Toggle header = card front; contents = card back. Nested toggles become their own cards. Open expands nested contents; Close keeps them collapsed for step-by-step review.",
+      "toggleOpen": "Open nested toggles",
+      "toggleClose": "Close nested toggles"
+    },
+    "groups": {
+      "content": "Content",
+      "cardTypes": "Card types",
+      "filtering": "Filtering",
+      "linksFormatting": "Links & formatting",
+      "pdfAi": "PDF & AI",
+      "media": "Media",
+      "imageQuizzes": "Image quizzes",
+      "debugging": "Debugging"
+    },
+    "codeBlocks": {
+      "heading": "Code blocks",
+      "intro": "Code from your notes keeps its colors in Anki. Pick the look.",
+      "themeLabel": "Code theme",
+      "themeHint": "Colors for code from your notes. Switches between light and dark to match your Anki theme."
+    },
+    "cardSize": {
+      "heading": "Card size",
+      "short": "Short",
+      "medium": "Medium",
+      "detailed": "Detailed",
+      "intro": "AI conversion uses this to decide how much fits on each card.",
+      "shortDesc": "1 fact per card, ~80 characters per answer. Best for vocabulary, dates, formulas.",
+      "mediumDesc": "1–2 facts per card, ~160 characters per answer. Good default for most notes.",
+      "detailedDesc": "3–4 facts per card, ~320 characters per answer. Better for tightly grouped concepts you want to review together."
+    },
+    "mcq": {
+      "heading": "Multiple choice questions (MCQ)",
+      "aria": "Enable multiple choice questions",
+      "off": "Off",
+      "on": "On",
+      "introPrefix": "Photo to deck and the AI chat generate MCQ when this is on. You can also write them yourself with the MCQ syntax — see the ",
+      "introDocs": "docs",
+      "introSuffix": ".",
+      "readAloud": "Read aloud",
+      "readAloudHint": "Pick a voice for each field. Anki will speak it on the card.",
+      "question": "Question",
+      "correctAnswer": "Correct answer",
+      "extra": "Extra",
+      "noVoiceHint": "If your Anki device has no installed voice for the picked language, the audio stays silent.",
+      "missingLangPrefix": "Missing a language? Email ",
+      "missingLangSuffix": " and we'll add it."
+    },
+    "overlappingCloze": {
+      "heading": "Overlapping cloze",
+      "off": "Off",
+      "showAll": "Show the whole list",
+      "windowed": "Show nearby lines only",
+      "intro": "Turn a list, poem, or quote into a set of cards that hide one line at a time. Best for ordered things you recite — steps, lyrics, or a passage you're learning by heart.",
+      "showAllDesc": "each card hides one item; the rest stays visible as context.",
+      "windowedDesc": "each card hides one item; only the lines just before and after stay visible."
+    },
+    "gated": {
+      "groupClozeHeading": "Group cloze blanks per toggle",
+      "groupClozeHelp": "When one Notion toggle holds several :: blanks, put them all on a single card and reveal them together. Off by default — each :: makes its own card.",
+      "inlineCodeHeading": "Inline code toggles become cloze",
+      "inlineCodeHelp": "When a toggle's contents contain inline code, hide the code as a cloze and use the toggle header as the hint. Works only when Cloze deletion is on."
+    },
+    "audio": {
+      "heading": "Audio",
+      "intro": "Two settings, opposite effects. One adds Anki's built-in voice to your cards. The other hides raw MP3 URLs your source may carry.",
+      "readAloud": "Read cards aloud",
+      "readAloudHint": "Adds Anki's on-device voice to each card. Japanese, Korean, and Chinese are detected automatically; everything else reads in English. No audio file is added to your deck.",
+      "pickVoice": "Pick a voice yourself",
+      "pickVoiceHint": "Choose a language and which side Anki reads. A pick here takes precedence over the automatic detection above.",
+      "language": "Language",
+      "read": "Read",
+      "readAria": "Read aloud side",
+      "sideFront": "Front",
+      "sideBack": "Back",
+      "sideBoth": "Both",
+      "noVoiceHint": "If your Anki device has no installed voice for the picked language, the audio stays silent.",
+      "removeMp3": "Remove MP3 links from audio files",
+      "removeMp3Hint": "Hides raw MP3 URLs that appear as visible text on cards. Embedded audio still plays — only the visible link is stripped."
+    },
+    "tts": {
+      "dontSpeak": "Don't speak"
+    },
+    "templates": {
+      "heading": "Templates",
+      "introPrefix": "Pick the look of your generated cards and the names 2anki gives the Anki note types it creates. Saved note types from ",
+      "introLink": "Note types",
+      "introMiddle": " show up under ",
+      "introStrong": "My note types",
+      "introSuffix": ".",
+      "cardStyleLabel": "Card style",
+      "cardStyleHint": "Pick the visual style applied during Notion → Anki conversion. Choose 'My note types' to use templates you saved in the Note types editor.",
+      "basicNoteType": "Basic note type",
+      "basicNoteHint": "Which of your saved note types to use for Basic (front/back) cards in this conversion.",
+      "clozeNoteType": "Cloze note type",
+      "clozeNoteHint": "Which of your saved note types to use for Cloze deletion cards in this conversion.",
+      "inputNoteType": "Input note type",
+      "inputNoteHint": "Which of your saved note types to use for Type-the-answer cards in this conversion.",
+      "basicTemplateName": "Basic template name",
+      "basicTemplateHint": "Name 2anki will give the Basic note type in Anki. Leave blank to use n2a-basic.",
+      "clozeTemplateName": "Cloze template name",
+      "clozeTemplateHint": "Name 2anki will give the Cloze note type in Anki. Leave blank to use n2a-cloze.",
+      "inputTemplateName": "Input template name",
+      "inputTemplateHint": "Name 2anki will give the Type-the-answer note type in Anki. Leave blank to use n2a-input.",
+      "basicPlaceholder": "Defaults to n2a-basic",
+      "clozePlaceholder": "Defaults to n2a-cloze",
+      "inputPlaceholder": "Defaults to n2a-input"
     }
   }
 }

--- a/web/src/pages/DownloadsPage/DownloadsPage.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.tsx
@@ -284,9 +284,11 @@ function renderFailurePanelContent(
   );
 }
 
-function formatUpdatedLabel(lastFetchedAt: Date | null): string {
+function formatUpdatedLabel(lastFetchedAt: Date | null, t: TFunction): string {
   if (lastFetchedAt == null) return '';
-  return `Updated ${getDistance(lastFetchedAt)} ago`;
+  return t('downloads.updatedRelative', {
+    time: getDistance(lastFetchedAt),
+  });
 }
 
 function FilterChip({
@@ -616,7 +618,7 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                 <td>
                                   {row.job.created_at != null && (
                                     <span className={styles.timeAgo}>
-                                      {getDistance(row.job.created_at)} ago
+                                      {getDistance(row.job.created_at)}
                                     </span>
                                   )}
                                 </td>
@@ -882,7 +884,7 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                               <td>
                                 {u.created_at != null && (
                                   <span className={styles.timeAgo}>
-                                    {getDistance(u.created_at)} ago
+                                    {getDistance(u.created_at)}
                                   </span>
                                 )}
                               </td>
@@ -966,7 +968,7 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                               <td>
                                 {d.created_at != null && (
                                   <span className={styles.timeAgo}>
-                                    {getDistance(d.created_at)} ago
+                                    {getDistance(d.created_at)}
                                   </span>
                                 )}
                               </td>
@@ -1015,7 +1017,7 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                               <td>
                                 {g.last_converted_at != null && (
                                   <span className={styles.timeAgo}>
-                                    {getDistance(g.last_converted_at)} ago
+                                    {getDistance(g.last_converted_at)}
                                   </span>
                                 )}
                               </td>
@@ -1083,7 +1085,7 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                   color: 'var(--color-text-tertiary)',
                 }}
               >
-                {formatUpdatedLabel(lastFetchedAt)}
+                {formatUpdatedLabel(lastFetchedAt, t)}
               </div>
             </div>
           )}

--- a/web/src/pages/DownloadsPage/components/PaywallBanner.tsx
+++ b/web/src/pages/DownloadsPage/components/PaywallBanner.tsx
@@ -84,13 +84,13 @@ export function PaywallBanner({ inProgressJob }: PaywallBannerProps) {
             </span>
             {'" to finish — started '}
             {startedDistance}
-            {' ago.'}
+            {'.'}
           </span>
         )}
         {inProgressJob != null && startedDistance != null && !hasTitle && (
           <span className={styles.secondary}>
             Or wait for your current conversion to finish — started{' '}
-            {startedDistance} ago.
+            {startedDistance}.
           </span>
         )}
         <Link className={styles.seeAllPlans} to={SEE_ALL_PLANS_HREF}>

--- a/web/src/pages/UploadPage/components/RecentSources/RecentSources.tsx
+++ b/web/src/pages/UploadPage/components/RecentSources/RecentSources.tsx
@@ -13,9 +13,7 @@ function RecentSourceRow({ source }: Readonly<{ source: RecentSource }>) {
         <span data-hj-suppress className={styles.title} title={source.title}>
           {source.title}
         </span>
-        <span className={styles.timeAgo}>
-          {getDistance(source.updatedAt)} ago
-        </span>
+        <span className={styles.timeAgo}>{getDistance(source.updatedAt)}</span>
       </div>
       <Link
         to={source.convertUrl}

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-16-app-german-wave3.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-16-app-german-wave3.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-16-app-german-wave3",
+  "date": "2026-07-16",
+  "type": "feature",
+  "title": "More of the app now speaks German, including relative times and card options"
+}


### PR DESCRIPTION
## What
Wave 3 of the German i18n rollout (continuing #3640-#3644). Translates the remaining in-app chrome: the consent, column-mapping, and producer-capture modals; the Card options form's authored copy; and relative timestamps. `getDistance` now renders a suffixed relative phrase in the active language.

## Why
The app is being localized to German surface by surface. Earlier waves covered the homepage, auth, pricing, downloads, settings modal, and upload form. This wave picks up the modals, the card options field labels/help, and the relative-time helper that was flagged as deferred.

## How
- **getDistance** — now uses `formatDistance(..., { addSuffix: true, locale })`, selecting date-fns' `de` locale when the active i18n language is German. Call sites that appended a literal " ago" were updated to drop it (the suffix now lives inside the phrase); `DownloadsPage`'s "Updated …" label became `downloads.updatedRelative`. English output is byte-identical ("2 minutes ago"); German reads "vor 2 Minuten".
- **Modals** — `ConsentModal`, `NotionColumnMappingModal`, `ProducerCaptureModal` migrated to `useTranslation()` under a new `modals` namespace. The producer team-size options keep their **English canonical `value`** (sent to analytics) while translating only the displayed label.
- **CardOptionsForm** — every component-authored string (headings, section labels, help text, segment/toggle labels, buttons, placeholders) moved to a new `cardOptions` namespace. `OPTION_GROUPS` was refactored to carry a stable `id` because the group label was used in control-flow comparisons (`group.label === 'PDF & AI'`); translating the label directly would have broken that logic.

### CardOptionsForm approach — and why
I investigated both offered paths. The existing `getVisibleText` / `app.document.json` text system is **not language-aware** (single JSON, no locale dimension) and CardOptionsForm doesn't consume it, so "add German to the text system" isn't viable without rebuilding that system. The lower-risk path was bridging the component's authored copy to react-i18next `t()`, matching every other migrated surface. Done for all component-authored strings.

## Measuring success
No revenue metric — this is localization depth for German users. Confirm in production by switching the language toggle to Deutsch and opening `/downloads` (relative times read "vor N Minuten"), the chat consent modal, and Card options — all render German. i18n is client-side; nothing new is logged.

## Testing
- Unit tests added: `getDistance.test.ts` (en/de), and `*.i18n.test.tsx` for ConsentModal, NotionColumnMappingModal, ProducerCaptureModal (incl. an assertion that the analytics team-size value stays `Just me`), and CardOptionsForm.
- Full web suite green (275 files / 2287 tests) — includes the existing `CardOptionsForm.test.tsx`, `DownloadsPage`, `RecentSources`, and `PaywallBanner` tests, confirming English output is unchanged.
- `pnpm typecheck` green; `pnpm lint` exits 0 (only pre-existing warnings); `oxfmt --check` clean on all changed files.
- Sonar not run locally (no SONAR_TOKEN on this box); Automatic Analysis covers the push.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: `pnpm --filter 2anki-web test:golden-path` — 2 passed (landing + signed-in dashboard at 375px).

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-07-16-app-german-wave3.json` — "More of the app now speaks German, including relative times and card options"

## Strings left English (pending approval or out of scope)
- **Backend-sourced `CardOption.label` / `.description`** — the checkbox option labels in CardOptionsForm come from server `CardOption` rows, not the component; translating them needs a coordinated server-side effort. Out of scope for a frontend i18n PR.
- **`DEFAULT_USER_INSTRUCTIONS`** in CardOptionsForm — a persisted default that is saved and sent to the AI as a prompt, not display chrome. Left English to avoid changing model input.
- **`classifyUploadError` / `classifyError`** (`getErrorMessage.ts`) — a pure helper (not a component) returning `{title, detail}` strings consumed by ConversionResult, UploadForm, and the error presenters. i18n-ing it means returning keys and translating at every call boundary — a cross-cutting refactor better done as its own PR. This covers the deferred locked-PDF / unsupported-format / Google-Doc-empty notices, which all live in that copy table.
- **Proper nouns / product names** left verbatim per VOICE.md: Anki, Notion, PDF, MCQ, Cloze, MP3, `n2a-*`, code-theme names (GitHub, One Dark, …), and the TTS language names.
- **PaywallBanner / RecentSources** surrounding sentence copy stays English (those components aren't otherwise migrated); only the relative-time value they render now localizes. Full migration is a later wave.

## Risks
Low. English rendering is unchanged (verified by the full green suite including pre-existing tests). The `OPTION_GROUPS` id refactor is covered by the passing CardOptionsForm tests. Rollback is a straight revert.

## Goal alignment
None on MRR directly — this is localization depth for the German market, widening addressable acquisition for German-speaking learners. No funnel metric targeted this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs4pvvQ4BKVpvEtGA9GXTn
