### PR TITLE
feat: translate landing page visible copy to German

### DIFF
--- a/web/src/lib/i18n/locales/de/landing.json
+++ b/web/src/lib/i18n/locales/de/landing.json
@@ -1,0 +1,224 @@
+{
+  "steps": {
+    "dropFile": {
+      "title": "Leg deine Datei ab",
+      "body": "Notion-Export, PDF, Word, Markdown oder ein Quizlet-Export."
+    },
+    "buildsDeck": {
+      "title": "2anki erstellt deinen Stapel",
+      "body": "Meist ein paar Sekunden. Größere Dateien dauern eine Minute."
+    },
+    "openInAnki": {
+      "title": "Öffne ihn in Anki",
+      "body": "Doppelklicke die .apkg-Datei. Deine Karten sind bereit zum Lernen."
+    }
+  },
+  "sections": {
+    "howItWorks": "So funktioniert's",
+    "supportedFormats": "Unterstützte Formate",
+    "whatYouGet": "Was du wirklich in Anki bekommst",
+    "commonQuestions": "Häufige Fragen",
+    "related": "Verwandte Seiten"
+  },
+  "hero": {
+    "freeQuota": "Kostenlos · bis zu 1 000 Karten pro Import",
+    "orPrefix": "oder ",
+    "signUpFree": "kostenlos registrieren",
+    "tryUnlimited": "Unlimited 1 Stunde kostenlos testen"
+  },
+  "footer": {
+    "readyPrefix": "Bereit zum Ausprobieren? ",
+    "dropLink": "Leg oben auf dieser Seite eine Datei ab."
+  },
+  "hub": {
+    "h1": "Alles in Anki umwandeln",
+    "subhead": "Wähle deine Quelle. Jeder Konverter macht aus deinen Notizen, Dateien oder Karteikarten einen sauberen .apkg-Stapel, den du in Anki lernst.",
+    "groups": {
+      "note-apps": "Notiz-Apps",
+      "flashcard-apps": "Karteikarten-Apps",
+      "files": "Dateien",
+      "language-tools": "Sprach-Tools"
+    }
+  },
+  "answers": {
+    "faqHeading": "Häufig gestellte Fragen",
+    "convert-notion-to-anki": {
+      "h1": "So wandelst du Notion in Anki-Karteikarten um",
+      "intro": "Notion speichert deine Notizen. Anki macht daraus ein Wiederholungssystem. 2anki schließt die Lücke — aus jeder Notion-Seite erhältst du in unter einer Minute einen .apkg-Stapel."
+    },
+    "notion-to-anki-sync": {
+      "h1": "Automatische Synchronisierung von Notion zu Anki",
+      "intro": "Auto Sync überwacht deine verbundenen Notion-Seiten und überträgt Änderungen alle 5 Minuten in deine Anki-Stapel. Bearbeite einen Toggle in Notion; die Karte aktualisiert sich in Anki vor deiner nächsten Lernsitzung."
+    },
+    "pdf-to-anki": {
+      "h1": "So wandelst du ein PDF in Anki-Karteikarten um",
+      "intro": "Lade ein PDF zu 2anki hoch und lade einen .apkg-Stapel herunter. Funktioniert mit Vorlesungsfolien, Lehrbuchkapiteln und jedem PDF mit Textebene."
+    },
+    "quizlet-to-anki": {
+      "h1": "So wechselst du von Quizlet zu Anki",
+      "intro": "Quizlet speichert deine Sets. Anki gibt dir einen echten Algorithmus fürs verteilte Lernen. 2anki wandelt einen Quizlet-Export in einen .apkg-Stapel um, den du direkt in Anki öffnest."
+    },
+    "fsrs-explained": {
+      "h1": "FSRS in Anki — was es ist und warum deine nächste Wiederholung falsch wirkt",
+      "intro": "FSRS ist der moderne Algorithmus fürs verteilte Lernen, den Anki seit Version 23.10 (November 2023) mitbringt. Er ist weiterhin optional — SM-2 bleibt die Voreinstellung —, wird aber in der Community breit empfohlen, und das Anki-Handbuch stellt ihn als genauer als SM-2 dar. FSRS sagt vorher, wie lange du dir eine Karte merkst, und plant die nächste Wiederholung an dem Punkt, an dem deine Erinnerungswahrscheinlichkeit auf 90 % fällt. Bei einer Karte, die du leicht beantwortest, kann dieser Punkt ein Jahr oder mehr entfernt sein — daher stammt die Frage „Warum ist meine nächste Wiederholung in 17 Monaten?“, die r/Anki jede Woche füllt."
+    },
+    "lecture-notes-to-anki": {
+      "h1": "So machst du aus Vorlesungsnotizen Anki-Karteikarten",
+      "intro": "Deine Vorlesungsnotizen liegen schon irgendwo — Folien-PDFs, ein Word- oder Google-Dokument, eine Notion-Seite oder ein Foto aus der Vorlesung. 2anki liest jede davon und gibt dir einen .apkg-Stapel, den du in Anki öffnest. Wähle die Quelle, die zu deinen Notizen passt, und lerne noch am selben Tag."
+    },
+    "word-to-anki": {
+      "h1": "So wandelst du ein Word-Dokument in Anki um",
+      "intro": "Wenn deine Notizen in einem Word-Dokument liegen, musst du sie nicht von Hand als Karten nachbauen. Lade die .docx-Datei zu 2anki hoch und lade einen .apkg-Stapel herunter, der in Anki öffnet. Überschriften, Bilder und Formatierung kommen mit."
+    },
+    "image-occlusion-anki": {
+      "h1": "So erstellst du Bildverdeckungskarten in Anki",
+      "intro": "Bildverdeckungskarten verbergen einen Teil eines Diagramms und fragen ab, was darunter liegt — der schnellste Weg, Anatomie, Strukturen, Karten und beschriftete Abbildungen zu lernen. Lade ein Bild zu 2anki hoch, verdecke die Teile, die du abfragen willst, und lade einen Anki-Stapel herunter."
+    },
+    "google-docs-to-anki": {
+      "h1": "So wandelst du Google Docs in Anki-Karteikarten um",
+      "intro": "Google Docs verbindet sich nicht direkt mit 2anki, aber du musst nichts abtippen. Lade dein Dokument als Word (.docx) oder Markdown herunter, lade die Datei hoch und lade einen .apkg-Stapel herunter, der in Anki öffnet. Überschriften, Bilder und Formatierung kommen mit."
+    },
+    "handwritten-notes-to-anki": {
+      "h1": "So machst du aus handschriftlichen Notizen Anki-Karteikarten",
+      "intro": "Handschriftliche Notizen sind schwer zu wiederholen und unmöglich zu durchsuchen. Fotografiere eine Seite, lade sie zu 2anki hoch, und das Werkzeug Foto zu Stapel liest sie mit KI und entwirft Karten, die du vor dem Download prüfst. Du erhältst einen .apkg-Stapel, der in Anki öffnet."
+    },
+    "textbook-to-anki": {
+      "h1": "So machst du aus einem Lehrbuchkapitel Anki-Karteikarten",
+      "intro": "Ein Lehrbuchkapitel ist viel Material, um es von Hand zu Karten zu machen. Lade das Kapitel als PDF hoch, und 2anki liest seinen Text in Frage-Antwort-Karten, behält die Abbildungen und gibt dir einen .apkg-Stapel. Wandle ein Kapitel nach dem anderen um, damit jeder Stapel wiederholbar bleibt."
+    },
+    "kindle-highlights-to-anki": {
+      "h1": "So wandelst du Kindle-Markierungen in Anki-Karteikarten um",
+      "intro": "Jede Markierung, die du auf einem Kindle machst, wird in einer einzigen Datei namens My Clippings.txt gespeichert. 2anki liest diese Datei und macht aus jeder Passage eine Karte, sodass die Zeilen, die du beim Lesen markiert hast, zu einem Stapel werden, den du in Anki wiederholst. Du erhältst eine .apkg, die du per Doppelklick öffnest."
+    },
+    "language-app-to-anki": {
+      "h1": "So überträgst du deine Karteikarten von einer Sprach-App zu Anki",
+      "intro": "Sprach-Apps sind gut darin, Vokabeln zu erfassen, aber schwach bei der langfristigen Wiederholung. Anki gibt dir einen echten Algorithmus fürs verteilte Lernen. Egal, mit welcher App du angefangen hast, der Weg ist derselbe: Exportiere eine Datei, lade sie zu 2anki hoch und lade einen .apkg-Stapel herunter, den du auf jedem Gerät lernst. So passt jede gängige App in diesen Weg."
+    },
+    "obsidian-to-anki": {
+      "h1": "So wandelst du Obsidian-Notizen in Anki-Karteikarten um",
+      "intro": "Obsidian-Notizen sind einfache Markdown-Dateien, das heißt, sie lassen sich ohne Plugin in Anki umwandeln. Lade eine .md-Datei zu 2anki hoch und lade einen .apkg-Stapel herunter, der in Anki öffnet. Aufzählungen, Frage-Antwort-Paare, Überschriften und Codeblöcke kommen alle mit."
+    }
+  },
+  "pages": {
+    "ai-flashcard-generator": {
+      "h1": "Verwandle deine Notizen in Anki-Karten",
+      "subhead": "Echte Notizen rein, echte Karten raus. 2anki baut deinen Stapel aus dem, was du hochlädst — Fakten werden nie erfunden."
+    },
+    "anki-to-notion": {
+      "h1": "Importiere Anki-Stapel mit einem Klick in Notion.",
+      "subhead": "Lade eine .apkg-Datei hoch. Jede Karte wird zu einem Toggle auf einer Notion-Seite, die du lernen, durchsuchen und bearbeiten kannst."
+    },
+    "goodnotes-to-anki": {
+      "h1": "Verwandle GoodNotes in Anki-Karteikarten",
+      "subhead": "Exportiere dein Notizbuch als PDF, leg es hier ab und lade einen Anki-Stapel herunter."
+    },
+    "anki-for-japanese": {
+      "h1": "Notion zu Anki fürs Japanische und Sprachenlernen",
+      "subhead": "Leg eine Notion-Seite mit gesammelten Sätzen oder Vokabeln ab. Screenshots, Audio und Lesungen kommen so mit, wie du sie geschrieben hast."
+    },
+    "markdown-to-anki": {
+      "h1": "Verwandle Markdown-Notizen in Anki-Karten",
+      "subhead": "Leg eine .md-Datei ab und lade einen Stapel herunter — Aufzählungen und Frage-Antwort-Paare kommen mit."
+    },
+    "mcat-anki": {
+      "h1": "Verwandle deine MCAT-Inhaltswiederholung in Anki-Karten, die du steuerst",
+      "subhead": "Leg ein PDF oder einen Notion-Export deiner Wiederholungsnotizen ab — Aminosäuren, Orgo-Reaktionen, Psych- und Soc-Begriffe. 2anki baut saubere Karten aus deinem Material, nicht aus Vermutungen."
+    },
+    "anki-from-medical-lecture-slides": {
+      "h1": "Verwandle Vorlesungsfolien in Anki-Karten",
+      "subhead": "Lade ein PDF deiner Folien hoch — Überschriften werden zu Stapelnamen, Aufzählungen zu Karten."
+    },
+    "nclex-anki": {
+      "h1": "Verwandle deine NCLEX-Wiederholungsnotizen in Anki-Karten, die du steuerst",
+      "subhead": "Leg ein PDF oder einen Notion-Export deiner Saunders-, UWorld- oder ATI-Notizen ab — Laborwerte, Medikamenten-Endungen, Priorisierung und Delegation. 2anki baut saubere Karten aus deinem Material, nicht aus Vermutungen."
+    },
+    "notion-to-anki": {
+      "h1": "Notion zu Anki — kostenlos, kein Add-on nötig",
+      "subhead": "Verbinde Notion einmal, füge einen beliebigen Seitenlink ein und erhalte einen .apkg-Stapel. Keine Software zu installieren."
+    },
+    "nursing-flashcards": {
+      "h1": "Anki-Karteikarten aus Pflege-Vorlesungsfolien und -Notizen",
+      "subhead": "Leg ein PDF oder einen Notion-Export ab. 2anki zieht die Begriffe, Medikamente und Verfahren heraus."
+    },
+    "pdf-to-anki": {
+      "h1": "Erstelle Anki-Karteikarten aus einem PDF",
+      "subhead": "Leg ein PDF ab und wir ziehen den Text heraus, aus dem du Karten machen kannst."
+    },
+    "powerpoint-to-anki": {
+      "h1": "Erstelle Anki-Karteikarten aus einer PowerPoint",
+      "subhead": "Leg eine .pptx-Datei ab und 2anki liest den Text auf deinen Folien und baut einen Anki-Stapel, den du bearbeiten kannst."
+    },
+    "quizlet-to-anki": {
+      "h1": "Übertrage dein Quizlet-Set zu Anki",
+      "subhead": "Exportiere aus Quizlet, leg die Datei hier ab und lade einen Anki-Stapel herunter."
+    },
+    "step1-anki": {
+      "h1": "Verwandle deine First-Aid-Anmerkungen und Vorlesungsnotizen in Step-1-Karten, die du steuerst",
+      "subhead": "Anki ist das Rückgrat der Step-1-Vorbereitung. Lade deine annotierten First-Aid-Seiten, Pathoma-Übersichten oder Vorlesungs-PDFs hoch und erhalte saubere, ertragreiche Karten — aus deinem Material gebaut, nie erfunden."
+    },
+    "usmle-anki": {
+      "h1": "USMLE-Step-1- und Step-2-Stapel aus deinen eigenen Notizen",
+      "subhead": "Lade Vorlesungsfolien, First-Aid-Exporte oder ein beliebiges PDF hoch. Ertragreiche Karten, bereit für verteiltes Lernen."
+    },
+    "convert-notion-to-anki": {
+      "h1": "Notion zu Anki — mach aus deinen Notizen Karteikarten",
+      "subhead": "Verbinde Notion einmal, füge einen beliebigen Seitenlink ein und erhalte einen .apkg-Stapel. Toggles werden zu Karten. Kein Add-on, kein Kopieren und Einfügen."
+    },
+    "convert-pdf-to-anki": {
+      "h1": "PDF zu Anki — Karteikarten aus Vorlesungsfolien und Lehrbuchkapiteln",
+      "subhead": "Leg ein Vorlesungs-PDF, einen Folienexport oder ein Lehrbuchkapitel ab und lade einen .apkg-Stapel herunter. 2anki liest den Text in Frage-Antwort-Karten, weicht auf Bildkarten aus, wenn eine Seite keinen Text hat, und kann Karten mit KI schreiben, wenn das PDF dicht ist."
+    },
+    "convert-markdown-to-anki": {
+      "h1": "Markdown zu Anki — .md-Dateien und Obsidian-Notizen umwandeln",
+      "subhead": "Leg eine .md-Datei ab und lade einen Stapel herunter — Aufzählungen, Frage-Antwort-Paare und Codeblöcke kommen alle mit."
+    },
+    "convert-csv-to-anki": {
+      "h1": "CSV zu Anki — Tabellen als Karteikartenstapel importieren",
+      "subhead": "Leg eine .csv-Datei ab und erhalte einen .apkg-Stapel. Spalte A wird zur Vorderseite, alles nach A bildet die Rückseite. Funktioniert auch mit Excel-Exporten."
+    },
+    "convert-html-to-anki": {
+      "h1": "HTML zu Anki — aus Webseiten Karteikartenstapel machen",
+      "subhead": "Leg eine .html-Datei ab und lade einen .apkg-Stapel herunter. Überschriften, Aufzählungen und Tabellen kommen alle mit."
+    },
+    "convert-apkg-to-csv": {
+      "h1": "Anki-Stapel zu CSV — Karten in eine Tabelle exportieren",
+      "subhead": "Leg eine .apkg-Datei ab und lade eine CSV herunter. Jede Kartenvorderseite, -rückseite und jedes Tag in einer Tabelle, die du bearbeiten kannst."
+    },
+    "convert-notion-tables-to-anki": {
+      "h1": "Notion-Tabellen zu Anki — eine Zeile, eine Karte",
+      "subhead": "Füge eine Notion-Seite mit einer Tabelle ein. Spalte 1 wird zur Vorderseite, Spalte 2 zur Rückseite."
+    },
+    "convert-brainscape-to-anki": {
+      "h1": "Übertrage deine Brainscape-Karteikarten zu Anki",
+      "subhead": "Exportiere deinen Brainscape-Stapel als CSV, leg ihn hier ab und erhalte einen .apkg-Stapel, der sauber in Anki öffnet."
+    },
+    "convert-lingvist-to-anki": {
+      "h1": "Übertrage deine Lingvist-Karteikarten zu Anki",
+      "subhead": "Exportiere deine Lingvist-Vokabeln als CSV, leg sie hier ab und erhalte einen .apkg-Stapel. Deine Wörter und Übersetzungen kommen als Basic-Karten mit."
+    },
+    "convert-studystack-to-anki": {
+      "h1": "Übertrage deine StudyStack-Karteikarten zu Anki",
+      "subhead": "Exportiere deinen StudyStack als CSV, leg ihn hier ab und erhalte einen .apkg-Stapel. Begriffe und Definitionen werden zu Basic-Karten, bereit zum Wiederholen in Anki."
+    },
+    "convert-pleco-to-anki": {
+      "h1": "Übertrage deine Pleco-Karteikarten zu Anki",
+      "subhead": "Exportiere dein Pleco-userdict als .txt-Datei, leg sie hier ab und erhalte einen .apkg-Stapel. Hanzi, Pinyin und Definitionen kommen als Basic-Karten mit."
+    },
+    "convert-zorbi-to-anki": {
+      "h1": "Übertrage deine Zorbi-Karteikarten zu Anki",
+      "subhead": "Exportiere deinen Zorbi-Stapel als CSV, leg ihn hier ab und erhalte einen .apkg-Stapel. Fragen und Antworten werden zu Basic-Anki-Karten."
+    },
+    "convert-language-reactor-to-anki": {
+      "h1": "Übertrage deine Language-Reactor-Speicherungen zu Anki",
+      "subhead": "Leg die Export-ZIP von Language Reactor ab — deine gespeicherten Sätze, Bilder und Audios kommen als sauberer .apkg-Stapel mit, den du auf jedem Gerät lernen kannst."
+    },
+    "convert-epub-to-anki": {
+      "h1": "EPUB-Markierungen zu Anki — von E-Book-Markierungen zu Karten",
+      "subhead": "Leg eine DRM-freie .epub-Datei ab und lade eine .apkg herunter. Jede markierte Passage wird zu einer Karte, mit Buchtitel und Autor auf der Rückseite."
+    },
+    "convert-kindle-to-anki": {
+      "h1": "Kindle-Markierungen zu Anki — von My Clippings.txt zum Stapel",
+      "subhead": "Kopiere My Clippings.txt von deinem Kindle, leg sie hier ab und lade eine .apkg herunter. Jede markierte Passage — und jede von dir getippte Notiz — wird zu einer Karte."
+    }
+  }
+}

