### PR TITLE
feat: add German documentation with English fallback

### DIFF
--- a/web/src/pages/DocsPage/DocContent.tsx
+++ b/web/src/pages/DocsPage/DocContent.tsx
@@ -1,5 +1,6 @@
 import { AnchorHTMLAttributes, useEffect, useMemo } from 'react';
 import { Link, Navigate, useLocation, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import ReactMarkdown, { Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
@@ -130,7 +131,8 @@ const rehypePlugins = [rehypeRaw, rehypeSlug];
 const EDIT_BASE = 'https://github.com/2anki/server/edit/main/';
 
 export function DocContent({ slug }: Readonly<DocContentProps>) {
-  const doc = loadDoc(slug);
+  const { i18n } = useTranslation();
+  const doc = loadDoc(slug, i18n.resolvedLanguage);
   const { hash } = useLocation();
   const resolvedSlug = resolveSlug(slug);
 

--- a/web/src/pages/DocsPage/content/de/help/bug-report.md
+++ b/web/src/pages/DocsPage/content/de/help/bug-report.md
@@ -1,0 +1,50 @@
+---
+title: Einen Fehler melden
+description: Eine kurze Vorlage, die dir eine schnelle Antwort bringt.
+---
+
+Hilf uns, 2anki.net zu verbessern, indem du einen Fehlerbericht einreichst. Du kannst ihn öffentlich auf [GitHub](https://github.com/2anki/server/issues/new?assignees=&labels=&template=bug_report.md&title=) einreichen oder privat per E-Mail an [support@2anki.net](mailto:support@2anki.net).
+
+## Bevor du meldest
+
+Wenn der Fehler eine fehlgeschlagene Konvertierung ist, besuche die [/debug](/debug)-Seite und aktiviere **Share files when a conversion fails**. Das ist standardmäßig aus, um deine Notizen privat zu halten, aber mit aktivierter Option schickt der nächste fehlgeschlagene Upload die Datei und die Fehlerdetails direkt an unser Postfach — kein Hin und Her nötig. Schalte es wieder aus, sobald das Problem behoben ist.
+
+Nutze die Vorlage unten.
+
+## Beschreibe den Fehler
+
+Eine klare und knappe Beschreibung, worin der Fehler besteht.
+
+## So reproduzierst du ihn
+
+Schritte, um das Verhalten zu reproduzieren:
+
+1. Geh zu '...'
+2. Klick auf '...'
+3. Scroll nach unten zu '...'
+4. Sieh den Fehler
+
+## Erwartetes Verhalten
+
+Eine klare und knappe Beschreibung dessen, was du erwartet hast.
+
+## Screenshots
+
+Falls zutreffend, füge Screenshots oder eine kurze Bildschirmaufnahme bei.
+
+### Desktop
+
+- Betriebssystem: [z. B. macOS 14]
+- Browser: [z. B. Chrome, Safari]
+- Version: [z. B. 131]
+
+### Smartphone
+
+- Gerät: [z. B. iPhone 15]
+- Betriebssystem: [z. B. iOS 17]
+- Browser: [z. B. Standard-Browser, Safari]
+- Version: [z. B. 17.3]
+
+## Zusätzlicher Kontext
+
+Alles andere, was uns helfen könnte, das Problem zu reproduzieren — Upload-IDs, Dateigrößen, ob die Claude-KI-Generierung aktiviert war, usw.

--- a/web/src/pages/DocsPage/content/de/help/common-problems.md
+++ b/web/src/pages/DocsPage/content/de/help/common-problems.md
@@ -1,0 +1,110 @@
+---
+title: Häufige Probleme
+description: Die Fehler, die Nutzer wirklich treffen, mit der Lösung auf derselben Seite.
+---
+
+Wenn du einen Fehler gesehen hast und die Lösung willst, finde die Überschrift unten, die zu dem passt, was du gesehen hast. Wenn dein Problem nicht dabei ist, [kontaktiere uns](/documentation/help/contact) oder [melde einen Fehler](/documentation/help/bug-report).
+
+Die Fehlermeldungen unten sind in Anführungszeichen genau so belassen, wie 2anki sie ausgibt.
+
+## Is 2anki down?
+
+Prüfe die [Statusseite](/status) — sie zeigt, ob API, Datenbank und Notion-Verbindung gesund sind. Wenn die Seite selbst nicht erreichbar ist, ist der Server wahrscheinlich down; sieh in der Community auf Reddit nach Updates.
+
+## "Please select a file to upload."
+
+**Was du gesehen hast.** Ein roter Fehler erscheint in dem Moment, in dem du absendest, bevor irgendetwas hochlädt.
+
+**Warum es passiert ist.** Das Formular wurde ohne angehängte Datei gesendet.
+
+**Wie du es behebst.** Zieh eine Datei auf den Upload-Bereich oder klick darauf, um eine von deinem Computer auszuwählen. Siehe [unterstützte Formate](/documentation/reference/file-formats).
+
+## "The uploaded file appears to be invalid. Please try again."
+
+**Was du gesehen hast.** Der Upload startet, schlägt aber sofort fehl.
+
+**Warum es passiert ist.** Der Browser hat eine Datei ohne Namen gesendet. Das passiert meist, wenn eine Erweiterung oder ein Hintergrundprozess den Upload abfängt.
+
+**Wie du es behebst.** Versuch einen anderen Browser, oder deaktiviere Erweiterungen, die Downloads oder Uploads berühren (Datenschutz-Tools, „Save-to-cloud“-Erweiterungen). Häng die Datei dann erneut an.
+
+## "[file] appears to be empty. Please re-export your file and try again."
+
+**Was du gesehen hast.** Der Upload gibt diese Meldung mit dem Namen deiner Datei zurück.
+
+**Warum es passiert ist.** Die Datei hat 0 Byte — meist, weil ein Export stillschweigend fehlgeschlagen ist oder die Datei kopiert wurde, während die Quell-App noch schrieb.
+
+**Wie du es behebst.** Exportiere erneut aus der Quelle (Notion, Obsidian, Excel usw.). Bestätige, dass die Datei Inhalt hat, indem du sie vor dem Hochladen lokal öffnest.
+
+## "[file] is already an Anki deck. 2anki converts source files like Notion HTML exports, not existing decks."
+
+**Was du gesehen hast.** Du hast versucht, eine `.apkg` hochzuladen.
+
+**Warum es passiert ist.** 2anki erstellt Anki-Decks; es liest sie nicht. Eine bestehende `.apkg` hochzuladen ist kein Weg, den wir unterstützen.
+
+**Wie du es behebst.** Lade die Quelle hoch, aus der du das Deck gemacht hast (HTML-Export, Markdown, PDF, CSV) — nicht das Deck selbst. Um eine `.apkg` zu öffnen, die du schon hast, siehe [Öffne dein Deck in Anki](/documentation/start-here/open-in-anki). Um es als PDF zu drucken oder zu teilen, nutze [Print Decks](/print).
+
+## "PDF exceeds maximum page limit of 100 for free and anonymous users."
+
+**Was du gesehen hast.** Ein PDF-Upload schlägt direkt nach dem Absenden fehl.
+
+**Warum es passiert ist.** Kostenlose Konten begrenzen PDFs auf 100 Seiten, damit die Konvertierung schnell und kostenlos bleibt.
+
+**Wie du es behebst.** Teile das PDF in kleinere Dateien (jeder PDF-Reader hat eine „Teilen“-Option), oder [abonniere](/pricing), um die Grenze zu entfernen. Siehe [Grenzen und Kontingente](/documentation/help/limits) für die vollständige Liste.
+
+## "This PDF is password-protected."
+
+**Was du gesehen hast.** Du hast ein PDF hochgeladen, und der Upload-Bereich wechselte zu einem Passwortfeld mit dem Dateinamen darüber.
+
+**Warum es passiert ist.** Das PDF wurde mit einem Öffnen-Passwort erstellt — Anki kann es nicht lesen, und 2anki auch nicht, bis du es entsperrst.
+
+**Wie du es behebst.** Tipp das Passwort ins Feld und klick auf **Unlock**. Die Datei wird im Speicher entschlüsselt, konvertiert, und das Passwort wird verworfen — wir speichern es nicht. Wenn du das Passwort nicht kennst, frag denjenigen, der das PDF geteilt hat, oder entferne das Passwort in deinem PDF-Reader (die meisten Reader haben eine Option **File → Save as → Properties → Security → No Security**) und lade erneut hoch.
+
+Wenn du irgendwo anders klickst und das Feld verschwindet, wirf die Datei erneut hinein — die Passwortabfrage kommt zurück.
+
+## Notion Markdown export produces 0 cards
+
+**Was du gesehen hast.** Du hast eine Notion-Seite als Markdown exportiert und hochgeladen, aber 0 Karten bekommen — obwohl die Seite Toggles hat.
+
+**Warum es passiert ist.** Notions Markdown-Export flacht Toggle-Blöcke in einfachen Text ab. Die Toggles, die 2anki in Karteikarten verwandelt, werden aus der Datei entfernt, bevor sie den Konverter erreicht.
+
+**Wie du es behebst.** Exportiere dieselbe Seite aus Notion stattdessen als **HTML**. Die Toggles bleiben in HTML erhalten und konvertieren korrekt.
+
+## "Could not create a deck using your file and rules."
+
+**Was du gesehen hast.** Der Upload wird abgeschlossen, erzeugt aber kein Deck.
+
+**Warum es passiert ist.** 2anki konnte nichts finden, das wie eine Karteikarte aussieht. Standardmäßig sucht es nach Toggle-Blöcken; ohne Toggles musst du eine andere Option aktivieren.
+
+**Wie du es behebst.** Öffne [Kartenoptionen](/documentation/cards/card-options) und schalte die Option ein, die zu deiner Quelle passt — für Markdown-Aufzählungshierarchien **Markdown Nested Bullet Points**; für Notion-Exporte ohne Toggles strukturiere deine Quelle um, oder [kontaktiere uns](/documentation/help/contact) mit einem Beispiel.
+
+## "Claude couldn't find any content to turn into flashcards in this Notion page."
+
+**Was du gesehen hast.** Du hast die Claude-KI-Generierung aktiviert, und die Konvertierung schlug mit dieser Meldung fehl.
+
+**Warum es passiert ist.** Die Seite, die Claude erhalten hat, war leer oder enthielt nur Layout-Elemente (Buttons, Platzhalter) — nichts, das es in eine Frage verwandeln konnte.
+
+**Wie du es behebst.** Füge der Seite Überschriften mit Erklärungen, Toggle-Listen oder Frage-und-Antwort-Text hinzu, und konvertiere dann erneut.
+
+## A Notion page won't show up in the picker
+
+**Was du gesehen hast.** Du hast Notion verbunden, aber eine Seite, die du konvertieren willst, ist nicht aufgelistet.
+
+**Warum es passiert ist.** Notion teilt nur Seiten, denen du der 2anki-Integration ausdrücklich Zugriff gegeben hast.
+
+**Wie du es behebst.** Öffne die Seite in Notion → **Share** → **Add connections** → wähle **2anki**. Aktualisiere dann die Auswahl.
+
+## My Google Doc converted to 0 cards
+
+**Was du gesehen hast.** Du hast ein Doc aus Google Drive gewählt, die Konvertierung wurde abgeschlossen, und das Deck hat keine Karten.
+
+**Warum es passiert ist.** 2anki liest Docs als Aufzählungs-Gliederungen. Ein Top-Level-Aufzählungspunkt wird zur Frage; darunter eingerückte Punkte werden zur Antwort. Docs, die als fließende Absätze geschrieben sind, oder mit Aufzählungspunkten, die alle auf derselben Einrückungsebene sitzen, geben uns keine Frage-und-Antwort-Struktur, aus der wir Karten machen können. Überschriften, gefolgt von Absätzen, funktionieren auch, aber nur, wenn jede Überschrift einen Absatz darunter hat.
+
+**Wie du es behebst.** Öffne dein Doc, strukturiere den Inhalt als Aufzählungspunkte um, bei denen jede Frage auf der obersten Ebene steht und die Antwort einen Schritt darunter eingerückt ist, und wähle dann das Doc erneut. Das vollständige Aufzählungsbeispiel steht auf der Seite [Dateiformate](/documentation/reference/file-formats).
+
+## Some images are missing from my deck
+
+**Was du gesehen hast.** Karten erscheinen, aber Bilder sind kaputt.
+
+**Warum es passiert ist.** Du hast wahrscheinlich eine einzelne `.html`-Datei statt des vollständigen `.zip` hochgeladen. Notions HTML-Export verweist auf Bilder in einem `assets/`-Ordner, und wenn du nur die `.html` hochlädst, bleiben die Bilder zurück.
+
+**Wie du es behebst.** Lade stattdessen das originale `.zip` hoch. Wenn dein Browser Zips automatisch entpackt, schalte das aus — in Safari, **Preferences → General**, deaktiviere **Open "safe" files after downloading**.

--- a/web/src/pages/DocsPage/content/de/help/contact.md
+++ b/web/src/pages/DocsPage/content/de/help/contact.md
@@ -1,0 +1,12 @@
+---
+title: Kontaktiere uns
+description: Drei Wege, einen Menschen zu erreichen.
+---
+
+Der schnellste Weg, uns zu erreichen, ist per E-Mail an [support@2anki.net](mailto:support@2anki.net). Konstruktives Feedback — gut oder schlecht — ist immer willkommen.
+
+## Probleme melden
+
+Öffentliche Fehlerberichte gehen auf [GitHub](https://github.com/2anki/2anki.net/issues). Bitte nutze die bereitgestellte Vorlage und füge nach Möglichkeit ein minimales Beispiel bei.
+
+Wenn du die Details lieber nicht öffentlich teilst, schick dieselben Informationen privat an [support@2anki.net](mailto:support@2anki.net) — siehe die [Fehlerbericht-Vorlage](/documentation/help/bug-report).

--- a/web/src/pages/DocsPage/content/de/help/limits.md
+++ b/web/src/pages/DocsPage/content/de/help/limits.md
@@ -1,0 +1,92 @@
+---
+title: Grenzen und Kontingente
+description: Was auf jedem Plan erlaubt ist und wie lange deine Decks bleiben.
+---
+
+2anki.net ist für die Konvertierungsfunktionen kostenlos. Die Grenzen unten halten den gehosteten Dienst für alle schnell. Wenn du selbst hostest, kannst du sie ändern — siehe [Self-Hosting](/documentation/reference/self-hosting).
+
+## Karten pro Monat
+
+| Plan                    | Karten pro Monat        |
+| ----------------------- | ----------------------- |
+| Anonym (kein Konto)     | 21 pro Konvertierung    |
+| Kostenloses Konto       | 100 pro Monat           |
+| Subscription / Lifetime | Unbegrenzt              |
+
+Das kostenlose Monatslimit zählt Karten über **jeden** Konvertierungsweg — Datei-Uploads, `.zip`, Notion, alle davon — nicht nur Notion. Der Zähler setzt sich zu Beginn jedes Kalendermonats zurück.
+
+Ohne Konto ist jede Konvertierung auf 21 Karten begrenzt. Registriere ein kostenloses Konto, um die vollen 100 Karten pro Monat zu bekommen.
+
+## Dateigröße
+
+| Plan                    | Max. Upload-Größe    |
+| ----------------------- | -------------------- |
+| Free                    | 100 MB pro Anfrage   |
+| Subscription / Lifetime | ~10 GB pro Anfrage   |
+
+Free umfasst anonyme und angemeldete Nutzer ohne kostenpflichtigen Plan.
+
+## PDF-Seiten
+
+| Plan                    | Max. Seiten pro PDF |
+| ----------------------- | ------------------- |
+| Free                    | 100                 |
+| Subscription / Lifetime | Keine feste Grenze  |
+
+PDFs über dem kostenlosen Limit geben zurück: _PDF exceeds maximum page limit of 100 for free and anonymous users._
+
+## KI-generierte Karteikarten
+
+Die Kartenoption **Use Claude AI** ist eine Subscription-/Lifetime-Funktion. Kostenlose Konten sehen den Schalter, aber die Konvertierung fällt auf den Standard-Parser zurück.
+
+## Chat
+
+Der Chat-Lernassistent ist für alle angemeldeten Nutzer verfügbar.
+
+|                       | Free             | Subscription       | Lifetime           |
+| --------------------- | ---------------- | ------------------ | ------------------ |
+| Nachrichten pro Monat | 20               | Unbegrenzt         | Unbegrenzt         |
+| Nachrichtenlänge      | 4 000 Zeichen    | 100 000 Zeichen    | 100 000 Zeichen    |
+| Modell                | Claude Haiku     | Claude Sonnet      | Claude Sonnet      |
+
+Kostenlose Nutzer, die 20 Nachrichten erreichen, sehen das genaue Reset-Datum (der Erste des Folgemonats). Der Nachrichtenzähler setzt sich monatlich zurück.
+
+## Speicherung
+
+Was „Speicherung“ bedeutet, hängt davon ab, welchen Weg du genutzt hast.
+
+### Datei-Upload (ohne Claude AI)
+
+Deine Datei liegt nur so lange auf der Festplatte, wie es dauert, das Deck zu bauen. Die `.apkg` wird direkt als Antwort zurückgeschickt — wir behalten keine Kopie. Die temporären Arbeitsdateien werden nach **zwei Stunden** gelöscht.
+
+**Plan:** beliebig (anonym, kostenloses Konto, Subscription, Lifetime — dasselbe Zeitfenster für alle).
+
+### Notion-Konvertierung und Claude-KI-Uploads
+
+Diese Wege bauen dein Deck im Hintergrund und speichern die `.apkg` in unserem Bucket, damit du es unter **My Decks** erneut herunterladen kannst und damit [Sync](/documentation/sync/how-it-works) etwas zum Aktualisieren hat.
+
+| Plan               | Wie lange deine Decks im Bucket bleiben                    |
+| ------------------ | --------------------------------------------------------- |
+| Kostenloses Konto  | In der nächsten täglichen Bereinigung entfernt (binnen 24 Stunden). |
+| Subscription       | Behalten, solange dein Abo aktiv ist.                     |
+| Lifetime (Patreon) | Unbegrenzt behalten.                                      |
+
+Wenn dein Abo ausläuft, werden deine gespeicherten Decks in der nächsten täglichen Bereinigung entfernt — konvertiere erneut, und sie kommen zurück. Du kannst ein Deck auch jederzeit selbst unter **My Decks** löschen.
+
+## Free vs. kostenpflichtig
+
+Free deckt die Konvertierungswege ab, die die meisten Leute brauchen: eine Datei hineinziehen, ein Deck zurückbekommen. Die kostenpflichtigen Pläne fügen KI-generierte Karteikarten, größere Uploads, längere Speicherung und Notion-Sync hinzu.
+
+| Fähigkeit                                          | Free               | Subscription  | Lifetime   |
+| -------------------------------------------------- | ------------------ | ------------- | ---------- |
+| Karten pro Monat                                   | 100 (21 anonym)    | Unbegrenzt    | Unbegrenzt |
+| Anonymer Datei-Upload                              | ✓                  | ✓             | ✓          |
+| Kontofunktionen (Verlauf, Favoriten, Vorlagen)     | Anmeldung nötig    | ✓             | ✓          |
+| KI-generierte Karteikarten (Claude)                | —                  | ✓             | ✓          |
+| Chat (Lernassistent)                               | 20 Nachr. / Monat  | Unbegrenzt    | Unbegrenzt |
+| Langzeit-Deckspeicherung                           | 24 h               | aktives Abo   | unbegrenzt |
+| Auto Sync (Notion → Anki)                          | —                  | 30 $/Mo. Add-on | ✓        |
+
+Siehe die [Preisseite](/pricing) für die aktuelle Planliste. Datenschutzdetails — was wir lesen, was nicht — findest du in der [Datenschutzerklärung](/documentation/reference/privacy).
+
+Wenn etwas falsch aussieht, [kontaktiere uns](/documentation/help/contact).

--- a/web/src/pages/DocsPage/content/de/start-here/connect-notion.md
+++ b/web/src/pages/DocsPage/content/de/start-here/connect-notion.md
@@ -1,0 +1,43 @@
+---
+title: Notion in 5 Minuten verbinden
+description: Vom Anmelden bis zum ersten heruntergeladenen Deck.
+---
+
+Das ist der schnellste Weg, deine Notion-Notizen in Anki zu bekommen. Du verbindest dein Notion-Konto einmal, wählst eine Seite, und 2anki baut das Deck. Keine Exporte, keine Zip-Dateien.
+
+<ol class="steps">
+<li>
+
+**Mit Notion anmelden.** Geh zu [2anki.net](https://2anki.net/), klick auf **Sign up with Notion** und gib 2anki Zugriff auf die Seiten, die du konvertieren möchtest. Du kannst bestimmte Seiten statt deines ganzen Workspace wählen — nur was du teilst, ist für 2anki sichtbar.
+
+</li>
+<li>
+
+**Eine Seite wählen.** Wähle auf dem Startbildschirm eine Seite aus der Auswahl. Du kannst nach Titel suchen, und die Auswahl merkt sich deine zuletzt verwendeten Seiten. Seiten mit Toggle-Listen ergeben die saubersten Karten.
+
+</li>
+<li>
+
+**Dein Deck herunterladen.** Klick auf **Convert** bei der gewählten Seite. 2anki liest die Seite, verwandelt Toggles in Karteikarten und gibt dir eine `.apkg`-Datei zum Herunterladen.
+
+</li>
+<li>
+
+**In Anki öffnen.** Doppelklick auf die `.apkg` am Desktop oder öffne sie aus der Dateien-App unter iOS oder Android. Siehe [Öffne dein Deck in Anki](/documentation/start-here/open-in-anki) für Hinweise je Plattform.
+
+</li>
+</ol>
+
+## Was, wenn eine Seite nicht auftaucht?
+
+Ein paar Dinge zum Prüfen:
+
+- **Du hast die Seite nicht mit der 2anki-Integration geteilt.** Öffne die Seite in Notion, klick auf **Share**, dann **Add connections**, und wähle 2anki. Notion zeigt 2anki nur die Seiten, die du ausdrücklich teilst.
+- **Die Seite ist in einem Workspace, mit dem 2anki nicht verbunden ist.** Melde dich ab und wieder an, und wähle dann den richtigen Workspace, wenn Notion fragt.
+- **Die Seite wurde gerade erst erstellt.** Die Auswahl zwischenspeichert Seiten für ein paar Minuten. Aktualisiere die Auswahl oder warte, und versuch es dann erneut.
+
+Wenn eine Seite auftaucht, aber die Konvertierung fehlschlägt, siehe [Häufige Probleme](/documentation/help/common-problems).
+
+## Notion vs. eine Datei hochladen
+
+Notion zu verbinden ist der empfohlene Weg, weil Änderungen in Notion in dein Anki-Deck zurückfließen können — siehe [Wie Sync funktioniert](/documentation/sync/how-it-works). Wenn du lieber ein PDF oder einen Notion-HTML-Export hineinwirfst, siehe [Stattdessen eine Datei hochladen](/documentation/start-here/upload-a-file).

--- a/web/src/pages/DocsPage/content/de/start-here/import-from-anki.md
+++ b/web/src/pages/DocsPage/content/de/start-here/import-from-anki.md
@@ -1,0 +1,42 @@
+---
+title: Ein Anki-Deck in Notion importieren
+description: Verwandle eine .apkg in Notion-Toggle-Seiten — kostenlos bis 1.000 Karten pro Import.
+---
+
+Die Umkehrung von allem anderen, was 2anki macht. Du lädst eine bestehende `.apkg` hoch, und wir bauen die Karten als Toggles innerhalb einer Notion-Seite nach. Nützlich, um ein altes Deck zurück in bearbeitbare Notizen zu holen, oder um jemandem ein Lern-Deck zu geben, der in Notion statt in Anki arbeitet.
+
+**Plan:** Kostenlos bis 1.000 Karten pro Import. Abo und Lifetime bekommen unbegrenzte Importe.
+
+## Wann du das nutzt
+
+- Du hast ein Anki-Deck und willst die Karten als Notion-Inhalt, den du umschreiben kannst.
+- Du gibst ein Lernset an ein Teammitglied oder eine Mitstudierende weiter, die schon in Notion lebt.
+- Du willst ein Deck überarbeiten — Tippfehler beheben, Fragen umschreiben, Vorlagen ändern — und es dann über den normalen 2anki-Weg wieder herausgeben.
+
+Das ist eine einmalige Kopie, kein Live-Sync. Änderungen in Notion nach dem Import fließen nicht in die originale `.apkg` zurück. Für laufenden Sync siehe [Wie Sync funktioniert](/documentation/sync/how-it-works).
+
+## Den Import ausführen
+
+1. Öffne [2anki.net/import](https://2anki.net/import). Wenn du Notion noch nicht verbunden hast, wirst du zuerst dorthin geschickt — siehe [Notion verbinden](/documentation/start-here/connect-notion).
+2. Zieh deine `.apkg` auf den Upload-Bereich, oder klick, um eine auszuwählen. Hier funktionieren nur `.apkg`-Dateien.
+3. Wähle ein Ziel:
+   - **Quick import** erstellt eine neue „2anki Imports“-Seite in deinem Workspace.
+   - **Choose a page** lässt dich den Import unter einer bestehenden Top-Level-Seite verschachteln. Es tauchen nur Seiten auf, die du mit der 2anki-Integration geteilt hast.
+4. Klick auf **Import to selected page** (oder **Quick import**). Die Fortschrittsleiste zeigt Karten, während sie ankommen.
+5. Wenn es fertig ist, klick auf **Open in Notion**, um direkt zur neuen Seite zu springen.
+
+:::tip
+Karten werden zu Toggles — die Vorderseite ist die Toggle-Zusammenfassung, die Rückseite ist der Inhalt darin. Cloze-Karten behalten ihre `{{c1::...}}`-Syntax, damit du sie später erneut importieren kannst.
+:::
+
+## Häufige Fehler
+
+- **Falscher Dateityp.** Die Seite akzeptiert nur `.apkg`. Wenn du eine `.colpkg` (vollständiges Collection-Backup) hast, öffne sie zuerst in Anki und exportiere das gewünschte Deck als `.apkg`.
+- **Deck über dem kostenlosen Limit.** Kostenlos stoppt hart bei 1.000 Karten pro Import. Teile das Deck in Anki (Rechtsklick → **Export** mit einer gefilterten Teilmenge) oder [upgrade](/pricing) für unbegrenzt.
+- **Seite nicht in der Auswahl.** Die Ziel-Auswahl zeigt nur Seiten, auf die die 2anki-Integration Zugriff hat. Öffne die Seite in Notion → **Share** → **Add connections** → wähle **2anki**.
+
+## Verwandt
+
+- [Notion verbinden](/documentation/start-here/connect-notion) — die Workspace-Verbindung, die dieser Weg nutzt
+- [Grenzen und Kontingente](/documentation/help/limits) — was jeder Plan enthält
+- [Preise](/pricing) — upgrade für unbegrenzte Importe

--- a/web/src/pages/DocsPage/content/de/start-here/open-in-anki.md
+++ b/web/src/pages/DocsPage/content/de/start-here/open-in-anki.md
@@ -1,0 +1,64 @@
+---
+title: Öffne dein Deck in Anki
+description: Bring die heruntergeladene .apkg auf jedem Gerät in Anki.
+---
+
+Anki öffnet `.apkg`-Dateien auf jeder Plattform — Desktop, iPhone, iPad, Android und im Web. Der Ablauf unterscheidet sich leicht je Plattform. Wähle deine unten.
+
+**Plan:** Kostenlos (Anki selbst ist auf jeder Plattform außer iOS kostenlos)
+
+## Anki Desktop (Windows, macOS, Linux)
+
+1. Stell sicher, dass Anki installiert ist — [lade es von ankiweb.net](https://apps.ankiweb.net/).
+2. Doppelklick auf die heruntergeladene `.apkg`-Datei. Anki öffnet sich und importiert sie.
+3. Das neue Deck erscheint in deiner Deckliste, bereit zum Lernen.
+
+Wenn der Doppelklick nicht funktioniert, öffne Anki und nutze **File → Import**, und wähle dann die `.apkg`.
+
+## AnkiMobile (iPhone, iPad)
+
+AnkiMobile ist eine kostenpflichtige App vom offiziellen Anki-Team — der direkte Kauf finanziert die Entwicklung von Anki.
+
+1. Speichere die `.apkg` in der Dateien-App (z. B. per AirDrop, Mail oder iCloud Drive).
+2. Öffne Dateien, tippe auf die `.apkg`, und wähle **Open in AnkiMobile**.
+3. Bestätige den Import. Das Deck erscheint in deiner Deckliste.
+
+Wenn die Datei stattdessen in einer Vorschau-App öffnet, nutze die **Share**-Schaltfläche und wähle AnkiMobile aus der Liste.
+
+## AnkiDroid (Android)
+
+AnkiDroid ist kostenlos bei Google Play.
+
+1. Speichere die `.apkg` auf deinem Telefon — der direkte Download aus Chrome oder Firefox funktioniert.
+2. Öffne die Datei aus deinen Benachrichtigungen oder der Dateien-App.
+3. Wähle **AnkiDroid**, wenn Android fragt, wie es geöffnet werden soll. Das Deck wird automatisch importiert.
+
+## AnkiWeb
+
+AnkiWeb ist der offizielle Sync-Dienst. Du kannst im Browser lernen, aber er wird hauptsächlich genutzt, um Desktop und Mobil synchron zu halten.
+
+1. Melde dich unter [ankiweb.net](https://ankiweb.net/) an.
+2. AnkiWeb selbst importiert `.apkg`-Dateien nicht direkt — importiere am Desktop oder Mobil, und lass Anki das Deck dann zu AnkiWeb hochsynchronisieren.
+
+## Ein bestehendes Deck aktualisieren
+
+Wenn du dieselbe Notion-Seite oder Datei erneut konvertierst, hält 2anki die Karten-IDs stabil. Der erneute Import der neuen `.apkg` aktualisiert bestehende Karten an Ort und Stelle — dein Lernverlauf bleibt erhalten, du bekommst keine Duplikate.
+
+:::note
+Beim ersten erneuten Import eines Decks nach dieser Änderung zeigt Anki seinen eingebauten „Duplicate“-Dialog, weil die Karten-IDs auf ein neues stabiles Format umgestellt wurden. Wähle **Keep existing** — dein Lernverlauf bleibt erhalten, und künftige erneute Importe aktualisieren stillschweigend.
+:::
+
+Für Notion-Seiten, bei denen Aktualisierungen automatisch fließen sollen, ohne erneut hochzuladen, nutze stattdessen [Sync](/documentation/sync/how-it-works).
+
+### Warum Duplikate nach dem Umstrukturieren von Toggles auftauchen
+
+Die Karten-ID ist an die Notion-Block-ID des Toggles verankert. Notion behält diese Block-ID bei manchen Änderungen bei und ersetzt sie bei anderen:
+
+- **Den Text innerhalb eines Toggles bearbeiten** behält dieselbe Block-ID → der erneute Import aktualisiert die bestehende Karte an Ort und Stelle.
+- **Ein Toggle ausschneiden und anderswo einfügen** vergibt eine neue Block-ID → der erneute Import erstellt eine neue Karte neben der alten.
+- **Ein Toggle duplizieren** (per Rechtsklick → Duplicate oder ⌘D) vergibt der Kopie eine neue Block-ID → beide Karten erscheinen nach dem erneuten Import.
+- **Ein Toggle per Ziehen verschieben** innerhalb derselben Seite behält meist die Block-ID; seitenübergreifendes Verschieben nicht.
+
+Wenn du erneut importierst und Duplikat-Karten siehst, ist die wahrscheinlichste Ursache ein Ausschneiden-und-Einfügen oder Duplizieren-und-Bearbeiten während des Bearbeitungsdurchgangs.
+
+**Ablauf, der Duplikate vermeidet:** bearbeite Toggle-Text an Ort und Stelle. Strukturiere die Seite vor der ersten Konvertierung um, wenn du kannst — sobald ein Deck in Anki live ist, behandle das Toggle-Layout als Anker und ändere die Inhalte, nicht die Positionen.

--- a/web/src/pages/DocsPage/content/de/start-here/share-a-deck.md
+++ b/web/src/pages/DocsPage/content/de/start-here/share-a-deck.md
@@ -1,0 +1,27 @@
+---
+title: Ein Deck per Link teilen
+description: Verwandle jedes konvertierte Deck in einen Link, den jeder öffnen kann — kein Konto nötig.
+---
+
+Öffne ein konvertiertes Deck in der **Deck-Vorschau** und klick oben rechts auf **Share**.
+
+2anki erzeugt einen nicht erratbaren Link. Jeder, der den Link hat, kann:
+
+- Alle Karten im Browser als Vorschau ansehen
+- Die `.apkg` herunterladen, um sie in Anki zu importieren
+
+Sie können das Deck nicht bearbeiten und brauchen kein 2anki-Konto.
+
+## Teilen beenden
+
+Öffne die Vorschauseite, klick auf **Share**, dann **Stop sharing**. Der Link funktioniert sofort nicht mehr. Du kannst jederzeit einen neuen Link erstellen.
+
+## Datenschutz
+
+Der Teilen-Link wird nicht von Suchmaschinen indexiert und erscheint nicht auf 2anki.net. Nur Leute, denen du den Link schickst, können ihn erreichen.
+
+Sei vorsichtig bei Decks mit persönlichen Notizen — jeder mit dem Link kann die Karten lesen.
+
+## Downloads-Seite
+
+Decks mit einem aktiven Link zeigen ein **Shared**-Abzeichen in deiner Downloads-Liste.

--- a/web/src/pages/DocsPage/content/de/start-here/upload-a-file.md
+++ b/web/src/pages/DocsPage/content/de/start-here/upload-a-file.md
@@ -1,0 +1,75 @@
+---
+title: Stattdessen eine Datei hochladen
+description: Für PDFs, Folien, Tabellen oder einen Notion-HTML-Export.
+---
+
+<figure>
+  <iframe
+    src="https://www.youtube.com/embed/y3Fcx-WGWnA"
+    title="2anki — make Anki cards from your Notion toggles in 30 seconds"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen
+    width="100%"
+    style="aspect-ratio: 16 / 9; border: 0; border-radius: var(--radius-md);"
+  ></iframe>
+</figure>
+
+Der Upload funktioniert ohne Konto. Du wirfst eine Datei hinein, 2anki baut das Deck, und du lädst eine `.apkg` herunter. Gut für einmalige Konvertierungen oder Quellen, die nicht in Notion liegen.
+
+Ohne Konto ist jede Konvertierung auf 21 Karten begrenzt. Registriere ein kostenloses Konto, um 100 Karten pro Monat über alle Konvertierungswege zu bekommen. Siehe [Grenzen und Kontingente](/documentation/help/limits).
+
+**Plan:** Kostenlos (anonym, keine Anmeldung nötig)
+
+## Wann Upload statt Notion verbinden
+
+Lade hoch, wenn:
+
+- Die Quelle ein PDF, eine Foliensammlung, eine Tabelle, eine CSV oder eine Markdown-Datei ist.
+- Du keinen Notion-Workspace hast oder die Seite nicht in Notion liegt.
+- Du eine schnelle Einmal-Konvertierung willst und keine künftigen Änderungen ins Deck fließen sollen.
+
+Nutze [Notion verbinden](/documentation/start-here/connect-notion), wenn die Quelle eine Notion-Seite ist und das Deck sich beim Bearbeiten aktualisieren soll.
+
+## Eine Datei hineinwerfen
+
+1. Geh zu [2anki.net/upload](https://2anki.net/upload).
+2. Zieh deine Datei auf den Ablagebereich, oder klick, um eine auszuwählen.
+3. Öffne das Einstellungspanel, wenn du Kartenoptionen ändern möchtest. Die Standardwerte sind für die erste Nutzung abgestimmt — siehe [Kartenoptionen](/documentation/cards/card-options) für die Bedeutung jeder Option.
+4. Klick auf **Convert**. Wenn es fertig ist, klick auf **Download**, um die `.apkg` zu holen.
+5. Öffne die Datei in Anki — siehe [Öffne dein Deck in Anki](/documentation/start-here/open-in-anki).
+
+## Von Dropbox oder Google Drive hochladen
+
+Wenn deine Datei in einem Cloud-Speicher liegt, musst du sie nicht erst herunterladen.
+
+- **Dropbox** — klick auf **Choose from Dropbox** im Upload-Bildschirm, melde dich einmal an, und wähle die Datei. Die Auswahl unterstützt dieselben Formate wie der reguläre Upload.
+- **Google Drive** — klick auf **Choose from Google Drive**. Du kannst jede Datei wählen, die 2anki akzeptiert, plus native Google Docs, Sheets und Slides. Native Google-Dateien werden zuerst in eine Aufzählungs-Gliederung umgewandelt — siehe [Häufige Probleme](/documentation/help/common-problems#my-google-doc-converted-to-0-cards) für die Struktur, die Karten erzeugt.
+
+Beide Schaltflächen sind nur sichtbar, wenn die Integration für die Seite, auf der du bist, konfiguriert ist. Wenn du sie nicht siehst, zieh die Datei stattdessen von deinem Computer hinein.
+
+:::tip
+Toggle-Listen ergeben die saubersten Karten. Wenn deine Quelle einfacher Fließtext ist, funktioniert die Konvertierung trotzdem, aber du bekommst bessere Ergebnisse aus einer Struktur, in der jede Karte ein Toggle, ein Aufzählungspaar oder eine Zeile ist.
+:::
+
+## Unterstützte Typen
+
+Die vollständige Tabelle der Formate und Grenzen findest du unter [Dateiformate](/documentation/reference/file-formats). Kurzfassung:
+
+- **Notion-HTML-Export** (`.zip`) — das `.zip`, das Notion dir gibt, wenn du mit „HTML“ + „Include subpages“ exportierst.
+- **HTML** — eine einzelne `.html`-Datei oder ein Ordner davon.
+- **Markdown** — `.md`, einschließlich Obsidian-Vaults.
+- **CSV / XLSX** — eine Zeile pro Karte.
+- **PDF** — Vorder-/Rückseite pro Seitenpaar, oder KI-generierte Fragen im kostenpflichtigen Plan.
+- **PPT / PPTX** — konvertiert über Folien zu PDF zu Bildern.
+
+Wirf das falsche Format hinein, und 2anki sagt es dir. Die Fehlermeldung nennt die unterstützten Typen, damit du nicht raten musst.
+
+## Was mit deiner Datei passiert
+
+Wir brauchen die Datei nur so lange, um sie zu konvertieren. Danach:
+
+- **Anonyme und kostenlose Konto-Uploads** — die temporären Arbeitsdateien werden innerhalb von zwei Stunden gelöscht. Die `.apkg` wird direkt als Antwort zurückgeschickt, wir behalten also keine Kopie.
+- **Claude-KI-Uploads und Notion-Konvertierungen** werden in deinem Konto gespeichert, damit du sie unter **My Decks** erneut herunterladen kannst. Kostenlose Konten: innerhalb von 24 Stunden entfernt. Abo: behalten, solange dein Abo aktiv ist. Lifetime: unbegrenzt behalten.
+- Wir lesen deine Inhalte aus keinem anderen Grund als dem Bau deines Decks. Wir trainieren keine Modelle damit.
+
+Die ganze Geschichte findest du in der [Datenschutzerklärung](/documentation/reference/privacy). Die harten Zahlen stehen unter [Grenzen und Kontingente](/documentation/help/limits).

--- a/web/src/pages/DocsPage/content/de/start-here/what-is-2anki.md
+++ b/web/src/pages/DocsPage/content/de/start-here/what-is-2anki.md
@@ -1,0 +1,43 @@
+---
+title: Was ist 2anki?
+description: 2anki verwandelt deine Notion-Seiten und Lerndateien in Anki-Decks.
+---
+
+2anki ist ein Werkzeug, das dein Lernmaterial in Anki-Karteikarten verwandelt. Wirf eine Notion-Seite, ein PDF oder eine Markdown-Datei hinein, und du bekommst ein `.apkg`-Deck zurück, das bereit zum Import ist.
+
+Du brauchst kein Konto, um es auszuprobieren. Du musst nicht wissen, wie Anki-Vorlagen funktionieren. Die Standardeinstellungen zielen auf eine Sache: ein sauberes Deck beim ersten Versuch.
+
+## Was du hineinwerfen kannst
+
+- Eine Seite aus deinem Notion-Workspace.
+- Ein PDF, eine Foliensammlung, eine Tabelle oder eine CSV.
+- Eine Markdown-Datei oder ein Obsidian-Vault.
+- Einen Notion-HTML-Export (das `.zip`, das Notion dir gibt).
+
+Die vollständige Liste mit Grenzen und Eigenheiten findest du unter [Dateiformate](/documentation/reference/file-formats).
+
+## Was du zurückbekommst
+
+Eine standardmäßige Anki-`.apkg`-Datei. Öffne sie auf Anki Desktop, AnkiMobile, AnkiDroid oder AnkiWeb — siehe [Öffne dein Deck in Anki](/documentation/start-here/open-in-anki).
+
+2anki funktioniert in jedem Browser, und es gibt eine native App für iPhone, iPad und Mac — kostenlos im App Store, mit Dateien, die direkt auf dem Gerät verarbeitet werden. Siehe [2anki für iPhone, iPad und Mac](/app).
+
+Im Deck:
+
+- Eine Karte pro Toggle (oder pro Aufzählungspaar, oder pro CSV-Zeile).
+- Drei Kartenformen: Basic, Cloze und Tippeingabe. Siehe [Kartentypen](/documentation/cards/card-types).
+- Bilder, Audio und andere Elemente sind eingebunden.
+
+## Drei Wege, es zu nutzen
+
+**Notion verbinden.** Melde dich mit Notion an, wähle eine Seite, erhalte ein Deck. Der empfohlene Weg für Inhalte, die in Notion liegen. Führe die Konvertierung erneut aus, wenn sich deine Notizen ändern, um das Deck zu aktualisieren. Anleitung: [Notion in 5 Minuten verbinden](/documentation/start-here/connect-notion).
+
+**Datei hochladen.** Kein Konto nötig. Gut für PDFs, Foliensammlungen, Markdown-Vaults oder eine einmalige CSV. Anleitung: [Stattdessen eine Datei hochladen](/documentation/start-here/upload-a-file).
+
+**Auto Sync.** Kostenpflichtig. Verbinde Notion einmal, und 2anki prüft deine Seiten alle 5 Minuten — Änderungen in Notion fließen automatisch in einen gehosteten Anki-Container, ohne manuellen Re-Export. Nutze das, wenn du täglich lernst und deine Notizen zwischen den Sitzungen aktualisierst. Anleitung: [Wie Sync funktioniert](/documentation/sync/how-it-works).
+
+## Kostenlos und kostenpflichtig
+
+**Kostenlos:** 100 Karten pro Monat über alle Konvertierungswege hinweg, Datei-Uploads bis 100 MB und PDFs bis 100 Seiten. Der Notion-verbinden-Weg funktioniert auch kostenlos mit einem 2anki-Konto. Ohne Konto ist jede Konvertierung auf 21 Karten begrenzt.
+
+**Kostenpflichtig:** größere Uploads, mehr PDF-Seiten, KI-Kartengenerierung und (für Lifetime-Unterstützer) beidseitigen Notion-Sync. Siehe die [Preisseite](/pricing) und [Grenzen und Kontingente](/documentation/help/limits) für die Zahlen.

--- a/web/src/pages/DocsPage/content/de/sync/how-it-works.md
+++ b/web/src/pages/DocsPage/content/de/sync/how-it-works.md
@@ -1,0 +1,37 @@
+---
+title: Wie Sync funktioniert
+description: Bearbeite eine Notion-Seite, erhalte das aktualisierte Deck — ohne erneutes Hochladen.
+---
+
+Sync beobachtet die Notion-Seiten, die du abonniert hast, und hält ein passendes Deck in Anki aktuell. Wenn du eine Seite in Notion bearbeitest, greift der nächste Sync-Lauf die Änderungen auf und aktualisiert das Deck — gleicher Deckname, gleiche Karten-IDs, kein Re-Import-Drama.
+
+## Was Sync macht
+
+- Beobachtet die Notion-Seiten, die du für Sync markierst.
+- Hält ein Anki-Deck pro Notion-Seite, mit Unterdecks für verschachtelte Unterseiten.
+- Aktualisiert bestehende Karten an Ort und Stelle, wenn sich ihre Notion-Quelle ändert — dein Lernverlauf bleibt erhalten.
+- Fügt neue Karten hinzu, wenn du Toggles in Notion hinzufügst. Entfernt Karten, wenn du die Quelle löschst.
+
+## Sync auf einer Seite einrichten
+
+Das machst du im **Auto Sync**-Bereich auf 2anki.net:
+
+1. Verbinde Notion (falls noch nicht geschehen — siehe [Notion in 5 Minuten verbinden](/documentation/start-here/connect-notion)).
+2. Öffne das **Auto Sync**-Dashboard und wähle eine Notion-Seite zum Abonnieren.
+3. Bestätige den Decknamen. Das Deck wird beim ersten Sync-Lauf erstellt.
+4. Öffne Anki auf dem Gerät, das das synchronisierte Deck halten soll, und lass 2anki über AnkiConnect verbinden.
+
+## Wie Aktualisierungen fließen
+
+```
+Notion page  →  2anki sync   →  AnkiConnect (your Anki)
+   edit            (poll)            update card
+```
+
+Ein Hintergrund-Job fragt deine abonnierten Seiten ab, vergleicht sie mit dem bereits Synchronisierten und schickt nur die Änderungen an Anki. Reviews und Planungsstatus bleiben erhalten, weil die Karten-IDs über Läufe hinweg stabil sind.
+
+## Zugang zu Auto Sync bekommen
+
+Auto Sync wird gerade nicht als eigenständiger Plan verkauft — nicht genug Leute nutzten es, um es auf der Preisseite zu halten. Es ist in einem Lifetime-Konto enthalten. Bei jedem anderen Plan schreib eine E-Mail an [support@2anki.net](mailto:support@2anki.net), und wir schalten es für dein Konto frei, damit du es ausprobieren kannst. Die Konvertierungsfunktionen, die es heute gibt — Notion verbinden + Deck herunterladen, plus Datei-Uploads — bleiben kostenlos.
+
+Siehe die [Preisseite](/pricing) für aktuelle Pläne, und [Wenn Sync hängen bleibt](/documentation/sync/troubleshooting), falls ein Sync nicht läuft.

--- a/web/src/pages/DocsPage/content/de/sync/review-cards.md
+++ b/web/src/pages/DocsPage/content/de/sync/review-cards.md
@@ -1,0 +1,32 @@
+---
+title: Lerne deine synchronisierten Decks im Browser
+description: Wähle ein synchronisiertes Deck auf der Ankify-Seite und bewerte seine fälligen Karten, ohne Anki zu öffnen.
+---
+
+Der Review-Tab lässt dich die fälligen Karten deiner synchronisierten Decks direkt in 2anki lernen — auf einem Handy, einem geliehenen Laptop, überall dort, wo dein gehostetes Anki läuft. Kein Desktop-Fenster zum Starten.
+
+**Plan:** Verfügbar für Auto-Sync-Abonnenten und Lifetime-Mitglieder. Der Review-Tab sitzt neben Decks, Find pages und Leeches auf der Ankify-Seite.
+
+## Wie eine Sitzung abläuft
+
+1. Öffne den **Review**-Tab. Jedes synchronisierte Deck zeigt seine Zähler für fällig, lernend und neu.
+2. Wähle ein Deck und wähle **Review**. Decks ohne Fälliges sind abgedunkelt.
+3. Die Kartenvorderseite erscheint zuerst. Wähle **Show answer** (oder drück Leertaste), um die Rückseite aufzudecken.
+4. Bewerte die Karte — **Again**, **Hard**, **Good** oder **Easy** (Tasten 1 bis 4). Die Bewertung plant die Karte in Anki genau so, wie es die Desktop-App tun würde.
+5. Die nächste Karte erscheint. Ein Zähler oben verfolgt deinen Fortschritt durch die Sitzung.
+6. Wenn die Warteschlange leer ist, siehst du eine Fertig-Zusammenfassung, und deine Lernserie rückt vor.
+
+## Eine Fehlbewertung rückgängig machen
+
+Falsche Schaltfläche getippt? Wähle **Undo last grade**, um die vorherige Karte zurückzuholen und sie erneut zu bewerten.
+
+## Tastenkürzel
+
+- **Leertaste** — die Antwort aufdecken, dann weiter.
+- **1 / 2 / 3 / 4** — bewerte Again / Hard / Good / Easy, sobald die Antwort angezeigt wird.
+
+## Wenn die Warteschlange nicht lädt
+
+Karten werden live aus deinem gehosteten Anki gelesen, wenn du eine Sitzung startest. Wenn der Container offline ist, siehst du „Anki isn't connected“. Öffne die Anki-App auf diesem Computer, und versuch es dann erneut. Bewertungen gelten immer nur für Decks, die 2anki für dich synchronisiert hat.
+
+Wenn ein Zähler nach einer Sitzung falsch aussieht, siehe [Wenn Sync hängen bleibt](/documentation/sync/troubleshooting).

--- a/web/src/pages/DocsPage/content/de/sync/review-export.md
+++ b/web/src/pages/DocsPage/content/de/sync/review-export.md
@@ -1,0 +1,50 @@
+---
+title: Schick deine Reviews zurück nach Notion
+description: Übertrage, wie oft du jede Karte richtig hattest, zurück in deine Notion-Datenbank.
+---
+
+Der Review-Export schreibt deinen Anki-Lernverlauf in eine Notion-Datenbank. Nach einer Lernsitzung aktualisiert sich die Zeile jeder Karte mit dem Datum, an dem du gelernt hast, und mit der Anzahl der Reviews — direkt neben deinen Notizen in Notion sichtbar.
+
+**Plan:** Verfügbar für Auto-Sync-Abonnenten und Lifetime-Mitglieder. Die Funktion lebt im Ankify-Dashboard.
+
+## Was du in Notion siehst
+
+Jede Karte, die 2anki ursprünglich aus deiner Notion-Seite gemacht hat, ordnet sich einer Zeile in der von dir gewählten Datenbank zu. Nach einem Sync-Lauf aktualisieren sich zwei Eigenschaften:
+
+- **Date** — wann du die Karte zuletzt gelernt hast.
+- **Reviews** — wie oft du die Karte insgesamt gelernt hast.
+
+Notion bleibt deine Quelle der Wahrheit für Frage und Antwort. 2anki schreibt nur diese zwei Zahlen — es rührt deinen Karteninhalt nie an.
+
+## Einschalten
+
+1. Stell sicher, dass die Quellseite schon über Auto Sync synchronisiert — siehe [Wie Sync funktioniert](/documentation/sync/how-it-works).
+2. Wähle eine Ziel-Datenbank. Du hast zwei Optionen:
+   - Nutze eine bestehende Datenbank, die bereits die richtige Struktur hat (eine **Date**-Eigenschaft vom Typ Date und eine **Reviews**-Eigenschaft vom Typ Number).
+   - Lass 2anki eine frische Datenbank für dich aus dem Ankify-Dashboard erstellen. Sie kommt mit der richtigen Struktur vorkonfiguriert.
+3. Öffne im Ankify-Dashboard die Einstellungen der Seite und schalte **Export reviews to Notion** ein.
+4. Wähle die Ziel-Datenbank.
+5. Nach deiner nächsten Anki-Lernsitzung füllen sich die Datenbankzeilen im nächsten Sync-Zyklus.
+
+## Erforderliche Notion-Eigenschaften
+
+Die Datenbank braucht diese Eigenschaften. Die Namen müssen genau übereinstimmen. Typen in Klammern.
+
+| Property | Type   |
+| -------- | ------ |
+| Date     | Date   |
+| Reviews  | Number |
+
+Du kannst auch andere Eigenschaften in der Datenbank haben — 2anki schreibt nur die zwei oben. Das Ankify-Dashboard zeigt einen grünen Haken neben Datenbanken, die bereits die richtige Struktur haben, damit du eine auswählen kannst, ohne zu raten.
+
+:::warning
+Wenn eine Eigenschaft fehlt oder den falschen Typ hat, überspringt der Sync diese Zeile stillschweigend. Das Lauf-Protokoll im Ankify-Dashboard zeigt, welche Zeilen aktualisiert wurden und welche nicht.
+:::
+
+## Grenzen
+
+- Der Review-Export läuft im selben Fünf-Minuten-Takt wie Sync. Er ist nicht in Echtzeit.
+- Nur Karten, die 2anki ursprünglich aus dieser Notion-Seite erstellt hat, werden verfolgt. Karten, die du von Hand in Anki hinzugefügt hast, passen nicht zurück.
+- Wenn du die Notion-Zeile löschst, bleibt die passende Anki-Karte — Anki ist die Quelle der Wahrheit für das, was du lernst, Notion ist die Quelle der Wahrheit für das, was du geschrieben hast.
+
+Wenn eine Zeile sich nicht aktualisiert, siehe [Wenn Sync hängen bleibt](/documentation/sync/troubleshooting).

--- a/web/src/pages/DocsPage/content/de/sync/study-stats.md
+++ b/web/src/pages/DocsPage/content/de/sync/study-stats.md
@@ -1,0 +1,24 @@
+---
+title: Sieh deine Lernstatistik auf der Ankify-Seite
+description: Deine Lernserie, der heutige Zähler und der Rückstand je Deck erscheinen live auf dem Ankify-Dashboard.
+---
+
+Das Ankify-Dashboard zeigt Live-Lernstatistiken, direkt aus deinem gehosteten Anki gezogen. Du siehst sie, ohne Anki selbst zu öffnen.
+
+**Plan:** Verfügbar für Auto-Sync-Abonnenten und Lifetime-Mitglieder. Die Statistiken leben auf dem Ankify-Dashboard, zwischen dem Konflikte-Banner und deinen synchronisierten Seiten.
+
+## Was du siehst
+
+- **Reviewed today** — Karten, die du seit deinem Anki-Tageswechsel gelernt hast.
+- **Day streak** — aufeinanderfolgende Tage mit mindestens einem Review. Ein Tag ohne bisherige Reviews hält die gestrige Serie am Leben, bis der Tag endet.
+- **Reviewed this year** — insgesamt in den letzten 12 Monaten gelernte Karten.
+- **Review-Heatmap** — eine Zelle pro Tag für das letzte Jahr, schattiert danach, wie viele Karten du an diesem Tag gelernt hast. Fahr über eine Zelle für die genaue Anzahl und das Datum.
+- **By deck** — ein gestapelter Balken pro synchronisiertem Deck, der die auf dich wartenden neuen, lernenden und Review-Karten zeigt.
+
+## Wenn Statistiken nicht erscheinen
+
+Statistiken werden bei jedem Laden der Seite live aus deinem gehosteten Anki gelesen. Wenn der Container offline ist, bleibt der Abschnitt ruhig und sagt dir, dass er lädt, sobald Anki wieder verbindet — meist innerhalb weniger Minuten. Nichts geht verloren; aktualisiere, sobald es zurück ist.
+
+Nur Decks, die 2anki für dich synchronisiert hat, erscheinen im Balken je Deck. Decks, die du von Hand in Anki erstellt hast, werden hier nicht verfolgt.
+
+Wenn ein Deck oder Zähler nach einer Lernsitzung falsch aussieht, siehe [Wenn Sync hängen bleibt](/documentation/sync/troubleshooting).

--- a/web/src/pages/DocsPage/content/de/sync/troubleshooting.md
+++ b/web/src/pages/DocsPage/content/de/sync/troubleshooting.md
@@ -1,0 +1,46 @@
+---
+title: Wenn Sync hängen bleibt
+description: Drei Dinge, die du versuchen kannst, wenn dein Deck sich nicht aktualisiert.
+---
+
+Sync läuft alle fünf Minuten im Hintergrund. Meistens bemerkst du ihn nicht. Wenn er doch hängen bleibt, ist es fast immer eines der drei Dinge unten.
+
+**Plan:** Lifetime (Sync ist durch denselben Zugang gesteuert wie [Wie Sync funktioniert](/documentation/sync/how-it-works))
+
+## Seite wurde nicht synchronisiert
+
+Du hast eine Notion-Seite bearbeitet. Das Deck in Anki hat sich nicht aktualisiert. Versuch, der Reihe nach:
+
+1. **Warte fünf Minuten.** Sync fragt in einem Fünf-Minuten-Takt ab, um innerhalb der Rate-Limits von Notions kostenlosem Tarif zu bleiben. Wenn du gerade erst bearbeitet hast, ist er vielleicht noch nicht gelaufen.
+2. **Öffne das Ankify-Dashboard.** Jede abonnierte Seite zeigt die letzte Laufzeit und einen etwaigen Fehler aus diesem Lauf. Wenn du einen Fehler siehst, zeigt er meist direkt auf die Ursache.
+3. **Prüfe, ob die Seite noch mit der 2anki-Integration geteilt ist.** Notion verliert die Verbindung manchmal nach einer Workspace-Änderung. Öffne die Seite in Notion, klick auf **Share → Add connections**, und füge 2anki erneut hinzu.
+4. **Prüfe, ob Anki geöffnet ist und AnkiConnect läuft.** Sync schreibt über AnkiConnect nach Anki — wenn Anki nicht auf dem Gerät geöffnet ist, das das Deck hält, wird der Lauf auf unserer Seite abgeschlossen, aber das Deck ändert sich nicht.
+
+Wenn das Dashboard zeigt, dass Läufe erfolgreich sind, das Deck sich aber trotzdem nicht aktualisiert, ist es fast immer AnkiConnect. Starte Anki neu, und löse dann einen manuellen Sync aus dem Dashboard aus.
+
+## Anki zeigt einen „Duplicate“-Dialog beim erneuten Import
+
+Beim ersten erneuten Import eines bestehenden Decks nach dieser Änderung stellen sich die Karten-IDs auf ein neues stabiles Format um. Ankis eingebauter „Duplicate“-Dialog erscheint einmal — wähle **Keep existing**. Deine Reviews bleiben erhalten, und künftige erneute Importe aktualisieren stillschweigend ohne Nachfrage.
+
+## Ich sehe ein echtes Duplikat-Deck
+
+Wenn zwei Kopien derselben Karten in Anki existieren, wurde die ältere Kopie vor der ID-Änderung importiert. Lösche das ältere Deck in Anki — behalte das mit deinem Lernverlauf. Künftige erneute Importe derselben Quelle aktualisieren das verbleibende Deck an Ort und Stelle.
+
+Wenn beide Decks einen Lernverlauf haben, der dir wichtig ist, [kontaktiere uns](/documentation/help/contact), bevor du eines löschst — wir können manchmal zusammenführen.
+
+## Ich habe den Zugriff versehentlich entzogen
+
+Wenn du 2anki aus deinem Notion-Workspace entfernt hast, stoppt Sync und das Dashboard zeigt einen Authentifizierungsfehler. Zum Wiederherstellen:
+
+1. Geh zu [2anki.net](https://2anki.net/) und melde dich erneut mit Notion an.
+2. Teile die Seiten, die du synchronisieren willst, erneut — öffne jede in Notion, klick auf **Share → Add connections**, und wähle 2anki.
+3. Bestehende Abonnements setzen beim nächsten Lauf wieder ein. Du musst nicht erneut abonnieren.
+
+Dein Kartenverlauf geht nicht verloren. Das Dashboard merkt sich, welche Notion-Seiten welchen Anki-Decks zugeordnet waren.
+
+## Immer noch hängen?
+
+Wenn nichts davon geholfen hat:
+
+- Sieh in [Häufige Probleme](/documentation/help/common-problems) für jede Fehlermeldung, die du siehst.
+- [Kontaktiere uns](/documentation/help/contact) — nenne den Namen der Notion-Seite, den Zeitstempel des Ankify-Laufs und die Fehlermeldung aus dem Dashboard.

--- a/web/src/pages/DocsPage/loader.test.ts
+++ b/web/src/pages/DocsPage/loader.test.ts
@@ -32,6 +32,30 @@ describe('loadDoc', () => {
   it('returns null for an unmapped slug', () => {
     expect(loadDoc('does/not/exist')).toBeNull();
   });
+
+  it('serves the German doc when language is de and a translation exists', () => {
+    const doc = loadDoc('start-here/what-is-2anki', 'de');
+    expect(doc).not.toBeNull();
+    expect(doc?.frontmatter.title).toBe('Was ist 2anki?');
+    expect(doc?.sourcePath).toBe(
+      'web/src/pages/DocsPage/content/de/start-here/what-is-2anki.md'
+    );
+  });
+
+  it('falls back to English when no German translation exists', () => {
+    const german = loadDoc('reference/glossary', 'de');
+    const english = loadDoc('reference/glossary');
+    expect(german).not.toBeNull();
+    expect(german).toEqual(english);
+    expect(german?.sourcePath).toBe(
+      'web/src/pages/DocsPage/content/reference/glossary.md'
+    );
+  });
+
+  it('resolves a redirect slug to the German translation of its target', () => {
+    const doc = loadDoc('guides/introduction', 'de');
+    expect(doc?.frontmatter.title).toBe('Was ist 2anki?');
+  });
 });
 
 describe('hasDoc', () => {

--- a/web/src/pages/DocsPage/loader.ts
+++ b/web/src/pages/DocsPage/loader.ts
@@ -1,6 +1,15 @@
 import { redirects } from './sidebar';
 
-const modules = import.meta.glob('./content/**/*.{md,mdx}', {
+const modules = import.meta.glob(
+  ['./content/**/*.{md,mdx}', '!./content/de/**'],
+  {
+    query: '?raw',
+    import: 'default',
+    eager: true,
+  }
+) as Record<string, string>;
+
+const germanModules = import.meta.glob('./content/de/**/*.{md,mdx}', {
   query: '?raw',
   import: 'default',
   eager: true,
@@ -103,8 +112,7 @@ function rewriteAssetPaths(body: string): string {
   return body.replaceAll(ASSET_PATH, '](/docs-assets/$1)');
 }
 
-function slugFromPath(path: string): string {
-  const prefix = './content/';
+function slugFromPath(path: string, prefix: string): string {
   const start = path.startsWith(prefix) ? prefix.length : 0;
   let end = path.length;
   if (path.endsWith('.mdx')) end -= 4;
@@ -114,25 +122,37 @@ function slugFromPath(path: string): string {
 
 const SOURCE_ROOT = 'web/src/pages/DocsPage/';
 
-const docs: Record<string, LoadedDoc> = {};
-for (const [path, raw] of Object.entries(modules)) {
-  const slug = slugFromPath(path);
-  const relPath = path.startsWith('./') ? path.slice(2) : path;
-  const sourcePath = `${SOURCE_ROOT}${relPath}`;
-  const parsed = parseFrontmatter(raw, sourcePath);
-  docs[slug] = {
-    frontmatter: parsed.frontmatter,
-    body: rewriteAssetPaths(parsed.body),
-    sourcePath,
-  };
+function buildDocs(
+  entries: Record<string, string>,
+  prefix: string
+): Record<string, LoadedDoc> {
+  const result: Record<string, LoadedDoc> = {};
+  for (const [path, raw] of Object.entries(entries)) {
+    const slug = slugFromPath(path, prefix);
+    const relPath = path.startsWith('./') ? path.slice(2) : path;
+    const sourcePath = `${SOURCE_ROOT}${relPath}`;
+    const parsed = parseFrontmatter(raw, sourcePath);
+    result[slug] = {
+      frontmatter: parsed.frontmatter,
+      body: rewriteAssetPaths(parsed.body),
+      sourcePath,
+    };
+  }
+  return result;
 }
+
+const docs = buildDocs(modules, './content/');
+const germanDocs = buildDocs(germanModules, './content/de/');
 
 export function resolveSlug(slug: string): string {
   return Object.hasOwn(redirects, slug) ? redirects[slug] : slug;
 }
 
-export function loadDoc(slug: string): LoadedDoc | null {
+export function loadDoc(slug: string, language?: string): LoadedDoc | null {
   const resolved = resolveSlug(slug);
+  if (language === 'de' && Object.hasOwn(germanDocs, resolved)) {
+    return germanDocs[resolved];
+  }
   return docs[resolved] ?? null;
 }
 

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-16-german-docs.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-16-german-docs.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-16-german-docs",
+  "date": "2026-07-16",
+  "type": "feature",
+  "title": "Documentation now available in German, with English fallback"
+}


### PR DESCRIPTION
## What
Adds German to the `/docs` documentation site as a content track. The loader now serves a German version of a doc when the active language is `de`, falling back to the English original per-file when no German version exists — so partial coverage never shows a broken or empty page. Ships German translations for the getting-started, sync, and help core (15 docs).

## Why
The docs were English-only while the rest of the app is being localized to German. German learners hitting `/documentation` got English regardless of their language choice. This is an acquisition-facing change: German-language docs lower first-conversion friction for the German cohort.

## How — loading mechanism found
`web/src/pages/DocsPage/loader.ts` loads every markdown doc eagerly via Vite `import.meta.glob('./content/**/*.{md,mdx}', { query: '?raw', import: 'default', eager: true })`, parses front-matter with a hand-rolled parser, and keys each doc by a slug derived from its path (`./content/<slug>.md`). `DocContent.tsx` calls `loadDoc(slug)`; `search.ts` builds its index from `getAllDocs()`. The active language is read on the client via i18next (`i18n.resolvedLanguage` → `'en'`/`'de'`), exposed through `web/src/lib/i18n/index.ts`.

## Fallback design
- The English glob now **excludes** `./content/de/**` via a negative pattern, so German files never pollute the English slug space or the search index.
- A second glob loads `./content/de/**` into a separate `germanDocs` map, keyed by the same slug (with the `de/` prefix stripped) — so `content/de/start-here/what-is-2anki.md` overlays the English `start-here/what-is-2anki`.
- `loadDoc(slug, language?)` returns the German doc only when `language === 'de'` **and** a German file exists for the resolved slug; otherwise it returns the English doc. Fallback is per-file, so any untranslated doc degrades gracefully to English.
- `DocContent` reads `i18n.resolvedLanguage` via `useTranslation()` and passes it to `loadDoc`, so the page re-renders into German when the language switches.
- English routes, slugs, redirects, `getAllDocs()`, and the search index are unchanged. `prerenderLandingPages.ts` and the sitemap were not touched.

## Translated vs English-fallback
**German (15 docs):**
- `start-here/` — all 6: what-is-2anki, connect-notion, upload-a-file, open-in-anki, import-from-anki, share-a-deck
- `sync/` — all 5: how-it-works, review-cards, review-export, study-stats, troubleshooting
- `help/` — 4: common-problems, limits, bug-report, contact

**Still English fallback (renders unchanged for `de` users until translated):**
- `cards/` — all 16 files
- `reference/` — all 9 files (incl. privacy, terms)
- `links/` — community
- `index.mdx` — the docs home renders via `DocsHome.tsx` (a component, not this content track), so translating it has no effect; left for the UI-string track.

Files were translated whole, never half — the fallback shows English for anything not yet done.

## Translation notes
- Protected verbatim: Anki, AnkiWeb, Notion, Quizlet, 2anki, format names (PDF/CSV/HTML/Markdown/APKG), AnkiConnect, and all in-product UI labels/button names (`Convert`, `Share`, `My Decks`, `Add connections`, etc.), code, CLI, and `{{c1::...}}` syntax.
- Markdown structure, headings, code blocks, front-matter keys, internal doc-link slugs, image paths, and table shapes preserved exactly.
- In `help/common-problems.md`, the headings that quote literal product error strings (`"Please select a file to upload."`, etc.) are kept in English verbatim: they are the exact strings the product emits today and are also in-page anchor targets (e.g. `#my-google-doc-converted-to-0-cards`, linked from `upload-a-file.md`) — translating them would break the anchors and invent UI strings that don't exist. A one-line German note at the top explains this to the reader. The surrounding explanatory prose is fully German.

## Legal docs
`reference/privacy` and `reference/terms` were **left in English** — legal copy needs legal review before a German version ships. They fall back to English for `de` users, which is the safe default.

## Measuring success
No new analytics event in this PR (content track, not a new product surface). German docs adoption is observable via the existing docs pageview analytics filtered by language; the funnel metric it should move is landing → signup for the German cohort, read in the standard funnel dashboard.

## Testing
- Unit tests added to `web/src/pages/DocsPage/loader.test.ts`: (1) serves the German doc when language is `de` and a translation exists, (2) falls back to English per-file when no German file exists (deep-equals the English doc), (3) resolves a redirect slug to the German translation of its target. All 10 loader tests green; all 60 DocsPage tests green; web typecheck green; oxlint clean on changed dirs (the one `search.ts` warning is pre-existing, untouched).
- `pnpm --filter 2anki-web test:golden-path` — 2 passed.
- Sonar not run locally; Automatic Analysis covers the push.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: verified via `pnpm --filter 2anki-web test:golden-path` (375px viewport, console-error-fail spec) — 2 passed.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-07-16-german-docs.json` — "Documentation now available in German, with English fallback"

## Risks
Low. English behavior is unchanged (glob excludes `de/`, search and slugs untouched); German is a per-file overlay with English fallback, so a missing or malformed German file degrades to English rather than breaking. Rollback: revert the PR — the `de/` tree and the `language` argument disappear and English serves as before.

## Goal alignment
Acquisition-facing: German-language docs reduce first-conversion friction for the German cohort (mission: simplest/fastest path from study material to a deck). Funnel metric: landing → signup for German users, read in the standard funnel dashboard; expect movement as the German app localization lands alongside this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs4pvvQ4BKVpvEtGA9GXTn
