### PR TITLE
feat: translate error and empty states to German

### DIFF
--- a/web/src/components/ChunkReloadOverlay/ChunkReloadOverlay.i18n.test.tsx
+++ b/web/src/components/ChunkReloadOverlay/ChunkReloadOverlay.i18n.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import i18n from '../../lib/i18n';
+import { ChunkReloadOverlay } from './ChunkReloadOverlay';
+
+describe('ChunkReloadOverlay in German', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('renders the update message in German', () => {
+    render(<ChunkReloadOverlay />);
+    expect(
+      screen.getByText('Aktualisierung auf die neueste Version.')
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/components/ChunkReloadOverlay/ChunkReloadOverlay.tsx
+++ b/web/src/components/ChunkReloadOverlay/ChunkReloadOverlay.tsx
@@ -1,6 +1,8 @@
+import { useTranslation } from 'react-i18next';
 import styles from './ChunkReloadOverlay.module.css';
 
 export function ChunkReloadOverlay() {
+  const { t } = useTranslation('errors');
   return (
     <div
       className={styles.overlay}
@@ -13,7 +15,7 @@ export function ChunkReloadOverlay() {
         src="https://2anki.net/mascot/navbar-logo.png"
         alt=""
       />
-      <p className={styles.message}>Updating to the latest version.</p>
+      <p className={styles.message}>{t('chunkOverlay.updating')}</p>
     </div>
   );
 }

--- a/web/src/components/DomRecoveryBoundary/DomRecoveryBoundary.i18n.test.tsx
+++ b/web/src/components/DomRecoveryBoundary/DomRecoveryBoundary.i18n.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { ReactElement } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from '../../lib/i18n';
+import { DomRecoveryBoundary } from './DomRecoveryBoundary';
+
+function AlwaysThrows(): ReactElement {
+  throw new Error('boom');
+}
+
+describe('DomRecoveryBoundary in German', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    consoleError.mockRestore();
+    await i18n.changeLanguage('en');
+  });
+
+  it('shows the recovery fallback in German', () => {
+    render(
+      <DomRecoveryBoundary>
+        <AlwaysThrows />
+      </DomRecoveryBoundary>
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Etwas ist schiefgelaufen' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Neu laden' })
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/components/DomRecoveryBoundary/DomRecoveryBoundary.tsx
+++ b/web/src/components/DomRecoveryBoundary/DomRecoveryBoundary.tsx
@@ -1,7 +1,32 @@
 import React, { type ErrorInfo, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import styles from '../../styles/shared.module.css';
 import { isDomManipulationError } from '../../lib/isDomManipulationError';
+
+function DomRecoveryFallback({ onReload }: Readonly<{ onReload: () => void }>) {
+  const { t } = useTranslation('errors');
+  return (
+    <main className={styles.pageNarrow}>
+      <section className={styles.card} role="alert" aria-live="assertive">
+        <header className={styles.pageHeader}>
+          <h1 className={styles.title}>{t('domRecovery.title')}</h1>
+          <p className={styles.subtitle}>{t('domRecovery.subtitle')}</p>
+        </header>
+
+        <div className={styles.modalFooter}>
+          <button
+            type="button"
+            className={`${styles.btnPrimary} ${styles.btnInline}`}
+            onClick={onReload}
+          >
+            {t('domRecovery.reload')}
+          </button>
+        </div>
+      </section>
+    </main>
+  );
+}
 
 type DomRecoveryBoundaryProps = Readonly<{
   children: ReactNode;
@@ -56,29 +81,7 @@ export class DomRecoveryBoundary extends React.Component<
 
   render() {
     if (this.state.error) {
-      return (
-        <main className={styles.pageNarrow}>
-          <section className={styles.card} role="alert" aria-live="assertive">
-            <header className={styles.pageHeader}>
-              <h1 className={styles.title}>Something went wrong</h1>
-              <p className={styles.subtitle}>
-                A browser extension may be interfering with this page. Reload to
-                start over.
-              </p>
-            </header>
-
-            <div className={styles.modalFooter}>
-              <button
-                type="button"
-                className={`${styles.btnPrimary} ${styles.btnInline}`}
-                onClick={this.reloadPage}
-              >
-                Reload
-              </button>
-            </div>
-          </section>
-        </main>
-      );
+      return <DomRecoveryFallback onReload={this.reloadPage} />;
     }
 
     return (

--- a/web/src/components/RootErrorBoundary/RootErrorBoundary.i18n.test.tsx
+++ b/web/src/components/RootErrorBoundary/RootErrorBoundary.i18n.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { ReactElement } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from '../../lib/i18n';
+import { RootErrorBoundary } from './RootErrorBoundary';
+
+function BrokenApp(): ReactElement {
+  throw new Error('boom');
+}
+
+describe('RootErrorBoundary in German', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    consoleError.mockRestore();
+    await i18n.changeLanguage('en');
+  });
+
+  it('shows the generic recovery screen in German', () => {
+    render(
+      <RootErrorBoundary>
+        <BrokenApp />
+      </RootErrorBoundary>
+    );
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Beim Laden von 2anki ist etwas schiefgelaufen',
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Neu laden' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Lokale Daten zurücksetzen' })
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/components/RootErrorBoundary/RootErrorBoundary.tsx
+++ b/web/src/components/RootErrorBoundary/RootErrorBoundary.tsx
@@ -1,7 +1,64 @@
 import React, { type ErrorInfo, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import styles from '../../styles/shared.module.css';
 import { isChunkLoadError, recoverFromChunkError } from '../../lib/chunkReload';
+
+type RootErrorFallbackProps = Readonly<{
+  chunkLoad: boolean;
+  resetFailed: boolean;
+  onReload: () => void;
+  onResetLocalData: () => void;
+}>;
+
+function RootErrorFallback({
+  chunkLoad,
+  resetFailed,
+  onReload,
+  onResetLocalData,
+}: RootErrorFallbackProps) {
+  const { t } = useTranslation('errors');
+  const title = chunkLoad
+    ? t('rootBoundary.chunkTitle')
+    : t('rootBoundary.genericTitle');
+  const subtitle = chunkLoad
+    ? t('rootBoundary.chunkSubtitle')
+    : t('rootBoundary.genericSubtitle');
+
+  return (
+    <main className={styles.pageNarrow}>
+      <section className={styles.card} role="alert" aria-live="assertive">
+        <header className={styles.pageHeader}>
+          <h1 className={styles.title}>{title}</h1>
+          <p className={styles.subtitle}>{subtitle}</p>
+        </header>
+
+        {resetFailed && (
+          <p className={styles.notificationDanger}>
+            {t('rootBoundary.resetFailed')}
+          </p>
+        )}
+
+        <div className={styles.modalFooter}>
+          <button
+            type="button"
+            className={`${styles.btnPrimary} ${styles.btnInline}`}
+            onClick={onReload}
+          >
+            {t('rootBoundary.reload')}
+          </button>
+          <button
+            type="button"
+            className={styles.btnSecondary}
+            onClick={onResetLocalData}
+          >
+            {t('rootBoundary.resetLocalData')}
+          </button>
+        </div>
+      </section>
+    </main>
+  );
+}
 
 type RootErrorBoundaryProps = Readonly<{
   children: ReactNode;
@@ -68,86 +125,13 @@ export class RootErrorBoundary extends React.Component<
     }
 
     if (this.state.error) {
-      if (this.state.chunkLoad) {
-        return (
-          <main className={styles.pageNarrow}>
-            <section className={styles.card} role="alert" aria-live="assertive">
-              <header className={styles.pageHeader}>
-                <h1 className={styles.title}>
-                  This page was updated while you had it open
-                </h1>
-                <p className={styles.subtitle}>
-                  Reload to load the latest version. If reload doesn't help,
-                  reset local data and reload.
-                </p>
-              </header>
-
-              {this.state.resetFailed && (
-                <p className={styles.notificationDanger}>
-                  Couldn't reset local data. Clear site data for 2anki in your
-                  browser settings, then reload.
-                </p>
-              )}
-
-              <div className={styles.modalFooter}>
-                <button
-                  type="button"
-                  className={`${styles.btnPrimary} ${styles.btnInline}`}
-                  onClick={this.reloadPage}
-                >
-                  Reload
-                </button>
-                <button
-                  type="button"
-                  className={styles.btnSecondary}
-                  onClick={this.resetLocalData}
-                >
-                  Reset local data
-                </button>
-              </div>
-            </section>
-          </main>
-        );
-      }
-
       return (
-        <main className={styles.pageNarrow}>
-          <section className={styles.card} role="alert" aria-live="assertive">
-            <header className={styles.pageHeader}>
-              <h1 className={styles.title}>
-                Something went wrong loading 2anki
-              </h1>
-              <p className={styles.subtitle}>
-                Try reloading. If that doesn't help, reset local data and
-                reload.
-              </p>
-            </header>
-
-            {this.state.resetFailed && (
-              <p className={styles.notificationDanger}>
-                Couldn't reset local data. Clear site data for 2anki in your
-                browser settings, then reload.
-              </p>
-            )}
-
-            <div className={styles.modalFooter}>
-              <button
-                type="button"
-                className={`${styles.btnPrimary} ${styles.btnInline}`}
-                onClick={this.reloadPage}
-              >
-                Reload
-              </button>
-              <button
-                type="button"
-                className={styles.btnSecondary}
-                onClick={this.resetLocalData}
-              >
-                Reset local data
-              </button>
-            </div>
-          </section>
-        </main>
+        <RootErrorFallback
+          chunkLoad={this.state.chunkLoad}
+          resetFailed={this.state.resetFailed}
+          onReload={this.reloadPage}
+          onResetLocalData={this.resetLocalData}
+        />
       );
     }
 

--- a/web/src/components/Skeleton/Skeleton.tsx
+++ b/web/src/components/Skeleton/Skeleton.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import styles from './Skeleton.module.css';
 
 interface SkeletonProps {
@@ -63,8 +64,9 @@ export function SkeletonList({
   count = 5,
   rowProps,
 }: Readonly<SkeletonListProps>) {
+  const { t } = useTranslation('errors');
   return (
-    <output aria-label="Loading">
+    <output aria-label={t('skeleton.loading')}>
       {Array.from({ length: count }, (_, idx) => (
         <SkeletonRow key={idx} {...rowProps} />
       ))}

--- a/web/src/components/StepIndicator/StepIndicator.i18n.test.tsx
+++ b/web/src/components/StepIndicator/StepIndicator.i18n.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import i18n from '../../lib/i18n';
+import { StepIndicator } from './StepIndicator';
+
+describe('StepIndicator in German', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('renders the step labels and progress label in German', () => {
+    render(<StepIndicator currentStep={2} />);
+
+    expect(
+      screen.getByRole('list', { name: 'Konvertierungsfortschritt' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Hochgeladen')).toBeInTheDocument();
+    expect(screen.getByText('Wird gelesen')).toBeInTheDocument();
+    expect(screen.getByText('Wird erstellt')).toBeInTheDocument();
+    expect(screen.getByText('Wird verpackt')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/StepIndicator/StepIndicator.tsx
+++ b/web/src/components/StepIndicator/StepIndicator.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import styles from './StepIndicator.module.css';
 import { StepIndex } from './jobStepFromStatus';
 
@@ -7,7 +8,12 @@ interface Props {
   readonly compact?: boolean;
 }
 
-const STEP_LABELS = ['Uploaded', 'Parsing', 'Generating', 'Packaging'] as const;
+const STEP_LABEL_KEYS = [
+  'uploaded',
+  'parsing',
+  'generating',
+  'packaging',
+] as const;
 
 function getPillClass(step: StepIndex, currentStep: StepIndex): string {
   if (step < currentStep) return styles.pillDone;
@@ -20,10 +26,13 @@ export function StepIndicator({
   substep,
   compact = false,
 }: Props) {
+  const { t } = useTranslation('errors');
+  const stepLabels = STEP_LABEL_KEYS.map((key) => t(`stepIndicator.${key}`));
+
   if (compact) {
-    const label = STEP_LABELS[currentStep - 1];
+    const label = stepLabels[currentStep - 1];
     return (
-      <ol className={styles.indicator} aria-label="Conversion progress">
+      <ol className={styles.indicator} aria-label={t('stepIndicator.progress')}>
         <li
           className={`${styles.pill} ${styles.pillActive}`}
           aria-current="step"
@@ -31,15 +40,15 @@ export function StepIndicator({
           <span className={styles.dot} />
           {label}
           {substep && <span className={styles.substep}>({substep})</span>}
-          <span className={styles.compactRest}> / {STEP_LABELS.length}</span>
+          <span className={styles.compactRest}> / {stepLabels.length}</span>
         </li>
       </ol>
     );
   }
 
   return (
-    <ol className={styles.indicator} aria-label="Conversion progress">
-      {STEP_LABELS.map((label, index) => {
+    <ol className={styles.indicator} aria-label={t('stepIndicator.progress')}>
+      {stepLabels.map((label, index) => {
         const step = (index + 1) as StepIndex;
         const isActive = step === currentStep;
         return (

--- a/web/src/components/errors/ErrorPresenter.i18n.test.tsx
+++ b/web/src/components/errors/ErrorPresenter.i18n.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import i18n from '../../lib/i18n';
+import { ErrorPresenter } from './ErrorPresenter';
+
+describe('ErrorPresenter in German', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('renders the classified title and both buttons in German', () => {
+    render(
+      <MemoryRouter>
+        <ErrorPresenter error={new Error('unauthorized')} onRetry={vi.fn()} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Sitzung abgelaufen.')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Erneut versuchen' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Schließen' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Anmelden' })).toBeInTheDocument();
+  });
+});

--- a/web/src/components/errors/ErrorPresenter.tsx
+++ b/web/src/components/errors/ErrorPresenter.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { classifyError } from './helpers/getErrorMessage';
 import { useDismissed } from './helpers/useDismissed';
@@ -12,6 +13,7 @@ export function ErrorPresenter({
   error,
   onRetry,
 }: Readonly<ErrorPresenterProps>) {
+  const { t } = useTranslation('errors');
   const { dismissed, setDismissed } = useDismissed(error);
 
   if (!error || dismissed) {
@@ -47,7 +49,7 @@ export function ErrorPresenter({
               onRetry();
             }}
           >
-            Try again
+            {t('presenter.tryAgain')}
           </button>
         )}
         <button
@@ -55,7 +57,7 @@ export function ErrorPresenter({
           className={styles.btnSecondary}
           onClick={() => setDismissed(true)}
         >
-          Dismiss
+          {t('presenter.dismiss')}
         </button>
       </div>
     </article>

--- a/web/src/components/errors/helpers/getErrorMessage.i18n.test.ts
+++ b/web/src/components/errors/helpers/getErrorMessage.i18n.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import i18n from '../../../lib/i18n';
+import { classifyError, classifyUploadError } from './getErrorMessage';
+import type { UploadErrorBody } from '../../../types/UploadErrorBody';
+
+describe('classifyError in German', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('renders the network error copy in German', () => {
+    const result = classifyError(new TypeError('Failed to fetch'));
+    expect(result.title).toBe('2anki nicht erreichbar.');
+    expect(result.detail).toBe('Prüfe deine Verbindung und versuch es erneut.');
+  });
+
+  it('renders session-expiry copy in German while keeping the /login target', () => {
+    const result = classifyError(new Error('unauthorized'));
+    expect(result.title).toBe('Sitzung abgelaufen.');
+    expect(result.actionLink).toEqual({ text: 'Anmelden', to: '/login' });
+  });
+
+  it('renders the Notion reconnect copy in German while keeping the /notion target', () => {
+    const result = classifyError(new Error('API token is invalid.'));
+    expect(result.title).toBe('Deine Notion-Verbindung ist abgelaufen');
+    expect(result.actionLink).toEqual({
+      text: 'Notion neu verbinden',
+      to: '/notion',
+    });
+  });
+
+  it('keeps support@2anki.net verbatim in the German fallback detail', () => {
+    const result = classifyError(undefined);
+    expect(result.title).toBe('Etwas ist schiefgelaufen.');
+    expect(result.detail).toContain('support@2anki.net');
+  });
+
+  it('does not translate a raw server message', () => {
+    const result = classifyError(new Error('No active subscription.'));
+    expect(result.title).toBe('No active subscription.');
+  });
+});
+
+describe('classifyUploadError in German', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('renders unsupported_format copy in German with the format list verbatim', () => {
+    const body: UploadErrorBody = {
+      code: 'unsupported_format',
+      message: 'raw',
+    };
+    const result = classifyUploadError(body);
+    expect(result.title).toBe('Dieser Dateityp wird nicht unterstützt.');
+    expect(result.detail).toBe(
+      'Verwende .zip, .html, .md, .pdf, .docx, .xlsx, .pptx, .csv oder .xml.'
+    );
+  });
+
+  it('keeps support@2anki.net verbatim in the German corrupted_apkg detail', () => {
+    const body: UploadErrorBody = {
+      code: 'corrupted_apkg',
+      message: 'raw',
+    };
+    const result = classifyUploadError(body);
+    expect(result.title).toBe('Diese .apkg-Datei ist beschädigt.');
+    expect(result.detail).toContain('support@2anki.net');
+  });
+});

--- a/web/src/components/errors/helpers/getErrorMessage.ts
+++ b/web/src/components/errors/helpers/getErrorMessage.ts
@@ -1,3 +1,4 @@
+import i18n from '../../../lib/i18n';
 import { stripHtmlTags } from '../../../lib/text/stripHtmlTags';
 import type { UploadErrorBody } from '../../../types/UploadErrorBody';
 
@@ -9,16 +10,28 @@ interface FriendlyError {
   actionLink?: { text: string; to: string };
 }
 
-const FALLBACK: FriendlyError = {
-  title: 'Something went wrong.',
-  detail: 'Try again. If the problem keeps happening, email support@2anki.net.',
-};
+function tr(key: string, fallback: string): string {
+  return i18n.t(`errors:${key}`, { defaultValue: fallback });
+}
 
-const UPLOAD_FALLBACK: FriendlyError = {
-  title: 'Something broke while reading this file.',
-  detail:
-    'Try again, or send the file to support@2anki.net so we can fix the parser.',
-};
+const FALLBACK = (): FriendlyError => ({
+  title: tr('messages.fallback.title', 'Something went wrong.'),
+  detail: tr(
+    'messages.fallback.detail',
+    'Try again. If the problem keeps happening, email support@2anki.net.'
+  ),
+});
+
+const UPLOAD_FALLBACK = (): FriendlyError => ({
+  title: tr(
+    'messages.uploadFallback.title',
+    'Something broke while reading this file.'
+  ),
+  detail: tr(
+    'messages.uploadFallback.detail',
+    'Try again, or send the file to support@2anki.net so we can fix the parser.'
+  ),
+});
 
 function toText(error: unknown): string {
   if (typeof error === 'string') return error;
@@ -30,11 +43,20 @@ function toText(error: unknown): string {
   return '';
 }
 
-const NOTION_UNAUTHORIZED: FriendlyError = {
-  title: 'Your Notion connection expired',
-  detail: 'Sign in to Notion again to keep converting your pages.',
-  actionLink: { text: 'Reconnect Notion', to: '/notion' },
-};
+const NOTION_UNAUTHORIZED = (): FriendlyError => ({
+  title: tr(
+    'messages.notionUnauthorized.title',
+    'Your Notion connection expired'
+  ),
+  detail: tr(
+    'messages.notionUnauthorized.detail',
+    'Sign in to Notion again to keep converting your pages.'
+  ),
+  actionLink: {
+    text: tr('messages.notionUnauthorized.action', 'Reconnect Notion'),
+    to: '/notion',
+  },
+});
 
 function httpMeta(error: unknown): { status?: number; url?: string } {
   if (error != null && typeof error === 'object') {
@@ -56,11 +78,11 @@ function isNotionUnauthorized(error: unknown): boolean {
 }
 
 export function classifyError(error: unknown): FriendlyError {
-  if (isNotionUnauthorized(error)) return NOTION_UNAUTHORIZED;
+  if (isNotionUnauthorized(error)) return NOTION_UNAUTHORIZED();
 
   const raw = toText(error);
 
-  if (!raw) return FALLBACK;
+  if (!raw) return FALLBACK();
 
   const lower = raw.toLowerCase();
 
@@ -71,8 +93,11 @@ export function classifyError(error: unknown): FriendlyError {
     lower.includes('load failed')
   ) {
     return {
-      title: "Couldn't reach 2anki.",
-      detail: 'Check your connection and try again.',
+      title: tr('messages.network.title', "Couldn't reach 2anki."),
+      detail: tr(
+        'messages.network.detail',
+        'Check your connection and try again.'
+      ),
     };
   }
 
@@ -84,15 +109,21 @@ export function classifyError(error: unknown): FriendlyError {
     lower.includes('service_unavailable')
   ) {
     return {
-      title: 'The service is unreachable right now.',
-      detail: 'This is usually temporary — try again in a moment.',
+      title: tr(
+        'messages.serviceUnavailable.title',
+        'The service is unreachable right now.'
+      ),
+      detail: tr(
+        'messages.serviceUnavailable.detail',
+        'This is usually temporary — try again in a moment.'
+      ),
     };
   }
 
   if (lower.includes('rate_limited') || lower.includes('429')) {
     return {
-      title: 'Too many requests.',
-      detail: 'Try again in a minute.',
+      title: tr('messages.rateLimited.title', 'Too many requests.'),
+      detail: tr('messages.rateLimited.detail', 'Try again in a minute.'),
     };
   }
 
@@ -102,9 +133,15 @@ export function classifyError(error: unknown): FriendlyError {
     lower.includes('authentication required')
   ) {
     return {
-      title: 'Session expired.',
-      detail: 'Sign in again to continue.',
-      actionLink: { text: 'Sign in', to: '/login' },
+      title: tr('messages.sessionExpired.title', 'Session expired.'),
+      detail: tr(
+        'messages.sessionExpired.detail',
+        'Sign in again to continue.'
+      ),
+      actionLink: {
+        text: tr('messages.sessionExpired.action', 'Sign in'),
+        to: '/login',
+      },
     };
   }
 
@@ -115,26 +152,45 @@ export function classifyError(error: unknown): FriendlyError {
     url?.startsWith('/api/apkg/')
   ) {
     return {
-      title: 'This deck is no longer available.',
-      detail:
-        'Uploaded decks are removed after a while. Convert or upload it again to preview it.',
-      actionLink: { text: 'Back to downloads', to: '/downloads' },
+      title: tr('messages.apkgGone.title', 'This deck is no longer available.'),
+      detail: tr(
+        'messages.apkgGone.detail',
+        'Uploaded decks are removed after a while. Convert or upload it again to preview it.'
+      ),
+      actionLink: {
+        text: tr('messages.apkgGone.action', 'Back to downloads'),
+        to: '/downloads',
+      },
     };
   }
 
   if (lower.includes('object_not_found') || lower.includes('404')) {
     return {
-      title: "We couldn't open that Notion page.",
-      detail:
-        "It may have been deleted, or it's no longer shared with 2anki. Share it again in Notion, or pick a different page.",
-      actionLink: { text: 'Choose a page', to: '/notion' },
+      title: tr(
+        'messages.notionPageNotFound.title',
+        "We couldn't open that Notion page."
+      ),
+      detail: tr(
+        'messages.notionPageNotFound.detail',
+        "It may have been deleted, or it's no longer shared with 2anki. Share it again in Notion, or pick a different page."
+      ),
+      actionLink: {
+        text: tr('messages.notionPageNotFound.action', 'Choose a page'),
+        to: '/notion',
+      },
     };
   }
 
   if (lower.includes('upload_limit') || lower.includes('upload limit')) {
     return {
-      title: "You've reached your monthly limit.",
-      detail: 'Upgrade your plan to convert more decks this month.',
+      title: tr(
+        'messages.monthlyLimit.title',
+        "You've reached your monthly limit."
+      ),
+      detail: tr(
+        'messages.monthlyLimit.detail',
+        'Upgrade your plan to convert more decks this month.'
+      ),
     };
   }
 
@@ -143,7 +199,7 @@ export function classifyError(error: unknown): FriendlyError {
     return { title: stripped };
   }
 
-  return FALLBACK;
+  return FALLBACK();
 }
 
 export const getErrorMessage = (error: unknown): string => {
@@ -153,7 +209,9 @@ export const getErrorMessage = (error: unknown): string => {
     : friendly.title;
 };
 
-const PER_CODE_COPY: Partial<Record<UploadErrorBody['code'], FriendlyError>> = {
+const UPLOAD_CODE_DEFAULTS: Partial<
+  Record<UploadErrorBody['code'], FriendlyError>
+> = {
   unsupported_format: {
     title: "This file type isn't supported.",
     detail: 'Use .zip, .html, .md, .pdf, .docx, .xlsx, .pptx, .csv, or .xml.',
@@ -223,12 +281,25 @@ const PER_CODE_COPY: Partial<Record<UploadErrorBody['code'], FriendlyError>> = {
   },
 };
 
+function localizeUploadCode(
+  code: UploadErrorBody['code'],
+  defaults: FriendlyError
+): FriendlyError {
+  const localized: FriendlyError = {
+    title: tr(`upload.${code}.title`, defaults.title),
+  };
+  if (defaults.detail !== undefined) {
+    localized.detail = tr(`upload.${code}.detail`, defaults.detail);
+  }
+  return localized;
+}
+
 export function classifyUploadError(body: UploadErrorBody): FriendlyError {
-  const perCode = PER_CODE_COPY[body.code];
-  if (perCode) return perCode;
+  const defaults = UPLOAD_CODE_DEFAULTS[body.code];
+  if (defaults) return localizeUploadCode(body.code, defaults);
   const stripped = stripHtmlTags(body.message);
   if (stripped.length > 0 && stripped.length < 280) {
     return { title: stripped };
   }
-  return UPLOAD_FALLBACK;
+  return UPLOAD_FALLBACK();
 }

--- a/web/src/lib/i18n/locales/de/errors.json
+++ b/web/src/lib/i18n/locales/de/errors.json
@@ -1,0 +1,146 @@
+{
+  "messages": {
+    "notionUnauthorized": {
+      "title": "Deine Notion-Verbindung ist abgelaufen",
+      "detail": "Melde dich erneut bei Notion an, um weiter Seiten zu konvertieren.",
+      "action": "Notion neu verbinden"
+    },
+    "network": {
+      "title": "2anki nicht erreichbar.",
+      "detail": "Prüfe deine Verbindung und versuch es erneut."
+    },
+    "serviceUnavailable": {
+      "title": "Der Dienst ist gerade nicht erreichbar.",
+      "detail": "Das ist meist vorübergehend — versuch es gleich noch einmal."
+    },
+    "rateLimited": {
+      "title": "Zu viele Anfragen.",
+      "detail": "Versuch es in einer Minute erneut."
+    },
+    "sessionExpired": {
+      "title": "Sitzung abgelaufen.",
+      "detail": "Melde dich erneut an, um fortzufahren.",
+      "action": "Anmelden"
+    },
+    "apkgGone": {
+      "title": "Dieser Stapel ist nicht mehr verfügbar.",
+      "detail": "Hochgeladene Stapel werden nach einer Weile entfernt. Konvertiere oder lade ihn erneut hoch, um eine Vorschau zu sehen.",
+      "action": "Zurück zu den Stapeln"
+    },
+    "notionPageNotFound": {
+      "title": "Wir konnten diese Notion-Seite nicht öffnen.",
+      "detail": "Sie wurde vielleicht gelöscht oder ist nicht mehr mit 2anki geteilt. Teile sie erneut in Notion oder wähle eine andere Seite.",
+      "action": "Seite auswählen"
+    },
+    "monthlyLimit": {
+      "title": "Du hast dein monatliches Limit erreicht.",
+      "detail": "Führe ein Upgrade durch, um diesen Monat mehr Stapel zu konvertieren."
+    },
+    "fallback": {
+      "title": "Etwas ist schiefgelaufen.",
+      "detail": "Versuch es erneut. Wenn das Problem bestehen bleibt, schreib an support@2anki.net."
+    },
+    "uploadFallback": {
+      "title": "Beim Lesen dieser Datei ist etwas schiefgelaufen.",
+      "detail": "Versuch es erneut oder sende die Datei an support@2anki.net, damit wir den Parser reparieren können."
+    }
+  },
+  "upload": {
+    "unsupported_format": {
+      "title": "Dieser Dateityp wird nicht unterstützt.",
+      "detail": "Verwende .zip, .html, .md, .pdf, .docx, .xlsx, .pptx, .csv oder .xml."
+    },
+    "too_large": {
+      "title": "Dieser Export ist zu groß, um ihn auf einmal zu konvertieren.",
+      "detail": "Teile ihn in kleinere Notion-Unterseiten auf und konvertiere jede einzeln."
+    },
+    "password_protected_pdf": {
+      "title": "Dieses PDF ist passwortgeschützt.",
+      "detail": "Entferne das Passwort in deinem PDF-Reader, speichere eine Kopie und lade diese hoch."
+    },
+    "invalid_markup": {
+      "title": "Ein Teil dieser Datei hat eine Formatierung, die wir nicht lesen konnten.",
+      "detail": "Öffne die Quelle, entferne oder vereinfache den fehlerhaften Block und versuch es erneut."
+    },
+    "malformed_notion": {
+      "title": "Dieser Notion-Export konnte nicht verarbeitet werden.",
+      "detail": "Exportiere die Seite erneut aus Notion und versuch es noch einmal."
+    },
+    "corrupted_apkg": {
+      "title": "Diese .apkg-Datei ist beschädigt.",
+      "detail": "Exportiere sie erneut aus Anki oder sende sie an support@2anki.net."
+    },
+    "empty_export": {
+      "title": "Dieser Export enthält keine Inhalte, aus denen wir Karten machen können.",
+      "detail": "Prüfe, ob die Seite Text oder Toggle-Blöcke enthält, und exportiere dann erneut."
+    },
+    "markdown_likely_lossy": {
+      "title": "Notion-Markdown-Exporte flachen Toggles ab — exportiere diese Seite erneut als HTML, dann werden die Toggles zu Karteikarten."
+    },
+    "claude_parse_failed": {
+      "title": "Beim Erstellen deiner Karten ist etwas schiefgelaufen.",
+      "detail": "Versuch es erneut — wenn es weiter passiert, schreib an support@2anki.net."
+    },
+    "parser_crash": {
+      "title": "Diese Datei konnte nicht gelesen werden.",
+      "detail": "Sie ist möglicherweise fehlerhaft oder nutzt eine Struktur, die wir noch nicht erkennen. Exportiere sie erneut aus der Quell-App oder sende die Datei an support@2anki.net."
+    },
+    "worker_timeout": {
+      "title": "Diese Konvertierung hat länger gedauert als das Zeitlimit erlaubt.",
+      "detail": "Teile die Datei in kleinere Teile auf oder entferne sehr große eingebettete Bilder."
+    },
+    "notion_rate_limit": {
+      "title": "Notion drosselt uns gerade.",
+      "detail": "Warte eine Minute und konvertiere erneut."
+    },
+    "notion_object_not_found": {
+      "title": "Wir konnten diese Notion-Seite nicht öffnen.",
+      "detail": "Teile sie in Notion mit der 2anki-Integration und versuch es dann erneut."
+    },
+    "apkg_too_large_for_anki": {
+      "title": "Dieser Stapel überschreitet Ankis Upload-Limit.",
+      "detail": "Teile ihn auf, indem du weniger Seiten einbeziehst, oder lade ihn direkt in Anki Desktop hoch."
+    },
+    "zip_invalid": {
+      "title": "Diese ZIP konnte nicht gelesen werden.",
+      "detail": "Stelle sicher, dass es der Markdown-&-CSV-Export aus Notion ist, nicht der HTML-Export."
+    }
+  },
+  "presenter": {
+    "tryAgain": "Erneut versuchen",
+    "dismiss": "Schließen"
+  },
+  "rootBoundary": {
+    "chunkTitle": "Diese Seite wurde aktualisiert, während du sie offen hattest",
+    "chunkSubtitle": "Lade neu, um die aktuelle Version zu laden. Wenn Neuladen nicht hilft, setze lokale Daten zurück und lade neu.",
+    "resetFailed": "Lokale Daten konnten nicht zurückgesetzt werden. Lösche die Website-Daten für 2anki in den Browsereinstellungen und lade dann neu.",
+    "genericTitle": "Beim Laden von 2anki ist etwas schiefgelaufen",
+    "genericSubtitle": "Versuch es mit Neuladen. Wenn das nicht hilft, setze lokale Daten zurück und lade neu.",
+    "reload": "Neu laden",
+    "resetLocalData": "Lokale Daten zurücksetzen"
+  },
+  "domRecovery": {
+    "title": "Etwas ist schiefgelaufen",
+    "subtitle": "Eine Browser-Erweiterung stört möglicherweise diese Seite. Lade neu, um von vorn zu beginnen.",
+    "reload": "Neu laden"
+  },
+  "chunkOverlay": {
+    "updating": "Aktualisierung auf die neueste Version."
+  },
+  "notFound": {
+    "pageTitle": "Seite nicht gefunden — 2anki",
+    "title": "Seite nicht gefunden",
+    "description": "Diese Seite existiert nicht oder wurde verschoben.",
+    "cta": "Zur Startseite"
+  },
+  "stepIndicator": {
+    "progress": "Konvertierungsfortschritt",
+    "uploaded": "Hochgeladen",
+    "parsing": "Wird gelesen",
+    "generating": "Wird erstellt",
+    "packaging": "Wird verpackt"
+  },
+  "skeleton": {
+    "loading": "Wird geladen"
+  }
+}

--- a/web/src/lib/i18n/locales/en/errors.json
+++ b/web/src/lib/i18n/locales/en/errors.json
@@ -1,0 +1,146 @@
+{
+  "messages": {
+    "notionUnauthorized": {
+      "title": "Your Notion connection expired",
+      "detail": "Sign in to Notion again to keep converting your pages.",
+      "action": "Reconnect Notion"
+    },
+    "network": {
+      "title": "Couldn't reach 2anki.",
+      "detail": "Check your connection and try again."
+    },
+    "serviceUnavailable": {
+      "title": "The service is unreachable right now.",
+      "detail": "This is usually temporary — try again in a moment."
+    },
+    "rateLimited": {
+      "title": "Too many requests.",
+      "detail": "Try again in a minute."
+    },
+    "sessionExpired": {
+      "title": "Session expired.",
+      "detail": "Sign in again to continue.",
+      "action": "Sign in"
+    },
+    "apkgGone": {
+      "title": "This deck is no longer available.",
+      "detail": "Uploaded decks are removed after a while. Convert or upload it again to preview it.",
+      "action": "Back to downloads"
+    },
+    "notionPageNotFound": {
+      "title": "We couldn't open that Notion page.",
+      "detail": "It may have been deleted, or it's no longer shared with 2anki. Share it again in Notion, or pick a different page.",
+      "action": "Choose a page"
+    },
+    "monthlyLimit": {
+      "title": "You've reached your monthly limit.",
+      "detail": "Upgrade your plan to convert more decks this month."
+    },
+    "fallback": {
+      "title": "Something went wrong.",
+      "detail": "Try again. If the problem keeps happening, email support@2anki.net."
+    },
+    "uploadFallback": {
+      "title": "Something broke while reading this file.",
+      "detail": "Try again, or send the file to support@2anki.net so we can fix the parser."
+    }
+  },
+  "upload": {
+    "unsupported_format": {
+      "title": "This file type isn't supported.",
+      "detail": "Use .zip, .html, .md, .pdf, .docx, .xlsx, .pptx, .csv, or .xml."
+    },
+    "too_large": {
+      "title": "This export is too large to convert in one go.",
+      "detail": "Split it into smaller Notion subpages and convert each one separately."
+    },
+    "password_protected_pdf": {
+      "title": "This PDF is password-protected.",
+      "detail": "Remove the password in your PDF reader, save a copy, and upload that."
+    },
+    "invalid_markup": {
+      "title": "Part of this file has formatting we couldn't read.",
+      "detail": "Open the source, remove or simplify the block that broke, and try again."
+    },
+    "malformed_notion": {
+      "title": "This Notion export couldn't be parsed.",
+      "detail": "Re-export the page from Notion and try again."
+    },
+    "corrupted_apkg": {
+      "title": "This .apkg file is damaged.",
+      "detail": "Re-export it from Anki, or send it to support@2anki.net."
+    },
+    "empty_export": {
+      "title": "This export has no content we can turn into cards.",
+      "detail": "Check the page has text or toggle blocks, then export again."
+    },
+    "markdown_likely_lossy": {
+      "title": "Notion Markdown exports flatten toggles — re-export this page as HTML and the toggles become flashcards."
+    },
+    "claude_parse_failed": {
+      "title": "Something went wrong while making your cards.",
+      "detail": "Try again — if it keeps happening, email support@2anki.net."
+    },
+    "parser_crash": {
+      "title": "Couldn't read this file.",
+      "detail": "It may be malformed or use a structure we don't recognise yet. Try re-exporting from the source app, or send the file to support@2anki.net."
+    },
+    "worker_timeout": {
+      "title": "This conversion took longer than the time budget.",
+      "detail": "Try splitting the file into smaller pieces, or remove very large embedded images."
+    },
+    "notion_rate_limit": {
+      "title": "Notion is rate-limiting us right now.",
+      "detail": "Wait a minute and convert again."
+    },
+    "notion_object_not_found": {
+      "title": "We couldn't open that Notion page.",
+      "detail": "Share it with the 2anki integration in Notion, then try again."
+    },
+    "apkg_too_large_for_anki": {
+      "title": "This deck is over Anki's upload limit.",
+      "detail": "Split it by toggling fewer pages, or upload directly to Anki desktop."
+    },
+    "zip_invalid": {
+      "title": "Couldn't read this zip.",
+      "detail": "Make sure it's the Markdown & CSV export from Notion, not the HTML export."
+    }
+  },
+  "presenter": {
+    "tryAgain": "Try again",
+    "dismiss": "Dismiss"
+  },
+  "rootBoundary": {
+    "chunkTitle": "This page was updated while you had it open",
+    "chunkSubtitle": "Reload to load the latest version. If reload doesn't help, reset local data and reload.",
+    "resetFailed": "Couldn't reset local data. Clear site data for 2anki in your browser settings, then reload.",
+    "genericTitle": "Something went wrong loading 2anki",
+    "genericSubtitle": "Try reloading. If that doesn't help, reset local data and reload.",
+    "reload": "Reload",
+    "resetLocalData": "Reset local data"
+  },
+  "domRecovery": {
+    "title": "Something went wrong",
+    "subtitle": "A browser extension may be interfering with this page. Reload to start over.",
+    "reload": "Reload"
+  },
+  "chunkOverlay": {
+    "updating": "Updating to the latest version."
+  },
+  "notFound": {
+    "pageTitle": "Page not found — 2anki",
+    "title": "Page not found",
+    "description": "This page doesn't exist or may have moved.",
+    "cta": "Go to homepage"
+  },
+  "stepIndicator": {
+    "progress": "Conversion progress",
+    "uploaded": "Uploaded",
+    "parsing": "Parsing",
+    "generating": "Generating",
+    "packaging": "Packaging"
+  },
+  "skeleton": {
+    "loading": "Loading"
+  }
+}

--- a/web/src/pages/NotFoundPage.i18n.test.tsx
+++ b/web/src/pages/NotFoundPage.i18n.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { HelmetProvider } from 'react-helmet-async';
+import i18n from '../lib/i18n';
+import NotFoundPage from './NotFoundPage';
+
+describe('NotFoundPage in German', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('renders the heading, description, and CTA in German', () => {
+    render(
+      <HelmetProvider>
+        <NotFoundPage />
+      </HelmetProvider>
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Seite nicht gefunden' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Diese Seite existiert nicht oder wurde verschoben.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Zur Startseite' })
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/NotFoundPage.tsx
+++ b/web/src/pages/NotFoundPage.tsx
@@ -1,22 +1,22 @@
 import { Helmet } from 'react-helmet-async';
+import { useTranslation } from 'react-i18next';
 import styles from '../styles/shared.module.css';
 
 function NotFoundPage() {
+  const { t } = useTranslation('errors');
   return (
     <div className={`${styles.pageNarrow} ${styles.textCenter}`}>
       <Helmet>
-        <title>Page not found — 2anki</title>
+        <title>{t('notFound.pageTitle')}</title>
         <meta name="robots" content="noindex, nofollow" />
       </Helmet>
       <div className={styles.emptyState}>
         <img src="/mascot/Notion 1.png" alt="" className={styles.mascot404} />
-        <h1 className={styles.title}>Page not found</h1>
-        <p className={styles.secondaryText}>
-          This page doesn't exist or may have moved.
-        </p>
+        <h1 className={styles.title}>{t('notFound.title')}</h1>
+        <p className={styles.secondaryText}>{t('notFound.description')}</p>
         <p>
           <a href="/" className={`${styles.btnPrimary} ${styles.btnInline}`}>
-            Go to homepage
+            {t('notFound.cta')}
           </a>
         </p>
       </div>

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-16-german-errors.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-16-german-errors.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-16-german-errors",
+  "date": "2026-07-16",
+  "type": "feature",
+  "title": "Error and empty-state messages now appear in German"
+}


### PR DESCRIPTION
## What
Adds a German translation for the error, recovery, and empty-state surfaces via a new `errors` i18n namespace (`web/src/lib/i18n/locales/{en,de}/errors.json`, auto-loaded by the existing glob). Covers the classified error/upload-error copy, the root and DOM recovery boundaries, the chunk-reload overlay, the 404 page, the conversion step indicator, and the loading skeleton.

## Why
German users saw these surfaces only in English. This continues the ongoing app-wide localization (react-i18next), so a German user hitting a network error, expired session, unsupported upload, 404, or a conversion in progress gets copy in their language.

## How
- New `errors` namespace with matching keys in both locales.
- `getErrorMessage.ts` resolves the rendered `title`/`detail`/`actionLink.text` through the `i18n` singleton (same pattern as `getDistance.ts`) with the English string as `defaultValue`. Signatures are unchanged, so out-of-scope callers (`App.tsx`, `UploadForm`, `ConversionResult`) keep working with zero edits and simply pick up the active language. **The raw backend match keys/conditions (`'api token is invalid'`, `'failed to fetch'`, `'econnreset'`, `404`, upload codes) are untouched** — only rendered copy is translated. `support@2anki.net` stays verbatim in both locales.
- The two class-component boundaries render an extracted functional fallback that uses `useTranslation('errors')` (hooks can't live in the class).
- `ErrorPresenter`, `ChunkReloadOverlay`, `NotFoundPage`, `StepIndicator`, and `SkeletonList` use `useTranslation('errors')`.

## Strings left in English (flagged)
- **LimitPage** (`web/src/pages/LimitPage/**`) — business-controlled paywall copy interwoven with the protected "100 cards"/monthly-limit strings and pricing. Left entirely in English per the VOICE.md protected-strings rule; localizing it needs explicit business approval.
- **EmptyState** — no hardcoded copy; all strings arrive via props from (out-of-scope) callers, so nothing to translate here.
- **TopMessage** — already migrated to `useTranslation` on a prior PR (keys live in `common.json`); skipped.
- Raw server/passthrough error messages (the `stripHtmlTags` fallback branch) are intentionally not translated — they're arbitrary backend text.

## Measuring success
No dedicated metric — this is a localization fill-in on existing surfaces. Signal is the absence of English error/empty-state strings for `de` users; verifiable by switching the language picker to Deutsch and triggering an error state.

## Testing
- Unit tests added: German render/behaviour tests for `getErrorMessage` (both `classifyError` and `classifyUploadError`, asserting German copy, that match logic still routes to the right branch, that `/login` and `/notion` targets are unchanged, that a raw server message is NOT translated, and that `support@2anki.net` stays verbatim), plus per-surface German render tests for `ErrorPresenter`, `RootErrorBoundary`, `DomRecoveryBoundary`, `ChunkReloadOverlay`, `StepIndicator`, and `NotFoundPage`.
- Full web suite green (2300 tests), `pnpm typecheck` clean, `pnpm lint` clean (only pre-existing warnings in unrelated files), `oxfmt` applied.
- Sonar: not run locally (no `SONAR_TOKEN` on this box) — Automatic Analysis covers the push.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: `pnpm --filter 2anki-web test:golden-path` green (2 passed, 375px viewport, no console errors).

## Changelog
`Error and empty-state messages now appear in German` (`2026-07-16-german-errors.json`).

## Risks
Low. Classification logic and signatures are unchanged; English is the `defaultValue` for every key, so a missing translation degrades gracefully to English. No new deps.

## Goal alignment
Localization lowers first-conversion friction and error-state confusion for the German-speaking segment — an acquisition/activation lever on the signup→first-conversion path. No direct revenue metric; supports the broader i18n rollout.