--- a/web/src/lib/i18n/locales/en/landing.json
+++ b/web/src/lib/i18n/locales/en/landing.json
@@ -1,0 +1,224 @@
+{
+  "steps": {
+    "dropFile": {
+      "title": "Drop your file",
+      "body": "Notion export, PDF, Word, Markdown, or a Quizlet export."
+    },
+    "buildsDeck": {
+      "title": "2anki builds your deck",
+      "body": "Usually a few seconds. Bigger files take a minute."
+    },
+    "openInAnki": {
+      "title": "Open it in Anki",
+      "body": "Double-click the .apkg file. Your cards are ready to study."
+    }
+  },
+  "sections": {
+    "howItWorks": "How it works",
+    "supportedFormats": "Supported formats",
+    "whatYouGet": "What you actually get in Anki",
+    "commonQuestions": "Common questions",
+    "related": "Related"
+  },
+  "hero": {
+    "freeQuota": "Free · up to 1 000 cards per import",
+    "orPrefix": "or ",
+    "signUpFree": "sign up free",
+    "tryUnlimited": "try Unlimited free for 1 hour"
+  },
+  "footer": {
+    "readyPrefix": "Ready to try it? ",
+    "dropLink": "Drop a file at the top of this page."
+  },
+  "hub": {
+    "h1": "Convert anything to Anki",
+    "subhead": "Pick your source. Every converter turns your notes, files, or flashcards into a clean .apkg deck you study in Anki.",
+    "groups": {
+      "note-apps": "Note apps",
+      "flashcard-apps": "Flashcard apps",
+      "files": "Files",
+      "language-tools": "Language tools"
+    }
+  },
+  "answers": {
+    "faqHeading": "Frequently asked questions",
+    "convert-notion-to-anki": {
+      "h1": "How to convert Notion to Anki flashcards",
+      "intro": "Notion stores your notes. Anki turns them into a review system. 2anki bridges the gap — you get a .apkg deck from any Notion page in under a minute."
+    },
+    "notion-to-anki-sync": {
+      "h1": "Notion to Anki automatic sync",
+      "intro": "Auto Sync watches your connected Notion pages and pushes changes to your Anki decks every 5 minutes. Edit a toggle in Notion; the card updates in Anki before your next review session."
+    },
+    "pdf-to-anki": {
+      "h1": "How to convert a PDF to Anki flashcards",
+      "intro": "Upload a PDF to 2anki and download a .apkg deck. Works with lecture slides, textbook chapters, and any PDF with a text layer."
+    },
+    "quizlet-to-anki": {
+      "h1": "How to move from Quizlet to Anki",
+      "intro": "Quizlet stores your sets. Anki gives you a proper spaced repetition algorithm. 2anki converts a Quizlet export into a .apkg deck you can open in Anki directly."
+    },
+    "fsrs-explained": {
+      "h1": "FSRS in Anki — what it is and why your next review looks wrong",
+      "intro": "FSRS is the modern spaced repetition algorithm Anki has shipped since version 23.10 (November 2023). It is still opt-in — SM-2 remains the default — but it is widely recommended in the community and the Anki manual presents it as more accurate than SM-2. FSRS predicts how long you will remember a card and schedules the next review at the point your recall probability drops to 90%. For a card you answer easily, that point can be a year or more away — which is the source of the \"why is my next review in 17 months\" question that fills r/Anki every week."
+    },
+    "lecture-notes-to-anki": {
+      "h1": "How to turn lecture notes into Anki flashcards",
+      "intro": "Your lecture notes are already somewhere — slide PDFs, a Word or Google doc, a Notion page, or a photo you took in class. 2anki reads each of those and gives you a .apkg deck you open in Anki. Pick the source that matches your notes and start reviewing the same day."
+    },
+    "word-to-anki": {
+      "h1": "How to convert a Word document to Anki",
+      "intro": "If your notes live in a Word document, you don't need to rebuild them as cards by hand. Upload the .docx file to 2anki and download a .apkg deck that opens in Anki. Headings, images, and formatting come across."
+    },
+    "image-occlusion-anki": {
+      "h1": "How to make image occlusion cards in Anki",
+      "intro": "Image occlusion cards hide part of a diagram and ask you to recall what's underneath — the fastest way to memorize anatomy, structures, maps, and labeled figures. Upload an image to 2anki, mask the parts you want to test, and download an Anki deck."
+    },
+    "google-docs-to-anki": {
+      "h1": "How to convert Google Docs to Anki flashcards",
+      "intro": "Google Docs doesn't connect to 2anki directly, but you don't have to retype anything. Download your doc as Word (.docx) or Markdown, upload the file, and download a .apkg deck that opens in Anki. Headings, images, and formatting come across."
+    },
+    "handwritten-notes-to-anki": {
+      "h1": "How to turn handwritten notes into Anki flashcards",
+      "intro": "Handwritten notes are hard to review and impossible to search. Photograph a page, upload it to 2anki, and the photo-to-deck tool reads it with AI and drafts cards you review before download. You get a .apkg deck that opens in Anki."
+    },
+    "textbook-to-anki": {
+      "h1": "How to turn a textbook chapter into Anki flashcards",
+      "intro": "A textbook chapter is a lot of material to card by hand. Upload the chapter as a PDF and 2anki reads its text into question-and-answer cards, keeps the figures, and gives you a .apkg deck. Convert one chapter at a time so each deck stays reviewable."
+    },
+    "kindle-highlights-to-anki": {
+      "h1": "How to convert Kindle highlights to Anki flashcards",
+      "intro": "Every highlight you make on a Kindle is saved to a single file called My Clippings.txt. 2anki reads that file and turns each passage into a card, so the lines you marked while reading become a deck you review in Anki. You get a .apkg you open with a double-click."
+    },
+    "language-app-to-anki": {
+      "h1": "How to move your flashcards from a language app to Anki",
+      "intro": "Language apps are good at capturing vocabulary but weak at long-term review. Anki gives you a proper spaced repetition algorithm. Whichever app you started in, the path is the same: export a file, upload it to 2anki, and download a .apkg deck you study on any device. Here is how each common app fits that path."
+    },
+    "obsidian-to-anki": {
+      "h1": "How to convert Obsidian notes to Anki flashcards",
+      "intro": "Obsidian notes are plain Markdown files, which means they convert to Anki without a plugin. Upload a .md file to 2anki and download a .apkg deck that opens in Anki. Bullets, question-and-answer pairs, headings, and code blocks all come across."
+    }
+  },
+  "pages": {
+    "ai-flashcard-generator": {
+      "h1": "Turn your notes into Anki cards",
+      "subhead": "Real notes in, real cards out. 2anki builds your deck from what you upload — it never invents facts."
+    },
+    "anki-to-notion": {
+      "h1": "Import Anki decks into Notion in one click.",
+      "subhead": "Upload an .apkg file. Get every card as a toggle in a Notion page you can study, search, and edit."
+    },
+    "goodnotes-to-anki": {
+      "h1": "Turn GoodNotes into Anki flashcards",
+      "subhead": "Export your notebook as PDF, drop it here, and download an Anki deck."
+    },
+    "anki-for-japanese": {
+      "h1": "Notion to Anki for Japanese and language learning",
+      "subhead": "Drop a Notion page of mined sentences or vocab. Screenshots, audio, and readings come across as you wrote them."
+    },
+    "markdown-to-anki": {
+      "h1": "Turn Markdown notes into Anki cards",
+      "subhead": "Drop a .md file and download a deck — bullets and Q/A pairs come across."
+    },
+    "mcat-anki": {
+      "h1": "Turn your MCAT content review into Anki cards you control",
+      "subhead": "Drop a PDF or Notion export of your content-review notes — amino acids, orgo reactions, psych and soc terms. 2anki builds clean cards from your material, not from a guess."
+    },
+    "anki-from-medical-lecture-slides": {
+      "h1": "Turn lecture slides into Anki cards",
+      "subhead": "Upload a PDF of your slides — headings become deck names, bullets become cards."
+    },
+    "nclex-anki": {
+      "h1": "Turn your NCLEX review notes into Anki cards you control",
+      "subhead": "Drop a PDF or Notion export of your Saunders, UWorld, or ATI notes — lab values, med suffixes, priority and delegation. 2anki builds clean cards from your material, not from a guess."
+    },
+    "notion-to-anki": {
+      "h1": "Notion to Anki — free, no add-on required",
+      "subhead": "Connect Notion once, paste any page link, get a .apkg deck. No software to install."
+    },
+    "nursing-flashcards": {
+      "h1": "Anki flashcards from nursing lecture slides and notes",
+      "subhead": "Drop a PDF or Notion export. 2anki pulls out the terms, medications, and procedures."
+    },
+    "pdf-to-anki": {
+      "h1": "Make Anki flashcards from a PDF",
+      "subhead": "Drop a PDF and we'll pull out the text you can turn into cards."
+    },
+    "powerpoint-to-anki": {
+      "h1": "Make Anki flashcards from a PowerPoint",
+      "subhead": "Drop a .pptx and 2anki reads the text on your slides and builds an Anki deck you can edit."
+    },
+    "quizlet-to-anki": {
+      "h1": "Move your Quizlet set to Anki",
+      "subhead": "Export from Quizlet, drop the file here, and download an Anki deck."
+    },
+    "step1-anki": {
+      "h1": "Turn your First Aid annotations and lecture notes into Step 1 cards you control",
+      "subhead": "Anki is the backbone of Step 1 prep. Upload your annotated First Aid pages, Pathoma outlines, or lecture PDFs and get clean, high-yield cards — built from your material, never invented."
+    },
+    "usmle-anki": {
+      "h1": "USMLE Step 1 and Step 2 decks from your own notes",
+      "subhead": "Upload lecture slides, First Aid exports, or any PDF. High-yield cards, spaced repetition-ready."
+    },
+    "convert-notion-to-anki": {
+      "h1": "Notion to Anki — turn your notes into flashcards",
+      "subhead": "Connect Notion once, paste any page link, get a .apkg deck. Toggles become cards. No add-on, no copy-pasting."
+    },
+    "convert-pdf-to-anki": {
+      "h1": "Convert PDF to Anki — flashcards from lecture slides and textbook chapters",
+      "subhead": "Drop a lecture PDF, slide export, or textbook chapter and download a .apkg deck. 2anki reads the text into question-and-answer cards, falls back to image cards when a page has no text, and can write cards with AI when the PDF is dense."
+    },
+    "convert-markdown-to-anki": {
+      "h1": "Markdown to Anki — convert .md files and Obsidian notes",
+      "subhead": "Drop a .md file and download a deck — bullets, Q/A pairs, and code blocks all come across."
+    },
+    "convert-csv-to-anki": {
+      "h1": "CSV to Anki — import spreadsheets as flashcard decks",
+      "subhead": "Drop a .csv file and get a .apkg deck. Column A becomes the front, everything after A joins into the back. Works with Excel exports too."
+    },
+    "convert-html-to-anki": {
+      "h1": "HTML to Anki — turn web pages into flashcard decks",
+      "subhead": "Drop an .html file and download a .apkg deck. Headings, bullets, and tables all come across."
+    },
+    "convert-apkg-to-csv": {
+      "h1": "Anki deck to CSV — export cards to a spreadsheet",
+      "subhead": "Drop an .apkg file and download a CSV. Every card front, back, and tag in one spreadsheet you can edit."
+    },
+    "convert-notion-tables-to-anki": {
+      "h1": "Notion tables to Anki — one row, one card",
+      "subhead": "Paste a Notion page with a table. Column 1 becomes the front, column 2 becomes the back."
+    },
+    "convert-brainscape-to-anki": {
+      "h1": "Move your Brainscape flashcards to Anki",
+      "subhead": "Export your Brainscape deck as CSV, drop it here, get a .apkg deck that opens clean in Anki."
+    },
+    "convert-lingvist-to-anki": {
+      "h1": "Move your Lingvist flashcards to Anki",
+      "subhead": "Export your Lingvist vocabulary as a CSV, drop it here, and get a .apkg deck. Your words and translations come across as basic cards."
+    },
+    "convert-studystack-to-anki": {
+      "h1": "Move your StudyStack flashcards to Anki",
+      "subhead": "Export your StudyStack as a CSV, drop it here, and get a .apkg deck. Terms and definitions become basic cards ready to review in Anki."
+    },
+    "convert-pleco-to-anki": {
+      "h1": "Move your Pleco flashcards to Anki",
+      "subhead": "Export your Pleco userdict as a .txt file, drop it here, and get a .apkg deck. Hanzi, pinyin, and definitions come across as basic cards."
+    },
+    "convert-zorbi-to-anki": {
+      "h1": "Move your Zorbi flashcards to Anki",
+      "subhead": "Export your Zorbi deck as a CSV, drop it here, and get a .apkg deck. Questions and answers become basic Anki cards."
+    },
+    "convert-language-reactor-to-anki": {
+      "h1": "Move your Language Reactor saves to Anki",
+      "subhead": "Drop the export zip from Language Reactor — your saved phrases, images, and audio come across as a clean .apkg you can study on any device."
+    },
+    "convert-epub-to-anki": {
+      "h1": "EPUB highlights to Anki — from ebook highlights to cards",
+      "subhead": "Drop a DRM-free .epub and download a .apkg. Each passage you highlighted becomes a card, with the book title and author on the back."
+    },
+    "convert-kindle-to-anki": {
+      "h1": "Kindle highlights to Anki — from My Clippings.txt to a deck",
+      "subhead": "Copy My Clippings.txt off your Kindle, drop it here, and download a .apkg. Each passage you highlighted — and any note you typed — becomes a card."
+    }
+  }
+}

