### PR TITLE
refactor: auto-load i18n namespaces via glob

### DIFF
--- a/web/src/lib/i18n/index.ts
+++ b/web/src/lib/i18n/index.ts
@@ -1,20 +1,41 @@
-import i18n, { type InitOptions } from 'i18next';
+import i18n, { type InitOptions, type Resource } from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
-import enCommon from './locales/en/common.json';
-import deCommon from './locales/de/common.json';
 
 export const SUPPORTED_LANGUAGES = ['en', 'de'] as const;
 export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
 
 export const LANGUAGE_STORAGE_KEY = '2anki-language';
 
+// Every locale namespace file under ./locales/<lang>/<namespace>.json is loaded
+// automatically. To add a surface's strings, drop a new <namespace>.json into
+// each language folder and reference it with t('<namespace>:key') — no edit to
+// this file is required, which lets parallel work add namespaces without
+// colliding here.
+const localeModules = import.meta.glob<{ default: Record<string, unknown> }>(
+  './locales/*/*.json',
+  { eager: true }
+);
+
+function buildResources(): Resource {
+  const resources: Resource = {};
+  for (const [path, mod] of Object.entries(localeModules)) {
+    const match = /\.\/locales\/([^/]+)\/([^/]+)\.json$/.exec(path);
+    if (!match) {
+      continue;
+    }
+    const [, language, namespace] = match;
+    resources[language] ??= {};
+    (resources[language] as Record<string, unknown>)[namespace] =
+      mod.default ?? mod;
+  }
+  return resources;
+}
+
 export const i18nInitOptions: InitOptions = {
-  resources: {
-    en: { common: enCommon },
-    de: { common: deCommon },
-  },
+  resources: buildResources(),
   defaultNS: 'common',
+  fallbackNS: 'common',
   fallbackLng: 'en',
   supportedLngs: [...SUPPORTED_LANGUAGES],
   nonExplicitSupportedLngs: true,


### PR DESCRIPTION
## What
Switch the i18n resource build from two hardcoded `common.json` imports to an `import.meta.glob` over `locales/<lang>/<namespace>.json`. Adding a surface's strings is now just dropping a new namespace file per language — no edit to `index.ts` — so parallel translation work can add namespaces without colliding on one shared file.

## Why
Enables a fan-out to complete German coverage across the remaining strings without every PR conflicting on `common.json`. Existing `common.json` keeps working; `fallbackNS: 'common'` preserves resolution.

## Verification
- Web typecheck clean
- i18n + translated-surface vitest: 60 passed (existing German surfaces still resolve through the glob loader)
- Golden-path 2/2, no console errors at 375px

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px

Sonar not run locally; Automatic Analysis covers the push.
