### PR TITLE
feat: translate account and checkout screens to German

### DIFF
--- a/web/src/components/AccessBanner/AccessBanner.i18n.test.tsx
+++ b/web/src/components/AccessBanner/AccessBanner.i18n.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import i18n from '../../lib/i18n';
+import { AccessBanner } from './AccessBanner';
+
+describe('AccessBanner in German', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('renders the active pass banner in German and keeps the pass name', () => {
+    const now = new Date('2026-07-16T10:00:00Z');
+    const expires = new Date('2026-07-17T10:00:00Z').toISOString();
+    render(<AccessBanner passExpiresAt={expires} passKind="24h" now={now} />);
+    expect(screen.getByText(/Day Pass aktiv/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Konvertiere so viel du willst/)
+    ).toBeInTheDocument();
+  });
+
+  it('renders the ending-soon warning in German', () => {
+    const now = new Date('2026-07-16T10:00:00Z');
+    const expires = new Date('2026-07-16T10:30:00Z').toISOString();
+    render(<AccessBanner passExpiresAt={expires} passKind="7d" now={now} />);
+    expect(screen.getByText(/Week Pass endet in/)).toBeInTheDocument();
+    expect(screen.getByText(/30 Minuten/)).toBeInTheDocument();
+  });
+});

--- a/web/src/components/AccessBanner/AccessBanner.tsx
+++ b/web/src/components/AccessBanner/AccessBanner.tsx
@@ -1,10 +1,12 @@
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import styles from './AccessBanner.module.css';
 
 const TWO_HOURS_MS = 2 * 60 * 60 * 1000;
 const TEN_MINUTES_MS = 10 * 60 * 1000;
 