--- a/web/src/pages/AnswersPage/AnswersPage.tsx
+++ b/web/src/pages/AnswersPage/AnswersPage.tsx
@@ -1,4 +1,5 @@
 import { Helmet } from 'react-helmet-async';
+import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import NotFoundPage from '../NotFoundPage';
 import { AnswerFigure } from './AnswerFigures';
@@ -9,6 +10,7 @@ import { buildArticleJsonLd, buildFaqJsonLd } from './answersJsonLd';
 export { buildArticleJsonLd, buildFaqJsonLd };
 
 function AnswersPage() {
+  const { t } = useTranslation('landing');
   const { slug } = useParams<{ slug: string }>();
   const config = slug == null ? undefined : ANSWERS_PAGES.get(slug);
 
@@ -35,8 +37,12 @@ function AnswersPage() {
         {faqJsonLd && <script type="application/ld+json">{faqJsonLd}</script>}
       </Helmet>
 
-      <h1 className={styles.h1}>{config.h1}</h1>
-      <p className={styles.intro}>{config.intro}</p>
+      <h1 className={styles.h1}>
+        {t(`answers.${config.slug}.h1`, { defaultValue: config.h1 })}
+      </h1>
+      <p className={styles.intro}>
+        {t(`answers.${config.slug}.intro`, { defaultValue: config.intro })}
+      </p>
 
       {config.sections.map((section) => (
         <div key={section.heading} className={styles.section}>
@@ -53,7 +59,11 @@ function AnswersPage() {
 
       {config.faqs && config.faqs.length > 0 && (
         <div className={styles.section}>
-          <h2 className={styles.sectionHeading}>Frequently asked questions</h2>
+          <h2 className={styles.sectionHeading}>
+            {t('answers.faqHeading', {
+              defaultValue: 'Frequently asked questions',
+            })}
+          </h2>
           {config.faqs.map((faq) => (
             <div key={faq.q}>
               <h3 className={styles.sectionHeading}>{faq.q}</h3>
@@ -63,8 +73,13 @@ function AnswersPage() {
         </div>
       )}
 
-      <nav className={styles.related} aria-label="Related">
-        <p className={styles.relatedHeading}>Related</p>
+      <nav
+        className={styles.related}
+        aria-label={t('sections.related', { defaultValue: 'Related' })}
+      >
+        <p className={styles.relatedHeading}>
+          {t('sections.related', { defaultValue: 'Related' })}
+        </p>
         <ul className={styles.relatedList}>
           {config.relatedLinks.map((link) => (
             <li key={link.href}>

--- a/web/src/pages/ConvertHubPage/ConvertHubPage.tsx
+++ b/web/src/pages/ConvertHubPage/ConvertHubPage.tsx
@@ -1,6 +1,11 @@
 import { Helmet } from 'react-helmet-async';
+import { useTranslation } from 'react-i18next';
 import styles from './ConvertHubPage.module.css';
 import { CONVERT_HUB_GROUPS } from './convertHubGroups';
+
+function groupKey(heading: string): string {
+  return heading.toLowerCase().replace(/\s+/g, '-');
+}
 
 const TITLE = 'Convert anything to Anki — every converter | 2anki';
 const DESCRIPTION =
@@ -10,6 +15,7 @@ const SUBHEAD =
   'Pick your source. Every converter turns your notes, files, or flashcards into a clean .apkg deck you study in Anki.';
 
 function ConvertHubPage() {
+  const { t } = useTranslation('landing');
   const canonical = 'https://2anki.net/convert';
 
   return (
@@ -27,13 +33,19 @@ function ConvertHubPage() {
       </Helmet>
 
       <header className={styles.hero}>
-        <h1 className={styles.h1}>{H1}</h1>
-        <p className={styles.subhead}>{SUBHEAD}</p>
+        <h1 className={styles.h1}>{t('hub.h1', { defaultValue: H1 })}</h1>
+        <p className={styles.subhead}>
+          {t('hub.subhead', { defaultValue: SUBHEAD })}
+        </p>
       </header>
 
       {CONVERT_HUB_GROUPS.map((group) => (
         <section key={group.heading} className={styles.group}>
-          <h2 className={styles.groupHeading}>{group.heading}</h2>
+          <h2 className={styles.groupHeading}>
+            {t(`hub.groups.${groupKey(group.heading)}`, {
+              defaultValue: group.heading,
+            })}
+          </h2>
           <ul className={styles.list}>
             {group.entries.map((entry) => (
               <li key={entry.slug} className={styles.item}>

--- a/web/src/pages/LandingPage/LandingPage.i18n.test.tsx
+++ b/web/src/pages/LandingPage/LandingPage.i18n.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { HelmetProvider } from 'react-helmet-async';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+import i18n from '../../lib/i18n';
+import LandingPage from './LandingPage';
+import usmleCopy from './copy/usmle';
+
+function renderLandingPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <HelmetProvider>
+          <LandingPage copy={usmleCopy} setErrorMessage={vi.fn()} />
+        </HelmetProvider>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('LandingPage in German', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('renders the per-page hero heading in German', () => {
+    renderLandingPage();
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: 'USMLE-Step-1- und Step-2-Stapel aus deinen eigenen Notizen',
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('translates the shared how-it-works label', () => {
+    renderLandingPage();
+    expect(screen.getByText("So funktioniert's")).toBeInTheDocument();
+  });
+
+  it('translates the secondary sign-up link', () => {
+    renderLandingPage();
+    expect(
+      screen.getByRole('link', { name: 'kostenlos registrieren' })
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/LandingPage/LandingPage.tsx
+++ b/web/src/pages/LandingPage/LandingPage.tsx
@@ -1,5 +1,7 @@
 import { useEffect, type ReactNode } from 'react';
 import { Helmet } from 'react-helmet-async';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import UploadForm from '../UploadPage/components/UploadForm/UploadForm';
 import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
 import { persistSignupOrigin } from '../../lib/signupOrigin';
@@ -13,22 +15,31 @@ interface LandingPageProps {
   heroSlot?: ReactNode;
 }
 
-const STEPS = [
-  {
+const STEP_KEYS = ['dropFile', 'buildsDeck', 'openInAnki'] as const;
+
+const STEP_FALLBACK: Record<
+  (typeof STEP_KEYS)[number],
+  { title: string; body: string }
+> = {
+  dropFile: {
     title: 'Drop your file',
     body: 'Notion export, PDF, Word, Markdown, or a Quizlet export.',
   },
-  {
+  buildsDeck: {
     title: '2anki builds your deck',
     body: 'Usually a few seconds. Bigger files take a minute.',
   },
-  {
+  openInAnki: {
     title: 'Open it in Anki',
     body: 'Double-click the .apkg file. Your cards are ready to study.',
   },
-];
+};
 
 const FORMATS = ['Notion', 'PDF', 'Markdown', 'HTML', 'CSV', 'Word', 'Quizlet'];
+
+function pageKeyFromPathname(pathname: string): string {
+  return pathname.replace(/^\//, '').replace(/\//g, '-');
+}
 
 interface HeroActionProps {
   heroSlot?: ReactNode;
@@ -36,6 +47,7 @@ interface HeroActionProps {
   ctaLabel?: string;
   setErrorMessage: ErrorHandlerType;
   registerHref: string;
+  t: TFunction<'landing'>;
 }
 
 function renderHeroAction({
@@ -44,6 +56,7 @@ function renderHeroAction({
   ctaLabel,
   setErrorMessage,
   registerHref,
+  t,
 }: Readonly<HeroActionProps>) {
   if (heroSlot != null) {
     return <div className={styles.uploadWrapper}>{heroSlot}</div>;
@@ -55,7 +68,9 @@ function renderHeroAction({
           {ctaLabel}
         </a>
         <p className={styles.secondaryLink}>
-          Free · up to 1 000 cards per import
+          {t('hero.freeQuota', {
+            defaultValue: 'Free · up to 1 000 cards per import',
+          })}
         </p>
       </div>
     );
@@ -66,9 +81,16 @@ function renderHeroAction({
         <UploadForm setErrorMessage={setErrorMessage} />
       </div>
       <p className={styles.secondaryLink}>
-        or <a href={registerHref}>sign up free</a>
+        {t('hero.orPrefix', { defaultValue: 'or ' })}
+        <a href={registerHref}>
+          {t('hero.signUpFree', { defaultValue: 'sign up free' })}
+        </a>
         {' — '}
-        <a href="/pricing">try Unlimited free for 1 hour</a>
+        <a href="/pricing">
+          {t('hero.tryUnlimited', {
+            defaultValue: 'try Unlimited free for 1 hour',
+          })}
+        </a>
       </p>
     </>
   );
@@ -79,12 +101,14 @@ function LandingPage({
   setErrorMessage,
   heroSlot,
 }: Readonly<LandingPageProps>) {
+  const { t } = useTranslation('landing');
   useEffect(() => {
     persistSignupOrigin(copy.pathname, globalThis.sessionStorage ?? null);
   }, [copy.pathname]);
 
   const canonical = `https://2anki.net${copy.pathname}`;
   const registerHref = `/register?source=${encodeURIComponent(copy.pathname)}`;
+  const pageKey = pageKeyFromPathname(copy.pathname);
 
   const faqJsonLd = JSON.stringify({
     '@context': 'https://schema.org',
@@ -116,27 +140,42 @@ function LandingPage({
 
       <section id="upload" className={styles.hero}>
         <div className={styles.heroInner}>
-          <h1 className={styles.heroTitle}>{copy.h1}</h1>
-          <p className={styles.heroSubhead}>{copy.subhead}</p>
+          <h1 className={styles.heroTitle}>
+            {t(`pages.${pageKey}.h1`, { defaultValue: copy.h1 })}
+          </h1>
+          <p className={styles.heroSubhead}>
+            {t(`pages.${pageKey}.subhead`, { defaultValue: copy.subhead })}
+          </p>
           {renderHeroAction({
             heroSlot,
             ctaHref: copy.ctaHref,
             ctaLabel: copy.ctaLabel,
             setErrorMessage,
             registerHref,
+            t,
           })}
         </div>
       </section>
 
       <section className={styles.stepsSection}>
         <div className={styles.stepsInner}>
-          <p className={styles.sectionLabel}>How it works</p>
+          <p className={styles.sectionLabel}>
+            {t('sections.howItWorks', { defaultValue: 'How it works' })}
+          </p>
           <div className={styles.stepsGrid}>
-            {STEPS.map((step, idx) => (
-              <div key={step.title} className={styles.step}>
+            {STEP_KEYS.map((key, idx) => (
+              <div key={key} className={styles.step}>
                 <span className={styles.stepNumber}>{idx + 1}</span>
-                <p className={styles.stepTitle}>{step.title}</p>
-                <p className={styles.stepBody}>{step.body}</p>
+                <p className={styles.stepTitle}>
+                  {t(`steps.${key}.title`, {
+                    defaultValue: STEP_FALLBACK[key].title,
+                  })}
+                </p>
+                <p className={styles.stepBody}>
+                  {t(`steps.${key}.body`, {
+                    defaultValue: STEP_FALLBACK[key].body,
+                  })}
+                </p>
               </div>
             ))}
           </div>
@@ -144,7 +183,11 @@ function LandingPage({
       </section>
 
       <section className={styles.section}>
-        <p className={styles.sectionLabel}>Supported formats</p>
+        <p className={styles.sectionLabel}>
+          {t('sections.supportedFormats', {
+            defaultValue: 'Supported formats',
+          })}
+        </p>
         <ul className={styles.formatsList}>
           {FORMATS.map((format) => (
             <li key={format} className={styles.formatTag}>
@@ -156,7 +199,11 @@ function LandingPage({
 
       {copy.whatComesAcross != null && (
         <section className={styles.section}>
-          <p className={styles.sectionLabel}>What you actually get in Anki</p>
+          <p className={styles.sectionLabel}>
+            {t('sections.whatYouGet', {
+              defaultValue: 'What you actually get in Anki',
+            })}
+          </p>
           <dl className={styles.stepsGrid}>
             {copy.whatComesAcross.map((item) => (
               <div key={item.title} className={styles.step}>
@@ -169,7 +216,9 @@ function LandingPage({
       )}
 
       <section className={styles.section}>
-        <p className={styles.sectionLabel}>Common questions</p>
+        <p className={styles.sectionLabel}>
+          {t('sections.commonQuestions', { defaultValue: 'Common questions' })}
+        </p>
         <div className={styles.faqList}>
           {copy.faqs.map((faq) => (
             <details key={faq.q} className={styles.faqItem}>
@@ -181,8 +230,13 @@ function LandingPage({
       </section>
 
       {copy.relatedLinks != null && copy.relatedLinks.length > 0 && (
-        <nav className={styles.related} aria-label="Related">
-          <p className={styles.relatedHeading}>Related</p>
+        <nav
+          className={styles.related}
+          aria-label={t('sections.related', { defaultValue: 'Related' })}
+        >
+          <p className={styles.relatedHeading}>
+            {t('sections.related', { defaultValue: 'Related' })}
+          </p>
           <ul className={styles.relatedList}>
             {copy.relatedLinks.map((link) => (
               <li key={link.href}>
@@ -197,9 +251,11 @@ function LandingPage({
 
       <section className={styles.footerCta}>
         <p className={styles.footerCtaText}>
-          Ready to try it?{' '}
+          {t('footer.readyPrefix', { defaultValue: 'Ready to try it? ' })}
           <a href="#upload" className={styles.footerCtaLink}>
-            Drop a file at the top of this page.
+            {t('footer.dropLink', {
+              defaultValue: 'Drop a file at the top of this page.',
+            })}
           </a>
         </p>
       </section>

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-16-german-landing.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-16-german-landing.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-16-german-landing",
+  "date": "2026-07-16",
+  "type": "feature",
+  "title": "Landing and answer pages now show in German when you pick Deutsch"
+}


### PR DESCRIPTION
## What
Translates the **visible, in-app** copy of the SEO landing surfaces to German so a visitor with the language picker set to Deutsch sees German. Covers `LandingPage` (16 copy modules), `ConvertLandingPage` (15 configs, reuses `LandingPage`), `AnswersPage` (15 configs), and `ConvertHubPage`. Adds a new `landing` i18n namespace (`locales/{en,de}/landing.json`).

## Why
Acquisition-facing: German is the largest non-English visitor segment on these pages. The full app chrome is already localized; the landing/answer/convert surfaces were still English-only after hydration. This makes the first-touch pages match the picker.

## How
- New `landing` namespace, auto-loaded by the existing glob in `i18n/index.ts` (untouched).
- `LandingPage`/`AnswersPage`/`ConvertHubPage` now call `useTranslation('landing')`.
- Shared chrome (steps, section labels, secondary CTA, footer, hub hero + group headings, "Related", FAQ heading) is keyed and translated in both locales.
- Per-page hero `h1`/`subhead` (and answer `h1`/`intro`) route through the namespace keyed by a sanitized pathname/slug, with `defaultValue` = the English source in the copy module. English values are mirrored into `en/landing.json` so the namespace is self-contained and the existing English tests still pass.
- Protected verbatim in both locales: brand/format names (Anki, Notion, Quizlet, PDF, CSV, HTML, Markdown, Word, PowerPoint, .apkg, GoodNotes, Obsidian, Kindle, EPUB, Pleco, Lingvist, StudyStack, Zorbi, Brainscape, Language Reactor), exam names (USMLE, NCLEX, MCAT, Step 1, First Aid, Pathoma, Saunders, UWorld, ATI), FSRS/SM-2. AI → KI.

## SEO caveat — strings intentionally left English (not translated in this PR)
These feed `<title>`/meta/canonical/JSON-LD/prerender and changing their language needs a routing/canonical strategy, so they stay English:
- **`copy.title` / `copy.description`** on every LandingPage/ConvertLanding/AnswersPage/ConvertHubPage — feed `<title>`, `og:*`, `twitter:*` meta.
- **LandingPage/ConvertLanding `faqs` (q + a)** — feed the FAQPage JSON-LD *and* the visible `<details>`. Left English to keep visible text matching structured data (avoids a visible-vs-structured mismatch).
- **AnswersPage `sections` (heading + body)** — feed the Article JSON-LD (`articleSection`, `articleBody`) and the visible sections.
- **AnswersPage `faqs` (q + a)** — feed the FAQPage JSON-LD and the visible FAQ.
- **AnswersPage `relatedLinks` / LandingPage `relatedLinks` labels** — internal-link anchor text (crawlable), left English.
- **ConvertHubPage entry anchors + blurbs** — internal-link anchor text + dense body, left English (only the group headings + hero are translated).
- **LandingPage `whatComesAcross` item title/body** — visible-only (not in JSON-LD) but per-page dense prose; deferred for scope, the section label is translated. Safe to translate in a follow-up, no SEO risk.

Design note: per-page keys exist in `de` and are mirrored in `en`; `defaultValue` on every `t()` call falls back to the copy-module source so a missing key never renders a raw key string.

## Measuring success
`landing_page_viewed` continues firing; watch the de-locale slice of landing → signup conversion in the funnel events (`/api/ops/metrics`). No new event added — this is a copy localization, not a new surface.

## Testing
- New `web/src/pages/LandingPage/LandingPage.i18n.test.tsx` — renders a landing page under `de` and asserts the German hero heading, the German "So funktioniert's" label, and the German sign-up link.
- Full web vitest suite green (276 files, 2290 tests). Web `tsc --noEmit` green. `oxlint` — no findings in changed files.
- `pnpm --filter 2anki-web test:golden-path` — 2 passed.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: golden-path spec (375px, network-mocked, fails on any console error) green.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-07-16-german-landing.json` — "Landing and answer pages now show in German when you pick Deutsch"

## Sonar
Sonar not run locally (no SONAR_TOKEN on this box); Automatic Analysis covers the push. Changes are JSX-to-`t()` swaps + JSON, no new branching/complexity.

## Risks
Low. English behavior is unchanged (namespace en = source, plus `defaultValue` fallback). No i18n/index.ts, common.json, App.tsx, prerender, or sitemap changes. Rollback = revert the PR.

## Goal alignment
Acquisition lane: localizes the first-touch SEO landing pages for German visitors, targeting the landing → signup step for the de slice. No pricing/limit/API change.