-function formatExpiryDate(date: Date): string {
-  return date.toLocaleString('en-GB', {
+function formatExpiryDate(date: Date, locale: string): string {
+  return date.toLocaleString(locale, {
     weekday: 'short',
     day: 'numeric',
     month: 'short',
@@ -17,14 +19,14 @@ function roundToNearest10Min(ms: number): number {
   return Math.round(ms / TEN_MINUTES_MS) * TEN_MINUTES_MS;
 }
 
-function formatTimeRemaining(ms: number): string {
+function formatTimeRemaining(ms: number, t: TFunction): string {
   const rounded = roundToNearest10Min(ms);
   const minutes = Math.floor(rounded / 60000);
   if (minutes < 60) {
-    return `${minutes} minutes`;
+    return t('accessBanner.minutes', { count: minutes });
   }
   const hours = Math.round(minutes / 60);
-  return `about ${hours} hour${hours === 1 ? '' : 's'}`;
+  return t('accessBanner.aboutHours', { count: hours });
 }
 
 type PassKind = '24h' | '7d' | 'unlimited';
@@ -46,6 +48,8 @@ export function AccessBanner({
   passKind,
   now = new Date(),
 }: Readonly<AccessBannerProps>) {
+  const { t, i18n } = useTranslation('account');
+
   if (passExpiresAt == null || passKind == null) return null;
 
   const expiresAt = new Date(passExpiresAt);
@@ -54,13 +58,16 @@ export function AccessBanner({
   if (remainingMs <= 0) return null;
 
   const passLabel = PASS_LABELS[passKind];
+  const locale = i18n.language.startsWith('de') ? 'de-DE' : 'en-GB';
 
   if (remainingMs >= TWO_HOURS_MS) {
     return (
       <output className={styles.banner}>
         <span className={styles.message}>
-          {passLabel} active — expires {formatExpiryDate(expiresAt)}. Convert as
-          much as you want.
+          {t('accessBanner.active', {
+            passLabel,
+            date: formatExpiryDate(expiresAt, locale),
+          })}
         </span>
       </output>
     );
@@ -69,8 +76,10 @@ export function AccessBanner({
   return (
     <output className={styles.banner}>
       <span className={styles.warning}>
-        {passLabel} ends in {formatTimeRemaining(remainingMs)} — finish any
-        pending conversions.
+        {t('accessBanner.endsIn', {
+          passLabel,
+          time: formatTimeRemaining(remainingMs, t),
+        })}
       </span>
     </output>
   );

--- a/web/src/components/CreateAccountNotice/CreateAccountNotice.i18n.test.tsx
+++ b/web/src/components/CreateAccountNotice/CreateAccountNotice.i18n.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import i18n from '../../lib/i18n';
+import { CreateAccountNotice } from './CreateAccountNotice';
+
+describe('CreateAccountNotice in German', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('renders the headline and CTA in German', () => {
+    render(
+      <MemoryRouter>
+        <CreateAccountNotice />
+      </MemoryRouter>
+    );
+    expect(
+      screen.getByText('Behalte deine nächsten Stapel')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Kostenloses Konto erstellen' })
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/components/CreateAccountNotice/CreateAccountNotice.tsx
+++ b/web/src/components/CreateAccountNotice/CreateAccountNotice.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 
 import { track } from '../../lib/analytics/track';
 import styles from '../PassLadderCard/PassLadderCard.module.css';
@@ -7,6 +8,7 @@ import styles from '../PassLadderCard/PassLadderCard.module.css';
 const SURFACE = 'upload_success_signup';
 
 export function CreateAccountNotice() {
+  const { t } = useTranslation('account');
   const shownFiredRef = useRef(false);
 
   useEffect(() => {
@@ -16,18 +18,15 @@ export function CreateAccountNotice() {
   }, []);
 
   return (
-    <section className={styles.card} aria-label="Save your next decks">
-      <p className={styles.headline}>Keep your next decks</p>
-      <p className={styles.body}>
-        With a free account, every deck you convert is saved to your downloads
-        history — re-download any of them later.
-      </p>
+    <section className={styles.card} aria-label={t('createAccount.aria')}>
+      <p className={styles.headline}>{t('createAccount.headline')}</p>
+      <p className={styles.body}>{t('createAccount.body')}</p>
       <Link
         className={styles.cta}
         to="/register?redirect=/upload"
         onClick={() => track('account_offer_clicked', { surface: SURFACE })}
       >
-        Create a free account
+        {t('createAccount.cta')}
       </Link>
     </section>
   );

--- a/web/src/components/VerifyEmailNotice/VerifyEmailNotice.i18n.test.tsx
+++ b/web/src/components/VerifyEmailNotice/VerifyEmailNotice.i18n.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import i18n from '../../lib/i18n';
+import { VerifyEmailNotice } from './VerifyEmailNotice';
+
+describe('VerifyEmailNotice in German', () => {
+  beforeEach(async () => {
+    globalThis.sessionStorage.setItem('email_verification_pending', '1');
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    globalThis.sessionStorage.removeItem('email_verification_pending');
+    await i18n.changeLanguage('en');
+  });
+
+  it('renders the verify-email message in German', () => {
+    render(<VerifyEmailNotice emailVerified={false} />);
+    expect(
+      screen.getByText(/Sieh in deinem Postfach nach/)
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/components/VerifyEmailNotice/VerifyEmailNotice.tsx
+++ b/web/src/components/VerifyEmailNotice/VerifyEmailNotice.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import styles from './VerifyEmailNotice.module.css';
 
 const FLAG_KEY = 'email_verification_pending';
@@ -26,6 +27,7 @@ interface VerifyEmailNoticeProps {
 export function VerifyEmailNotice({
   emailVerified,
 }: Readonly<VerifyEmailNoticeProps>) {
+  const { t } = useTranslation('account');
   const [pending, setPending] = useState(() => readPending());
 
   useEffect(() => {
@@ -44,16 +46,14 @@ export function VerifyEmailNotice({
 
   return (
     <output className={styles.banner}>
-      <span className={styles.message}>
-        Check your inbox — confirm your email to secure your account.
-      </span>
+      <span className={styles.message}>{t('verifyEmail.message')}</span>
       <button
         type="button"
         className={styles.dismiss}
-        aria-label="Dismiss"
+        aria-label={t('verifyEmail.dismiss')}
         onClick={dismiss}
       >
-        Dismiss
+        {t('verifyEmail.dismiss')}
       </button>
     </output>
   );

--- a/web/src/lib/i18n/locales/de/account.json
+++ b/web/src/lib/i18n/locales/de/account.json
@@ -1,0 +1,150 @@
+{
+  "reasons": {
+    "finished": "Ich habe erreicht, was ich brauchte",
+    "notEnough": "Ich nutze es nicht genug",
+    "tooExpensive": "Zu teuer",
+    "foundAlternative": "Ich habe eine Alternative gefunden",
+    "technicalIssues": "Technische Probleme",
+    "other": "Sonstiges"
+  },
+  "subscription": {
+    "premium": "Premium",
+    "unknownDate": "einem unbekannten Datum",
+    "endsPrefix": "Endet am",
+    "endedPrefix": "Beendet am",
+    "renewsPrefix": "Verlängert sich am",
+    "accessContinues": "Zugriff bleibt bis dahin bestehen.",
+    "cancelThisPlan": "Diesen Tarif kündigen",
+    "cancelThisPlanNow": "Diesen Tarif jetzt kündigen",
+    "cancelPlanNoticeWithLabel": "Kündigt den Tarif {{planLabel}} sofort. Deine Karte wird nicht für {{planLabel}} am {{date}} belastet. Das kann nicht rückgängig gemacht werden.",
+    "cancelPlanNotice": "Kündigt diesen Tarif sofort. Das kann nicht rückgängig gemacht werden.",
+    "processing": "Wird verarbeitet …",
+    "keepIt": "Behalten",
+    "multipleActive": "Du hast {{count}} aktive Abos. Vermutlich wirst du doppelt belastet — kündige das, das du nicht behalten willst.",
+    "billedThroughApple": "Über Apple abgerechnet",
+    "appleManageNotice": "Verwalte oder kündige dieses Abo in deinen Apple-Konto-Einstellungen: Öffne die Einstellungen auf deinem iPhone oder iPad, tippe auf deinen Namen und dann auf Abonnements.",
+    "pausedResumesPrefix": "Pausiert · Wird fortgesetzt am",
+    "pausedNotice": "Während der Pause wirst du nicht belastet. Dein Abo wird am {{date}} zu {{plan}} fortgesetzt. Während der Pause sind Bezahlfunktionen aus und alles, was du erstellt hast, bleibt gespeichert.",
+    "yourPlan": "deinem Tarif",
+    "resuming": "Wird fortgesetzt …",
+    "resumeNow": "Jetzt fortsetzen",
+    "cancelSubscription": "Abo kündigen",
+    "legacyForfeit": "Beim Kündigen verfällt dieser Bestandstarif.",
+    "cancelNowInstead": "Stattdessen jetzt kündigen",
+    "previousPlan": "Vorheriger Tarif: {{plan}}.",
+    "readingSubscription": "Dein Abo wird geladen",
+    "linkedEmailHeading": "Verknüpfte 2anki.net-E-Mail",
+    "managedThroughStripe": "Dein Abo wird über dein Stripe-Konto verwaltet unter",
+    "youCan": "Du kannst:",
+    "manageSubscription": "Dein Abo verwalten",
+    "updatePayment": "Zahlungsdaten aktualisieren",
+    "cancelYourSubscription": "Dein Abo kündigen",
+    "subscriptionEmail": "Abo-E-Mail",
+    "subscriptionEmailPlaceholder": "Abo-E-Mail eingeben",
+    "emailLinked": "E-Mail verknüpft.",
+    "linking": "Wird verknüpft …",
+    "linkEmail": "E-Mail verknüpfen"
+  },
+  "cancelFlow": {
+    "whyCancelling": "Warum kündigst du? (optional)",
+    "processing": "Wird verarbeitet …",
+    "cancelSubscription": "Abo kündigen",
+    "keepSubscription": "Abo behalten"
+  },
+  "pauseCard": {
+    "pauseInstead": "Stattdessen pausieren — keine Kosten, während du weg bist",
+    "notice": "Legst du zwischen den Semestern eine Pause ein? Pausiere dein Abo, statt zu kündigen. Während der Pause wirst du nicht belastet, und es setzt sich von selbst fort, wenn du bereit bist. Alles, was du erstellt hast, bleibt gespeichert.",
+    "pauseFor": "Pausieren für",
+    "pauseLengthAria": "Pausendauer",
+    "oneMonth": "1 Monat",
+    "nMonths": "{{count}} Monate",
+    "resumesLine": "Wird am {{date}} zu {{plan}} fortgesetzt. Du kannst jederzeit vorher kündigen.",
+    "yourPlan": "deinem Tarif",
+    "pausing": "Wird pausiert …",
+    "pauseSubscription": "Abo pausieren"
+  },
+  "cancellationFollowUp": {
+    "whyDidYouCancel": "Warum hast du gekündigt? (optional)",
+    "tellMore": "Erzähl uns mehr (optional)",
+    "skip": "Überspringen",
+    "sending": "Wird gesendet …",
+    "sendFeedback": "Feedback senden"
+  },
+  "accountDeletion": {
+    "deleteAccount": "Konto löschen",
+    "warning": "Alle deine Daten werden dauerhaft gelöscht. Das kann nicht rückgängig gemacht werden.",
+    "deleteAccountQuestion": "Konto löschen?",
+    "close": "schließen",
+    "cancel": "Abbrechen"
+  },
+  "claimSubscription": {
+    "paidDifferentEmail": "Mit einer anderen E-Mail bezahlt?",
+    "sent": "Gesendet. Sieh in diesem Postfach nach einem Bestätigungslink.",
+    "description": "Wenn du bei Stripe mit einer anderen E-Mail-Adresse bezahlt hast, gib sie hier ein. Wir senden einen Bestätigungslink an diese Adresse, um das Abo mit diesem Konto zu verknüpfen.",
+    "emailPlaceholder": "E-Mail, mit der du bezahlt hast",
+    "emailLabel": "E-Mail, mit der du bezahlt hast",
+    "error": "Etwas ist schiefgelaufen. Versuch es gleich noch einmal.",
+    "sending": "Wird gesendet …",
+    "sendConfirmation": "Bestätigungs-E-Mail senden"
+  },
+  "logOutEverywhere": {
+    "sessions": "Sitzungen",
+    "notice": "Gerät verloren? Melde dich überall ab, um jede Sitzung zu beenden, auch diese. Melde dich wieder an, um weiterzumachen.",
+    "confirm": "Bestätigen",
+    "cancel": "Abbrechen",
+    "logOutEverywhere": "Überall abmelden"
+  },
+  "planDetails": {
+    "lifetimeMeta": "Alle aktuellen und künftigen Funktionen.",
+    "premiumMeta": "Unbegrenzte Karten, alle Formate.",
+    "free": "Kostenlos",
+    "freeMeta": "100 cards per month.",
+    "seePlans": "Tarife ansehen"
+  },
+  "checkout": {
+    "youreOnUnlimited": "Du hast Unlimited",
+    "thanksActive": "Danke, {{firstName}} — dein Abo ist aktiv.",
+    "subscriptionActive": "Dein Abo ist aktiv.",
+    "makeDeck": "Stapel erstellen",
+    "goToAccount": "Zum Konto",
+    "paymentConfirmed": "Deine Zahlung wurde bestätigt",
+    "startUsingPrefix": "Um deine neuen Funktionen zu nutzen, melde dich an oder erstelle ein Konto mit ",
+    "sameEmailAddress": "derselben E-Mail-Adresse",
+    "startUsingSuffix": ", die du beim Bezahlen verwendet hast.",
+    "usedDifferentEmail": "Für die Zahlung eine andere E-Mail verwendet?",
+    "linkEmailsPrefix": "Du kannst Zahlungs- und Anmelde-E-Mails nach der Anmeldung auf deiner ",
+    "settingsPage": "Einstellungsseite",
+    "linkEmailsSuffix": " verknüpfen.",
+    "troubleLoggingIn": "Probleme beim Anmelden? Schreib an ",
+    "existingUser": "Bestehende Nutzerin oder Nutzer",
+    "existingUserBody": "Melde dich mit der E-Mail-Adresse an, die zu deiner Zahlung gehört.",
+    "logIn": "Anmelden",
+    "newUser": "Neue Nutzerin oder Nutzer",
+    "newUserBody": "Erstelle ein Konto mit derselben E-Mail-Adresse, die du für die Zahlung verwendet hast.",
+    "signUp": "Registrieren",
+    "note": "Hinweis:",
+    "timeoutBefore": " Wir aktivieren dein Abo noch. Wenn du bereits angemeldet bist, kannst du die ",
+    "notionPage": "Notion-Seite",
+    "timeoutAfter": " direkt öffnen oder diese Seite neu laden, um erneut zu prüfen.",
+    "processingPayment": "Deine Zahlung wird verarbeitet …",
+    "activatingSubscription": "Wir aktivieren dein Abo. Das dauert normalerweise nur ein paar Sekunden.",
+    "autoRedirect": "Du wirst automatisch weitergeleitet, sobald dein Abo aktiv ist."
+  },
+  "verifyEmail": {
+    "message": "Sieh in deinem Postfach nach — bestätige deine E-Mail, um dein Konto zu sichern.",
+    "dismiss": "Schließen"
+  },
+  "createAccount": {
+    "aria": "Deine nächsten Stapel speichern",
+    "headline": "Behalte deine nächsten Stapel",
+    "body": "Mit einem kostenlosen Konto wird jeder Stapel, den du konvertierst, in deinem Download-Verlauf gespeichert — lade sie jederzeit erneut herunter.",
+    "cta": "Kostenloses Konto erstellen"
+  },
+  "accessBanner": {
+    "active": "{{passLabel}} aktiv — läuft am {{date}} ab. Konvertiere so viel du willst.",
+    "endsIn": "{{passLabel}} endet in {{time}} — schließe alle offenen Konvertierungen ab.",
+    "minutes": "{{count}} Minuten",
+    "aboutHours_one": "etwa {{count}} Stunde",
+    "aboutHours_other": "etwa {{count}} Stunden"
+  }
+}

--- a/web/src/lib/i18n/locales/en/account.json
+++ b/web/src/lib/i18n/locales/en/account.json
@@ -1,0 +1,150 @@
+{
+  "reasons": {
+    "finished": "I finished what I needed",
+    "notEnough": "I don't use it enough",
+    "tooExpensive": "Too expensive",
+    "foundAlternative": "I found an alternative",
+    "technicalIssues": "Technical issues",
+    "other": "Other"
+  },
+  "subscription": {
+    "premium": "Premium",
+    "unknownDate": "an unknown date",
+    "endsPrefix": "Ends",
+    "endedPrefix": "Ended",
+    "renewsPrefix": "Renews",
+    "accessContinues": "Access continues until then.",
+    "cancelThisPlan": "Cancel this plan",
+    "cancelThisPlanNow": "Cancel this plan now",
+    "cancelPlanNoticeWithLabel": "Cancels the {{planLabel}} plan right away. Your card won't be charged the {{planLabel}} due {{date}}. This can't be undone.",
+    "cancelPlanNotice": "Cancels this plan right away. This can't be undone.",
+    "processing": "Processing…",
+    "keepIt": "Keep it",
+    "multipleActive": "You have {{count}} active subscriptions. You're likely being charged twice — cancel the one you don't want to keep.",
+    "billedThroughApple": "Billed through Apple",
+    "appleManageNotice": "Manage or cancel this subscription in your Apple Account settings: open Settings on your iPhone or iPad, tap your name, then Subscriptions.",
+    "pausedResumesPrefix": "Paused · Resumes",
+    "pausedNotice": "You won't be charged while paused. Your subscription resumes on {{date}} at {{plan}}. While paused, paid features are off and everything you've made is saved.",
+    "yourPlan": "your plan",
+    "resuming": "Resuming…",
+    "resumeNow": "Resume now",
+    "cancelSubscription": "Cancel subscription",
+    "legacyForfeit": "Cancelling forfeits this legacy rate.",
+    "cancelNowInstead": "Cancel now instead",
+    "previousPlan": "Previous plan: {{plan}}.",
+    "readingSubscription": "Reading your subscription",
+    "linkedEmailHeading": "Linked 2anki.net email",
+    "managedThroughStripe": "Your subscription is managed through your Stripe account at",
+    "youCan": "You can:",
+    "manageSubscription": "Manage your subscription",
+    "updatePayment": "Update payment details",
+    "cancelYourSubscription": "Cancel your subscription",
+    "subscriptionEmail": "Subscription email",
+    "subscriptionEmailPlaceholder": "Enter subscription email",
+    "emailLinked": "Email linked.",
+    "linking": "Linking…",
+    "linkEmail": "Link email"
+  },
+  "cancelFlow": {
+    "whyCancelling": "Why are you cancelling? (optional)",
+    "processing": "Processing…",
+    "cancelSubscription": "Cancel subscription",
+    "keepSubscription": "Keep subscription"
+  },
+  "pauseCard": {
+    "pauseInstead": "Pause instead — no charge while you're away",
+    "notice": "Taking a break between terms? Pause your subscription instead of cancelling. You won't be charged while it's paused, and it resumes on its own when you're ready. Everything you've made is saved.",
+    "pauseFor": "Pause for",
+    "pauseLengthAria": "Pause length",
+    "oneMonth": "1 month",
+    "nMonths": "{{count}} months",
+    "resumesLine": "Resumes {{date}} at {{plan}}. Cancel anytime before then.",
+    "yourPlan": "your plan",
+    "pausing": "Pausing…",
+    "pauseSubscription": "Pause subscription"
+  },
+  "cancellationFollowUp": {
+    "whyDidYouCancel": "Why did you cancel? (optional)",
+    "tellMore": "Tell us more (optional)",
+    "skip": "Skip",
+    "sending": "Sending…",
+    "sendFeedback": "Send feedback"
+  },
+  "accountDeletion": {
+    "deleteAccount": "Delete account",
+    "warning": "All your data will be permanently deleted. This cannot be undone.",
+    "deleteAccountQuestion": "Delete account?",
+    "close": "close",
+    "cancel": "Cancel"
+  },
+  "claimSubscription": {
+    "paidDifferentEmail": "Paid with a different email?",
+    "sent": "Sent. Check that inbox for a confirmation link.",
+    "description": "If you paid Stripe with another email address, enter it here. We'll send a confirmation link to that address to attach the subscription to this account.",
+    "emailPlaceholder": "Email you paid with",
+    "emailLabel": "Email you paid with",
+    "error": "Something went wrong. Try again in a moment.",
+    "sending": "Sending…",
+    "sendConfirmation": "Send confirmation email"
+  },
+  "logOutEverywhere": {
+    "sessions": "Sessions",
+    "notice": "Lost a device? Log out everywhere to end every session, including this one. Sign back in to continue.",
+    "confirm": "Confirm",
+    "cancel": "Cancel",
+    "logOutEverywhere": "Log out everywhere"
+  },
+  "planDetails": {
+    "lifetimeMeta": "All current and future features.",
+    "premiumMeta": "Unlimited cards, all formats.",
+    "free": "Free",
+    "freeMeta": "100 cards per month.",
+    "seePlans": "See plans"
+  },
+  "checkout": {
+    "youreOnUnlimited": "You're on Unlimited",
+    "thanksActive": "Thanks, {{firstName}} — your subscription is active.",
+    "subscriptionActive": "Your subscription is active.",
+    "makeDeck": "Make a deck",
+    "goToAccount": "Go to account",
+    "paymentConfirmed": "Your payment has been confirmed",
+    "startUsingPrefix": "To start using your new features, log in or create an account with the ",
+    "sameEmailAddress": "same email address",
+    "startUsingSuffix": " you used at checkout.",
+    "usedDifferentEmail": "Used a different email for payment?",
+    "linkEmailsPrefix": "You can link payment and login emails from your ",
+    "settingsPage": "settings page",
+    "linkEmailsSuffix": " after signing in.",
+    "troubleLoggingIn": "Having trouble logging in? Email ",
+    "existingUser": "Existing user",
+    "existingUserBody": "Log in with the email address associated with your payment.",
+    "logIn": "Log in",
+    "newUser": "New user",
+    "newUserBody": "Create an account using the same email address used for your payment.",
+    "signUp": "Sign up",
+    "note": "Note:",
+    "timeoutBefore": " We're still processing your subscription activation. If you're already logged in, you can try visiting the ",
+    "notionPage": "Notion page",
+    "timeoutAfter": " directly, or refresh this page to check again.",
+    "processingPayment": "Processing your payment...",
+    "activatingSubscription": "We're activating your subscription. This usually takes just a few seconds.",
+    "autoRedirect": "You'll be automatically redirected once your subscription is active."
+  },
+  "verifyEmail": {
+    "message": "Check your inbox — confirm your email to secure your account.",
+    "dismiss": "Dismiss"
+  },
+  "createAccount": {
+    "aria": "Save your next decks",
+    "headline": "Keep your next decks",
+    "body": "With a free account, every deck you convert is saved to your downloads history — re-download any of them later.",
+    "cta": "Create a free account"
+  },
+  "accessBanner": {
+    "active": "{{passLabel}} active — expires {{date}}. Convert as much as you want.",
+    "endsIn": "{{passLabel}} ends in {{time}} — finish any pending conversions.",
+    "minutes": "{{count}} minutes",
+    "aboutHours_one": "about {{count}} hour",
+    "aboutHours_other": "about {{count}} hours"
+  }
+}

--- a/web/src/pages/AccountPage/components/AccountDeletion.i18n.test.tsx
+++ b/web/src/pages/AccountPage/components/AccountDeletion.i18n.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import i18n from '../../../lib/i18n';
+import { AccountDeletion } from './AccountDeletion';
+
+describe('AccountDeletion in German', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('renders the delete-account heading and warning in German', () => {
+    render(
+      <MemoryRouter>
+        <AccountDeletion />
+      </MemoryRouter>
+    );
+    expect(
+      screen.getByRole('heading', { name: 'Konto löschen' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByText(
+        'Alle deine Daten werden dauerhaft gelöscht. Das kann nicht rückgängig gemacht werden.'
+      ).length
+    ).toBeGreaterThan(0);
+  });
+});

--- a/web/src/pages/AccountPage/components/AccountDeletion.tsx
+++ b/web/src/pages/AccountPage/components/AccountDeletion.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { useDialog } from '../../../lib/hooks/useDialog';
 import sharedStyles from '../../../styles/shared.module.css';
 import styles from '../AccountPage.module.css';
 
 export function AccountDeletion() {
+  const { t } = useTranslation('account');
   const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -23,17 +25,17 @@ export function AccountDeletion() {
 
   return (
     <div className={styles.dangerSection}>
-      <h4 className={styles.dangerTitle}>Delete account</h4>
-      <div className={styles.dangerNotice}>
-        All your data will be permanently deleted. This cannot be undone.
-      </div>
+      <h4 className={styles.dangerTitle}>
+        {t('accountDeletion.deleteAccount')}
+      </h4>
+      <div className={styles.dangerNotice}>{t('accountDeletion.warning')}</div>
       <button
         ref={triggerRef}
         type="button"
         className={styles.dangerButton}
         onClick={() => setIsOpen(true)}
       >
-        Delete account
+        {t('accountDeletion.deleteAccount')}
       </button>
       <dialog
         ref={dialogRef}
@@ -46,11 +48,11 @@ export function AccountDeletion() {
               id="delete-account-dialog-title"
               className={sharedStyles.modalHeaderTitle}
             >
-              Delete account?
+              {t('accountDeletion.deleteAccountQuestion')}
             </h4>
             <button
               type="button"
-              aria-label="close"
+              aria-label={t('accountDeletion.close')}
               onClick={close}
               className={sharedStyles.modalClose}
             >
@@ -58,7 +60,7 @@ export function AccountDeletion() {
             </button>
           </div>
           <section className={sharedStyles.modalBody}>
-            All your data will be permanently deleted. This cannot be undone.
+            {t('accountDeletion.warning')}
           </section>
           <div className={sharedStyles.modalFooter}>
             <button
@@ -67,14 +69,14 @@ export function AccountDeletion() {
               className={sharedStyles.btnSecondary}
               onClick={close}
             >
-              Cancel
+              {t('accountDeletion.cancel')}
             </button>
             <button
               type="button"
               className={sharedStyles.btnDanger}
               onClick={() => navigate('/delete-account')}
             >
-              Delete account
+              {t('accountDeletion.deleteAccount')}
             </button>
           </div>
         </div>

--- a/web/src/pages/AccountPage/components/CancelFlow.tsx
+++ b/web/src/pages/AccountPage/components/CancelFlow.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   CANCELLATION_REASONS,
   CancellationReason,
+  REASON_KEYS,
 } from './CancellationFollowUp';
 import { PauseCard } from './PauseCard';
 import { PauseMonths } from '../../../lib/backend/pauseSubscription';
@@ -39,6 +41,7 @@ export function CancelFlow({
   onKeep,
   onPause,
 }: CancelFlowProps) {
+  const { t } = useTranslation('account');
   const [reason, setReason] = useState<CancellationReason | ''>('');
   const offeredReasons = useRef<Set<CancellationReason>>(new Set());
 
@@ -70,7 +73,7 @@ export function CancelFlow({
 
   return (
     <div className={styles.dangerSection} role="group" aria-label="Cancel">
-      <p className={styles.dangerTitle}>Why are you cancelling? (optional)</p>
+      <p className={styles.dangerTitle}>{t('cancelFlow.whyCancelling')}</p>
       <div className={styles.reasonList}>
         {CANCELLATION_REASONS.map((r) => (
           <label key={r} className={styles.reasonOption}>
@@ -81,7 +84,7 @@ export function CancelFlow({
               checked={reason === r}
               onChange={() => setReason(r)}
             />
-            {r}
+            {t(REASON_KEYS[r])}
           </label>
         ))}
       </div>
@@ -102,7 +105,9 @@ export function CancelFlow({
           onClick={() => onCancel(reason)}
           disabled={isCancelling}
         >
-          {isCancelling ? 'Processing…' : 'Cancel subscription'}
+          {isCancelling
+            ? t('cancelFlow.processing')
+            : t('cancelFlow.cancelSubscription')}
         </button>
         <button
           type="button"
@@ -110,7 +115,7 @@ export function CancelFlow({
           onClick={() => onKeep(reason)}
           disabled={isCancelling}
         >
-          Keep subscription
+          {t('cancelFlow.keepSubscription')}
         </button>
       </div>
     </div>

--- a/web/src/pages/AccountPage/components/CancellationFollowUp.i18n.test.tsx
+++ b/web/src/pages/AccountPage/components/CancellationFollowUp.i18n.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from '../../../lib/i18n';
+import { CancellationFollowUp } from './CancellationFollowUp';
+
+describe('CancellationFollowUp in German', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('translates the reasons and submit button but keeps the English reason value', () => {
+    const onSubmit = vi.fn();
+    render(
+      <CancellationFollowUp
+        onSubmit={onSubmit}
+        onSkip={vi.fn()}
+        isSubmitting={false}
+      />
+    );
+
+    expect(
+      screen.getByText('Warum hast du gekündigt? (optional)')
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Zu teuer'));
+    fireEvent.click(screen.getByRole('button', { name: 'Feedback senden' }));
+
+    expect(onSubmit).toHaveBeenCalledWith('Too expensive', '');
+  });
+});

--- a/web/src/pages/AccountPage/components/CancellationFollowUp.tsx
+++ b/web/src/pages/AccountPage/components/CancellationFollowUp.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import sharedStyles from '../../../styles/shared.module.css';
 import styles from '../AccountPage.module.css';
 
@@ -13,6 +14,15 @@ export const CANCELLATION_REASONS = [
 
 export type CancellationReason = (typeof CANCELLATION_REASONS)[number];
 
+export const REASON_KEYS: Record<CancellationReason, string> = {
+  'I finished what I needed': 'reasons.finished',
+  "I don't use it enough": 'reasons.notEnough',
+  'Too expensive': 'reasons.tooExpensive',
+  'I found an alternative': 'reasons.foundAlternative',
+  'Technical issues': 'reasons.technicalIssues',
+  Other: 'reasons.other',
+};
+
 interface Props {
   readonly onSubmit: (reason: CancellationReason, comment: string) => void;
   readonly onSkip: () => void;
@@ -24,6 +34,7 @@ export function CancellationFollowUp({
   onSkip,
   isSubmitting,
 }: Props) {
+  const { t } = useTranslation('account');
   const [reason, setReason] = useState<CancellationReason | ''>('');
   const [comment, setComment] = useState('');
 
@@ -34,7 +45,7 @@ export function CancellationFollowUp({
 
   return (
     <div className={sharedStyles.marginTopLg}>
-      <p>Why did you cancel? (optional)</p>
+      <p>{t('cancellationFollowUp.whyDidYouCancel')}</p>
       <div className={styles.reasonList}>
         {CANCELLATION_REASONS.map((r) => (
           <label key={r} className={styles.reasonOption}>
@@ -45,7 +56,7 @@ export function CancellationFollowUp({
               checked={reason === r}
               onChange={() => setReason(r)}
             />
-            {r}
+            {t(REASON_KEYS[r])}
           </label>
         ))}
       </div>
@@ -53,7 +64,7 @@ export function CancellationFollowUp({
       {reason === 'Other' && (
         <textarea
           className={styles.reasonComment}
-          placeholder="Tell us more (optional)"
+          placeholder={t('cancellationFollowUp.tellMore')}
           value={comment}
           onChange={(e) => setComment(e.target.value)}
           rows={3}
@@ -63,7 +74,7 @@ export function CancellationFollowUp({
 
       <div className={styles.actions}>
         <button type="button" className={styles.textButton} onClick={onSkip}>
-          Skip
+          {t('cancellationFollowUp.skip')}
         </button>
         <button
           type="button"
@@ -71,7 +82,9 @@ export function CancellationFollowUp({
           onClick={handleSubmit}
           disabled={!reason || isSubmitting}
         >
-          {isSubmitting ? 'Sending…' : 'Send feedback'}
+          {isSubmitting
+            ? t('cancellationFollowUp.sending')
+            : t('cancellationFollowUp.sendFeedback')}
         </button>
       </div>
     </div>

--- a/web/src/pages/AccountPage/components/ClaimSubscription.tsx
+++ b/web/src/pages/AccountPage/components/ClaimSubscription.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { post } from '../../../lib/backend/api';
 import styles from '../AccountPage.module.css';
 import sharedStyles from '../../../styles/shared.module.css';
@@ -6,6 +7,7 @@ import sharedStyles from '../../../styles/shared.module.css';
 type Status = 'idle' | 'loading' | 'success' | 'error';
 
 export function ClaimSubscription() {
+  const { t } = useTranslation('account');
   const [expanded, setExpanded] = useState(false);
   const [email, setEmail] = useState('');
   const [status, setStatus] = useState<Status>('idle');
@@ -23,9 +25,7 @@ export function ClaimSubscription() {
     } else {
       setStatus('error');
       const body = (await res.json().catch(() => ({}))) as { message?: string };
-      setErrorMessage(
-        body.message ?? 'Something went wrong. Try again in a moment.'
-      );
+      setErrorMessage(body.message ?? t('claimSubscription.error'));
     }
   };
 
@@ -43,14 +43,14 @@ export function ClaimSubscription() {
           padding: 0,
         }}
       >
-        Paid with a different email?
+        {t('claimSubscription.paidDifferentEmail')}
       </button>
 
       {expanded && (
         <div style={{ marginTop: '1rem' }}>
           {status === 'success' ? (
             <output style={{ margin: 0, display: 'block' }}>
-              Sent. Check that inbox for a confirmation link.
+              {t('claimSubscription.sent')}
             </output>
           ) : (
             <>
@@ -61,9 +61,7 @@ export function ClaimSubscription() {
                   color: 'var(--color-text-secondary)',
                 }}
               >
-                If you paid Stripe with another email address, enter it here.
-                We'll send a confirmation link to that address to attach the
-                subscription to this account.
+                {t('claimSubscription.description')}
               </p>
               <form
                 onSubmit={handleSubmit}
@@ -77,10 +75,10 @@ export function ClaimSubscription() {
                   type="email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
-                  placeholder="Email you paid with"
+                  placeholder={t('claimSubscription.emailPlaceholder')}
                   required
                   disabled={status === 'loading'}
-                  aria-label="Email you paid with"
+                  aria-label={t('claimSubscription.emailLabel')}
                 />
                 {status === 'error' && (
                   <p
@@ -100,8 +98,8 @@ export function ClaimSubscription() {
                   disabled={status === 'loading' || !email}
                 >
                   {status === 'loading'
-                    ? 'Sending…'
-                    : 'Send confirmation email'}
+                    ? t('claimSubscription.sending')
+                    : t('claimSubscription.sendConfirmation')}
                 </button>
               </form>
             </>

--- a/web/src/pages/AccountPage/components/LogOutEverywhere.tsx
+++ b/web/src/pages/AccountPage/components/LogOutEverywhere.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { get2ankiApi } from '../../../lib/backend/get2ankiApi';
 import styles from '../AccountPage.module.css';
 
 export function LogOutEverywhere() {
+  const { t } = useTranslation('account');
   const [isConfirming, setIsConfirming] = useState(false);
   const [isWorking, setIsWorking] = useState(false);
 
@@ -13,10 +15,9 @@ export function LogOutEverywhere() {
 
   return (
     <section className={styles.section}>
-      <h4 className={styles.sessionsTitle}>Sessions</h4>
+      <h4 className={styles.sessionsTitle}>{t('logOutEverywhere.sessions')}</h4>
       <div className={styles.sessionsNotice}>
-        Lost a device? Log out everywhere to end every session, including this
-        one. Sign back in to continue.
+        {t('logOutEverywhere.notice')}
       </div>
       {isConfirming ? (
         <div className={styles.buttonRow}>
@@ -26,7 +27,7 @@ export function LogOutEverywhere() {
             onClick={revokeAll}
             disabled={isWorking}
           >
-            Confirm
+            {t('logOutEverywhere.confirm')}
           </button>
           <button
             type="button"
@@ -34,7 +35,7 @@ export function LogOutEverywhere() {
             onClick={() => setIsConfirming(false)}
             disabled={isWorking}
           >
-            Cancel
+            {t('logOutEverywhere.cancel')}
           </button>
         </div>
       ) : (
@@ -43,7 +44,7 @@ export function LogOutEverywhere() {
           className={styles.sessionsButton}
           onClick={() => setIsConfirming(true)}
         >
-          Log out everywhere
+          {t('logOutEverywhere.logOutEverywhere')}
         </button>
       )}
     </section>

--- a/web/src/pages/AccountPage/components/PauseCard.i18n.test.tsx
+++ b/web/src/pages/AccountPage/components/PauseCard.i18n.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from '../../../lib/i18n';
+import { PauseCard } from './PauseCard';
+
+describe('PauseCard in German', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('renders the pause offer and action in German', () => {
+    render(
+      <PauseCard
+        planLabel="$7.99 / month"
+        isPausing={false}
+        pauseError=""
+        onPause={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText(/Stattdessen pausieren/)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Abo pausieren' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: '2 Monate' })
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/AccountPage/components/PauseCard.tsx
+++ b/web/src/pages/AccountPage/components/PauseCard.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import styles from '../AccountPage.module.css';
 import sharedStyles from '../../../styles/shared.module.css';
 import { PauseMonths } from '../../../lib/backend/pauseSubscription';
@@ -31,24 +32,23 @@ export function PauseCard({
   pauseError,
   onPause,
 }: PauseCardProps) {
+  const { t } = useTranslation('account');
   const [months, setMonths] = useState<PauseMonths | null>(null);
 
   const resumeDate = months == null ? null : addMonths(new Date(), months);
-  const planText = planLabel ?? 'your plan';
+  const planText = planLabel ?? t('pauseCard.yourPlan');
 
   return (
     <div className={`${styles.section} ${sharedStyles.marginTopLg}`}>
-      <p className={styles.dangerTitle}>
-        Pause instead — no charge while you're away
-      </p>
-      <p className={styles.dangerNotice}>
-        Taking a break between terms? Pause your subscription instead of
-        cancelling. You won't be charged while it's paused, and it resumes on
-        its own when you're ready. Everything you've made is saved.
-      </p>
+      <p className={styles.dangerTitle}>{t('pauseCard.pauseInstead')}</p>
+      <p className={styles.dangerNotice}>{t('pauseCard.notice')}</p>
 
-      <p className={styles.dangerTitle}>Pause for</p>
-      <div className={styles.buttonRow} role="group" aria-label="Pause length">
+      <p className={styles.dangerTitle}>{t('pauseCard.pauseFor')}</p>
+      <div
+        className={styles.buttonRow}
+        role="group"
+        aria-label={t('pauseCard.pauseLengthAria')}
+      >
         {PAUSE_LENGTHS.map((length) => (
           <button
             key={length}
@@ -61,15 +61,19 @@ export function PauseCard({
             aria-pressed={months === length}
             onClick={() => setMonths(length)}
           >
-            {length === 1 ? '1 month' : `${length} months`}
+            {length === 1
+              ? t('pauseCard.oneMonth')
+              : t('pauseCard.nMonths', { count: length })}
           </button>
         ))}
       </div>
 
       {resumeDate && (
         <p className={styles.planDetail}>
-          Resumes {formatDate(resumeDate)} at {planText}. Cancel anytime before
-          then.
+          {t('pauseCard.resumesLine', {
+            date: formatDate(resumeDate),
+            plan: planText,
+          })}
         </p>
       )}
 
@@ -80,7 +84,9 @@ export function PauseCard({
           disabled={months == null || isPausing}
           onClick={() => months != null && onPause(months)}
         >
-          {isPausing ? 'Pausing…' : 'Pause subscription'}
+          {isPausing
+            ? t('pauseCard.pausing')
+            : t('pauseCard.pauseSubscription')}
         </button>
       </div>
 

--- a/web/src/pages/AccountPage/components/PlanDetails.i18n.test.tsx
+++ b/web/src/pages/AccountPage/components/PlanDetails.i18n.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import i18n from '../../../lib/i18n';
+import { PlanDetails } from './PlanDetails';
+
+describe('PlanDetails in German', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('renders the free tier meta and link in German', () => {
+    render(<PlanDetails subscriptionType="free" />);
+    expect(screen.getByText('Kostenlos')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Tarife ansehen' })
+    ).toBeInTheDocument();
+  });
+
+  it('keeps the Lifetime plan name and translates its meta', () => {
+    render(<PlanDetails subscriptionType="lifetime" />);
+    expect(screen.getByText('Lifetime')).toBeInTheDocument();
+    expect(
+      screen.getByText('Alle aktuellen und künftigen Funktionen.')
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/AccountPage/components/PlanDetails.tsx
+++ b/web/src/pages/AccountPage/components/PlanDetails.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import styles from '../AccountPage.module.css';
 
 interface PlanDetailsProps {
@@ -5,11 +6,13 @@ interface PlanDetailsProps {
 }
 
 export function PlanDetails({ subscriptionType }: PlanDetailsProps) {
+  const { t } = useTranslation('account');
+
   if (subscriptionType === 'lifetime') {
     return (
       <section className={styles.section}>
         <p className={styles.planTier}>Lifetime</p>
-        <p className={styles.planMeta}>All current and future features.</p>
+        <p className={styles.planMeta}>{t('planDetails.lifetimeMeta')}</p>
       </section>
     );
   }
@@ -17,18 +20,18 @@ export function PlanDetails({ subscriptionType }: PlanDetailsProps) {
   if (subscriptionType === 'subscriber') {
     return (
       <section className={styles.section}>
-        <p className={styles.planTier}>Premium</p>
-        <p className={styles.planMeta}>Unlimited cards, all formats.</p>
+        <p className={styles.planTier}>{t('subscription.premium')}</p>
+        <p className={styles.planMeta}>{t('planDetails.premiumMeta')}</p>
       </section>
     );
   }
 
   return (
     <section className={styles.section}>
-      <p className={styles.planTier}>Free</p>
-      <p className={styles.planMeta}>100 cards per month.</p>
+      <p className={styles.planTier}>{t('planDetails.free')}</p>
+      <p className={styles.planMeta}>{t('planDetails.freeMeta')}</p>
       <a href="/pricing" className={styles.primaryButton}>
-        See plans
+        {t('planDetails.seePlans')}
       </a>
     </section>
   );

--- a/web/src/pages/AccountPage/components/SubscriptionManagement.i18n.test.tsx
+++ b/web/src/pages/AccountPage/components/SubscriptionManagement.i18n.test.tsx
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode } from 'react';
+import i18n from '../../../lib/i18n';
+import { SubscriptionManagement } from './SubscriptionManagement';
+import type { StripeSubscriptionsState } from '../../../lib/hooks/useStripeSubscriptions';
+
+vi.mock('../../../lib/hooks/useStripeSubscriptions', () => ({
+  useStripeSubscriptions: vi.fn(),
+}));
+
+import { useStripeSubscriptions } from '../../../lib/hooks/useStripeSubscriptions';
+
+const mockUseStripeSubscriptions =
+  useStripeSubscriptions as unknown as ReturnType<typeof vi.fn>;
+
+const user = { email: 'learner@example.com', name: 'Learner' };
+
+function withQueryClient(ui: ReactNode) {
+  const client = new QueryClient();
+  return <QueryClientProvider client={client}>{ui}</QueryClientProvider>;
+}
+
+describe('SubscriptionManagement in German', () => {
+  beforeEach(async () => {
+    mockUseStripeSubscriptions.mockReset();
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('renders the active Stripe controls in German', () => {
+    const subscription = {
+      id: 'sub_1',
+      status: 'active',
+      created: Math.floor(Date.now() / 1000) - 120 * 24 * 60 * 60,
+      cancel_at_period_end: false,
+      current_period_end: 1893456000,
+      cancel_at: null,
+      canceled_at: null,
+      paused_until: null,
+      plan: { amount: 1000, currency: 'usd', interval: 'month' },
+    };
+    mockUseStripeSubscriptions.mockReturnValue({
+      subscriptions: [subscription],
+      activeSubscriptions: [subscription],
+      view: { kind: 'active', subscription },
+      isLoading: false,
+      refetch: vi.fn().mockResolvedValue(undefined),
+    } as unknown as StripeSubscriptionsState);
+
+    render(
+      withQueryClient(
+        <SubscriptionManagement
+          user={user}
+          locals={{ subscriber: true, planSource: 'stripe' }}
+          hasActivePlan
+          onRefetch={vi.fn().mockResolvedValue(undefined)}
+        />
+      )
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Abo kündigen' })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Verlängert sich am/)).toBeInTheDocument();
+  });
+
+  it('renders Apple management copy in German', () => {
+    render(
+      <SubscriptionManagement
+        user={user}
+        locals={{ subscriber: true, planSource: 'apple' }}
+        hasActivePlan
+        onRefetch={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    expect(screen.getByText(/Über Apple abgerechnet/)).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/AccountPage/components/SubscriptionManagement.tsx
+++ b/web/src/pages/AccountPage/components/SubscriptionManagement.tsx
@@ -1,4 +1,5 @@
 import React, { ChangeEvent, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useEmailLinking } from '../hooks/useEmailLinking';
 import { useSubscriptionCancellation } from '../hooks/useSubscriptionCancellation';
 import { usePerSubscriptionCancellation } from '../hooks/usePerSubscriptionCancellation';
@@ -45,8 +46,8 @@ interface SubscriptionManagementProps {
   readonly onRefetch: () => Promise<any>;
 }
 
-const formatDate = (seconds: number | null): string => {
-  if (!seconds) return 'an unknown date';
+const formatDate = (seconds: number | null, unknownLabel: string): string => {
+  if (!seconds) return unknownLabel;
   return new Date(seconds * 1000).toLocaleDateString(undefined, {
     year: 'numeric',
     month: 'long',
@@ -99,6 +100,9 @@ function MultipleSubscriptionsRow({
   readonly onConfirmCancel: (id: string) => void;
   readonly onDismiss: () => void;
 }) {
+  const { t } = useTranslation('account');
+  const fmt = (seconds: number | null) =>
+    formatDate(seconds, t('subscription.unknownDate'));
   const planLabel = formatPlan(sub);
   const isScheduled = sub.cancel_at_period_end;
   const isConfirming = confirmingSubId === sub.id;
@@ -107,9 +111,9 @@ function MultipleSubscriptionsRow({
     return (
       <div className={styles.section}>
         <p className={styles.statusLine}>
-          {planLabel ?? 'Premium'} · Ends{' '}
-          <strong>{formatDate(sub.cancel_at)}</strong>. Access continues until
-          then.
+          {planLabel ?? t('subscription.premium')} ·{' '}
+          {t('subscription.endsPrefix')} <strong>{fmt(sub.cancel_at)}</strong>.{' '}
+          {t('subscription.accessContinues')}
         </p>
       </div>
     );
@@ -118,8 +122,11 @@ function MultipleSubscriptionsRow({
   return (
     <div className={styles.section}>
       <p className={styles.statusLine}>
-        <span style={{ fontWeight: 500 }}>{planLabel ?? 'Premium'}</span> ·
-        Renews <strong>{formatDate(sub.current_period_end)}</strong>
+        <span style={{ fontWeight: 500 }}>
+          {planLabel ?? t('subscription.premium')}
+        </span>{' '}
+        · {t('subscription.renewsPrefix')}{' '}
+        <strong>{fmt(sub.current_period_end)}</strong>
       </p>
       {!isConfirming && (
         <div className={styles.actions}>
@@ -128,7 +135,7 @@ function MultipleSubscriptionsRow({
             className={styles.secondaryButton}
             onClick={() => onOpenConfirm(sub.id)}
           >
-            Cancel this plan
+            {t('subscription.cancelThisPlan')}
           </button>
         </div>
       )}
@@ -136,13 +143,18 @@ function MultipleSubscriptionsRow({
         <div
           className={styles.dangerSection}
           role="group"
-          aria-label="Cancel this plan now"
+          aria-label={t('subscription.cancelThisPlanNow')}
         >
-          <p className={styles.dangerTitle}>Cancel this plan now</p>
+          <p className={styles.dangerTitle}>
+            {t('subscription.cancelThisPlanNow')}
+          </p>
           <p className={styles.dangerNotice}>
             {planLabel
-              ? `Cancels the ${planLabel} plan right away. Your card won't be charged the ${planLabel} due ${formatDate(sub.current_period_end)}. This can't be undone.`
-              : "Cancels this plan right away. This can't be undone."}
+              ? t('subscription.cancelPlanNoticeWithLabel', {
+                  planLabel,
+                  date: fmt(sub.current_period_end),
+                })
+              : t('subscription.cancelPlanNotice')}
           </p>
           <div className={styles.buttonRow}>
             <button
@@ -151,7 +163,9 @@ function MultipleSubscriptionsRow({
               onClick={() => onConfirmCancel(sub.id)}
               disabled={isCancelling}
             >
-              {isCancelling ? 'Processing…' : 'Cancel this plan'}
+              {isCancelling
+                ? t('subscription.processing')
+                : t('subscription.cancelThisPlan')}
             </button>
             <button
               type="button"
@@ -159,7 +173,7 @@ function MultipleSubscriptionsRow({
               onClick={onDismiss}
               disabled={isCancelling}
             >
-              Keep it
+              {t('subscription.keepIt')}
             </button>
           </div>
         </div>
@@ -178,6 +192,7 @@ function MultipleSubscriptions({
   readonly subscriptions: StripeSubscriptionSummary[];
   readonly onRefetch: () => Promise<unknown>;
 }) {
+  const { t } = useTranslation('account');
   const {
     confirmingSubId,
     errorSubId,
@@ -195,8 +210,7 @@ function MultipleSubscriptions({
   return (
     <section className={styles.section}>
       <p className={styles.scheduledBadge}>
-        You have {subscriptions.length} active subscriptions. You're likely
-        being charged twice — cancel the one you don't want to keep.
+        {t('subscription.multipleActive', { count: subscriptions.length })}
       </p>
       {ordered.map((sub) => (
         <MultipleSubscriptionsRow
@@ -216,12 +230,14 @@ function MultipleSubscriptions({
 }
 
 function AppleSubscriptionManagement() {
+  const { t } = useTranslation('account');
   return (
     <section className={styles.section}>
-      <p className={styles.statusLine}>Unlimited · Billed through Apple</p>
+      <p className={styles.statusLine}>
+        Unlimited · {t('subscription.billedThroughApple')}
+      </p>
       <p className={sharedStyles.smallDescription}>
-        Manage or cancel this subscription in your Apple Account settings: open
-        Settings on your iPhone or iPad, tap your name, then Subscriptions.
+        {t('subscription.appleManageNotice')}
       </p>
     </section>
   );
@@ -244,18 +260,20 @@ function PausedState({
   readonly onResume: () => void;
   readonly onCancel: () => void;
 }) {
-  const resumeDate = formatDate(subscription.paused_until);
-  const planText = planLabel ?? 'your plan';
+  const { t } = useTranslation('account');
+  const resumeDate = formatDate(
+    subscription.paused_until,
+    t('subscription.unknownDate')
+  );
+  const planText = planLabel ?? t('subscription.yourPlan');
 
   return (
     <>
       <p className={styles.scheduledBadge}>
-        Paused · Resumes <strong>{resumeDate}</strong>
+        {t('subscription.pausedResumesPrefix')} <strong>{resumeDate}</strong>
       </p>
       <p className={styles.dangerNotice}>
-        You won't be charged while paused. Your subscription resumes on{' '}
-        {resumeDate} at {planText}. While paused, paid features are off and
-        everything you've made is saved.
+        {t('subscription.pausedNotice', { date: resumeDate, plan: planText })}
       </p>
       <div className={styles.actions}>
         <button
@@ -264,7 +282,9 @@ function PausedState({
           onClick={onResume}
           disabled={isResuming}
         >
-          {isResuming ? 'Resuming…' : 'Resume now'}
+          {isResuming
+            ? t('subscription.resuming')
+            : t('subscription.resumeNow')}
         </button>
         <button
           type="button"
@@ -272,7 +292,9 @@ function PausedState({
           onClick={onCancel}
           disabled={isCancelling}
         >
-          {isCancelling ? 'Processing…' : 'Cancel subscription'}
+          {isCancelling
+            ? t('subscription.processing')
+            : t('subscription.cancelSubscription')}
         </button>
       </div>
       {resumeError && <p className={styles.helpDanger}>{resumeError}</p>}
@@ -299,6 +321,9 @@ function StripeSubscriptionManagement({
   locals,
   onRefetch,
 }: SubscriptionManagementProps) {
+  const { t } = useTranslation('account');
+  const fmt = (seconds: number | null) =>
+    formatDate(seconds, t('subscription.unknownDate'));
   const {
     linkEmail,
     setLinkEmail,
@@ -399,14 +424,13 @@ function StripeSubscriptionManagement({
           {view.kind === 'active' && (
             <>
               <p className={styles.statusLine}>
-                {formatPlan(view.subscription) ?? 'Premium'} · Renews{' '}
-                <strong>
-                  {formatDate(view.subscription.current_period_end)}
-                </strong>
+                {formatPlan(view.subscription) ?? t('subscription.premium')} ·{' '}
+                {t('subscription.renewsPrefix')}{' '}
+                <strong>{fmt(view.subscription.current_period_end)}</strong>
               </p>
               {isLegacyRate(view.subscription) && (
                 <p className={styles.legacyNote}>
-                  Cancelling forfeits this legacy rate.
+                  {t('subscription.legacyForfeit')}
                 </p>
               )}
               {!confirming && (
@@ -417,7 +441,7 @@ function StripeSubscriptionManagement({
                     onClick={() => setConfirming(true)}
                     disabled={isCancelling}
                   >
-                    Cancel subscription
+                    {t('subscription.cancelSubscription')}
                   </button>
                 </div>
               )}
@@ -452,8 +476,9 @@ function StripeSubscriptionManagement({
           {view.kind === 'scheduled' && (
             <>
               <p className={styles.statusLine}>
-                Ends <strong>{formatDate(view.subscription.cancel_at)}</strong>.
-                Access continues until then.
+                {t('subscription.endsPrefix')}{' '}
+                <strong>{fmt(view.subscription.cancel_at)}</strong>.{' '}
+                {t('subscription.accessContinues')}
               </p>
               <div className={styles.actions}>
                 <button
@@ -462,7 +487,9 @@ function StripeSubscriptionManagement({
                   onClick={() => cancelUserSubscription('immediate')}
                   disabled={isCancelling}
                 >
-                  {isCancelling ? 'Processing…' : 'Cancel now instead'}
+                  {isCancelling
+                    ? t('subscription.processing')
+                    : t('subscription.cancelNowInstead')}
                 </button>
               </div>
             </>
@@ -470,16 +497,16 @@ function StripeSubscriptionManagement({
 
           {view.kind === 'cancelled' && (
             <p className={styles.statusLineMuted}>
-              Ended <strong>{formatDate(view.subscription.canceled_at)}</strong>
-              .
+              {t('subscription.endedPrefix')}{' '}
+              <strong>{fmt(view.subscription.canceled_at)}</strong>.
               {formatPlan(view.subscription) &&
-                ` Previous plan: ${formatPlan(view.subscription)}.`}
+                ` ${t('subscription.previousPlan', { plan: formatPlan(view.subscription) })}`}
             </p>
           )}
 
           {stripeStatus.isLoading && view.kind === 'none' && (
             <p className={sharedStyles.smallDescription}>
-              Reading your subscription
+              {t('subscription.readingSubscription')}
             </p>
           )}
 
@@ -492,34 +519,41 @@ function StripeSubscriptionManagement({
 
       {locals?.subscriber && (
         <div className={sharedStyles.marginTopLg}>
-          <h4 className={sharedStyles.smallHeading}>Linked 2anki.net email</h4>
+          <h4 className={sharedStyles.smallHeading}>
+            {t('subscription.linkedEmailHeading')}
+          </h4>
           {isEmailLinked ? (
             <div className={styles.linkedEmail}>
               <p>
-                Your subscription is managed through your Stripe account at{' '}
-                <strong>{locals.subscriptionInfo?.email}</strong>. You can:
+                {t('subscription.managedThroughStripe')}{' '}
+                <strong>{locals.subscriptionInfo?.email}</strong>.{' '}
+                {t('subscription.youCan')}
               </p>
               <ul className={sharedStyles.featureList}>
-                <li>Manage your subscription</li>
-                <li>Update payment details</li>
-                <li>Cancel your subscription</li>
+                <li>{t('subscription.manageSubscription')}</li>
+                <li>{t('subscription.updatePayment')}</li>
+                <li>{t('subscription.cancelYourSubscription')}</li>
               </ul>
             </div>
           ) : (
             <div>
               <div className={styles.field}>
-                <label htmlFor="subscription-email">Subscription email</label>
+                <label htmlFor="subscription-email">
+                  {t('subscription.subscriptionEmail')}
+                </label>
                 <input
                   id="subscription-email"
                   value={linkEmail}
                   onChange={onChangeLinkEmail}
                   type="email"
-                  placeholder="Enter subscription email"
+                  placeholder={t('subscription.subscriptionEmailPlaceholder')}
                   disabled={isEmailLinked}
                 />
                 {linkError && <p className={styles.helpDanger}>{linkError}</p>}
                 {linkSuccess && (
-                  <p className={styles.helpSuccess}>Email linked.</p>
+                  <p className={styles.helpSuccess}>
+                    {t('subscription.emailLinked')}
+                  </p>
                 )}
               </div>
 
@@ -529,7 +563,9 @@ function StripeSubscriptionManagement({
                 onClick={onLink}
                 disabled={isEmailLinked || !linkEmail.trim()}
               >
-                {isLinking ? 'Linking…' : 'Link email'}
+                {isLinking
+                  ? t('subscription.linking')
+                  : t('subscription.linkEmail')}
               </button>
             </div>
           )}

--- a/web/src/pages/SuccessfulCheckout/components/LoadingState.tsx
+++ b/web/src/pages/SuccessfulCheckout/components/LoadingState.tsx
@@ -1,20 +1,17 @@
 import Confetti from 'react-confetti';
+import { useTranslation } from 'react-i18next';
 import styles from '../../../styles/shared.module.css';
 
 export const LoadingState = () => {
+  const { t } = useTranslation('account');
   return (
     <div className={`${styles.pageNarrow} ${styles.textCenter}`}>
-      <h1 className={styles.title}>Processing your payment...</h1>
+      <h1 className={styles.title}>{t('checkout.processingPayment')}</h1>
       <div className={`${styles.flexCenter} ${styles.spinnerContainer}`}>
         <div className={styles.spinner} />
       </div>
-      <p className={styles.subtitle}>
-        We're activating your subscription. This usually takes just a few
-        seconds.
-      </p>
-      <p className={styles.secondaryText}>
-        You'll be automatically redirected once your subscription is active.
-      </p>
+      <p className={styles.subtitle}>{t('checkout.activatingSubscription')}</p>
+      <p className={styles.secondaryText}>{t('checkout.autoRedirect')}</p>
       <Confetti
         width={window.innerWidth}
         height={window.innerHeight}

--- a/web/src/pages/SuccessfulCheckout/components/LoggedInSuccess.i18n.test.tsx
+++ b/web/src/pages/SuccessfulCheckout/components/LoggedInSuccess.i18n.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import i18n from '../../../lib/i18n';
+import { LoggedInSuccess } from './LoggedInSuccess';
+
+describe('LoggedInSuccess in German', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('keeps the Unlimited plan name and renders German actions', () => {
+    render(
+      <MemoryRouter>
+        <LoggedInSuccess firstName="Alex" />
+      </MemoryRouter>
+    );
+    expect(
+      screen.getByRole('heading', { name: 'Du hast Unlimited' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Danke, Alex — dein Abo ist aktiv.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Stapel erstellen' })
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/SuccessfulCheckout/components/LoggedInSuccess.tsx
+++ b/web/src/pages/SuccessfulCheckout/components/LoggedInSuccess.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import styles from '../../../styles/shared.module.css';
 
 interface LoggedInSuccessProps {
@@ -6,14 +7,15 @@ interface LoggedInSuccessProps {
 }
 
 export const LoggedInSuccess = ({ firstName }: LoggedInSuccessProps) => {
+  const { t } = useTranslation('account');
   const navigate = useNavigate();
   const subhead = firstName
-    ? `Thanks, ${firstName} — your subscription is active.`
-    : 'Your subscription is active.';
+    ? t('checkout.thanksActive', { firstName })
+    : t('checkout.subscriptionActive');
 
   return (
     <div className={`${styles.card} ${styles.textCenter}`}>
-      <h1 className={styles.title}>You're on Unlimited</h1>
+      <h1 className={styles.title}>{t('checkout.youreOnUnlimited')}</h1>
       <p className={styles.subtitle}>{subhead}</p>
       <div className={`${styles.flexColumn} ${styles.marginTopLg}`}>
         <button
@@ -21,13 +23,13 @@ export const LoggedInSuccess = ({ firstName }: LoggedInSuccessProps) => {
           className={`${styles.btnPrimary} ${styles.btnInline}`}
           onClick={() => navigate('/upload')}
         >
-          Make a deck
+          {t('checkout.makeDeck')}
         </button>
         <a
           href="/account"
           className={`${styles.btnSecondary} ${styles.marginTopSm}`}
         >
-          Go to account
+          {t('checkout.goToAccount')}
         </a>
       </div>
     </div>

--- a/web/src/pages/SuccessfulCheckout/components/SuccessContent.tsx
+++ b/web/src/pages/SuccessfulCheckout/components/SuccessContent.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { UserActionCards } from './UserActionCards';
 import { TimeoutWarning } from './TimeoutWarning';
 import styles from '../../../styles/shared.module.css';
@@ -10,27 +11,30 @@ interface SuccessContentProps {
 }
 
 export const SuccessContent = ({ timeoutReached }: SuccessContentProps) => {
+  const { t } = useTranslation('account');
   return (
     <>
-      <h1 className={styles.title}>Your payment has been confirmed</h1>
+      <h1 className={styles.title}>{t('checkout.paymentConfirmed')}</h1>
 
       <p>
-        To start using your new features, log in or create an account with the{' '}
-        <strong>same email address</strong> you used at checkout.
+        {t('checkout.startUsingPrefix')}
+        <strong>{t('checkout.sameEmailAddress')}</strong>
+        {t('checkout.startUsingSuffix')}
       </p>
 
       <UserActionCards />
 
       <p>
-        <strong>Used a different email for payment?</strong>
+        <strong>{t('checkout.usedDifferentEmail')}</strong>
       </p>
       <p>
-        You can link payment and login emails from your{' '}
-        <a href={settingsLink}>settings page</a> after signing in.
+        {t('checkout.linkEmailsPrefix')}
+        <a href={settingsLink}>{t('checkout.settingsPage')}</a>
+        {t('checkout.linkEmailsSuffix')}
       </p>
 
       <p>
-        Having trouble logging in? Email{' '}
+        {t('checkout.troubleLoggingIn')}
         <a href={supportLink}>support@2anki.net</a>.
       </p>
 

--- a/web/src/pages/SuccessfulCheckout/components/TimeoutWarning.tsx
+++ b/web/src/pages/SuccessfulCheckout/components/TimeoutWarning.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import styles from '../../../styles/shared.module.css';
 
 interface TimeoutWarningProps {
@@ -5,15 +6,16 @@ interface TimeoutWarningProps {
 }
 
 export const TimeoutWarning = ({ show }: TimeoutWarningProps) => {
+  const { t } = useTranslation('account');
   if (!show) return null;
 
   return (
     <div className={styles.notificationWarning}>
       <p>
-        <strong>Note:</strong> We're still processing your subscription
-        activation. If you're already logged in, you can try visiting the{' '}
-        <a href="/notion">Notion page</a> directly, or refresh this page to
-        check again.
+        <strong>{t('checkout.note')}</strong>
+        {t('checkout.timeoutBefore')}
+        <a href="/notion">{t('checkout.notionPage')}</a>
+        {t('checkout.timeoutAfter')}
       </p>
     </div>
   );

--- a/web/src/pages/SuccessfulCheckout/components/UserActionCards.tsx
+++ b/web/src/pages/SuccessfulCheckout/components/UserActionCards.tsx
@@ -1,26 +1,26 @@
+import { useTranslation } from 'react-i18next';
 import styles from '../../../styles/shared.module.css';
 
 const loginLink = 'https://2anki.net/login';
 const registerLink = 'https://2anki.net/register';
 
 export const UserActionCards = () => {
+  const { t } = useTranslation('account');
   return (
     <div className={styles.columns2}>
       <div>
-        <h3 className={styles.sectionTitle}>Existing user</h3>
-        <p>Log in with the email address associated with your payment.</p>
+        <h3 className={styles.sectionTitle}>{t('checkout.existingUser')}</h3>
+        <p>{t('checkout.existingUserBody')}</p>
         <a href={loginLink} className={styles.btnPrimary}>
-          Log in
+          {t('checkout.logIn')}
         </a>
       </div>
 
       <div>
-        <h3 className={styles.sectionTitle}>New user</h3>
-        <p>
-          Create an account using the same email address used for your payment.
-        </p>
+        <h3 className={styles.sectionTitle}>{t('checkout.newUser')}</h3>
+        <p>{t('checkout.newUserBody')}</p>
         <a href={registerLink} className={styles.btnPrimary}>
-          Sign up
+          {t('checkout.signUp')}
         </a>
       </div>
     </div>

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-16-german-account.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-16-german-account.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-16-german-account",
+  "date": "2026-07-16",
+  "type": "feature",
+  "title": "Account, billing, and post-checkout screens now available in German"
+}


### PR DESCRIPTION
## What
Adds German translations for the account/billing management, cancellation and pause retention flow, post-checkout success screens, and the verify-email / access-pass / create-account notices. Introduces a new `account` i18n namespace (`locales/{en,de}/account.json`) wired via `useTranslation('account')`.

## Why
German is a supported UI language (`react-i18next` on main), but these surfaces were still English-only. This is part of a parallel i18n fan-out — this PR owns the account/checkout/auth-notice surfaces. Widening supported-language coverage lowers signup and retention friction for German-speaking learners.

## How
- New `account` namespace with sub-objects per surface (`subscription`, `cancelFlow`, `pauseCard`, `cancellationFollowUp`, `accountDeletion`, `claimSubscription`, `logOutEverywhere`, `planDetails`, `checkout`, `verifyEmail`, `createAccount`, `accessBanner`, plus a shared `reasons` map).
- Cancellation reasons keep their English constant as the tracked `value`/`onSubmit` payload; only the displayed label is translated via a `REASON_KEYS` map, so analytics and the `Other`-branch check are unchanged.
- `AccessBanner` date formatting now picks `de-DE`/`en-GB` from `i18n.language`; hour count uses i18next plural keys.
- `SubscriptionManagement.formatDate` takes the unknown-date label as an argument so the module-level helper stays pure.
- Did NOT touch `i18n/index.ts`, `common.json`, or already-translated surfaces (AccountPage top-level, auth login/register/forgot, CheckYourEmail, ConsentModal).

## Measuring success
No new metric. UI-language coverage change; German users on these screens now render localized copy. Regression-guarded by per-surface German render tests (assert German text renders in `de`).

## Testing
- Unit tests added: German render tests for AccessBanner, VerifyEmailNotice, CreateAccountNotice, LoggedInSuccess, PauseCard, CancellationFollowUp, PlanDetails, AccountDeletion, SubscriptionManagement.
- `pnpm --filter 2anki-web test` (affected): 65 passed.
- `pnpm --filter 2anki-web typecheck`: green. `oxlint` on changed files: clean. `oxfmt`: formatted.
- `pnpm --filter 2anki-web test:golden-path`: 2 passed.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: golden-path Playwright spec (375px, console-error-failing) green.

## Strings left English (deliberate / protected)
- Stripe/plan names and pass names kept verbatim both locales: `Premium`, `Unlimited`, `Lifetime`, `Day Pass`, `Week Pass`.
- `100 cards per month` (PlanDetails free-tier meta) kept verbatim in German — protected marketing string per VOICE.md; flagging rather than translating.
- Brand nouns kept: `2anki.net`, `Notion`, `Apple`, `Stripe`, `support@2anki.net`.

## Sonar
Sonar not run locally (no SONAR_TOKEN on this box); Automatic Analysis covers the push. Changes are copy-extraction + small pure-helper signature tweaks, low smell risk.

## Risks
Low. No behavior change in English (default `en` maps to the original strings; existing English tests pass unchanged). Cancellation payloads preserved. Rollback = revert the branch.

## Goal alignment
Acquisition/retention: removes an English-only wall on the billing, cancellation, and post-checkout surfaces for German learners. No direct MRR metric wired; supports the broader i18n coverage push toward the 300K-user goal.
