### PR TITLE
feat: translate chat and search to German

### DIFF
--- a/web/src/components/ChatPanel/ChatPanel.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { get, patch, post, postMultipart } from '../../lib/backend/api';
 import {
   type ChatCardTemplate,
@@ -244,10 +245,11 @@ function UserMessage({
   expanded: boolean;
   onToggleExpand: () => void;
 }) {
+  const { t } = useTranslation('chat');
   const isLong =
     message.content.length > 600 || message.content.split('\n').length > 12;
   return (
-    <div className={styles.userRow} aria-label="User message">
+    <div className={styles.userRow} aria-label={t('message.userMessage')}>
       <div
         className={`${styles.userBubble} ${isLong && !expanded ? styles.userBubbleClamped : ''}`}
       >
@@ -260,7 +262,7 @@ function UserMessage({
           onClick={onToggleExpand}
           aria-expanded={expanded}
         >
-          {expanded ? 'Show less' : 'Show full message'}
+          {expanded ? t('message.showLess') : t('message.showFull')}
         </button>
       )}
     </div>
@@ -333,6 +335,7 @@ function StreamingMessage({
   streamingText: string;
   isCardStreaming: boolean;
 }) {
+  const { t } = useTranslation('chat');
   if (streamingText.length > 0) {
     return (
       <div className={styles.assistantRow}>
@@ -340,15 +343,21 @@ function StreamingMessage({
           {visibleStreamingText(streamingText)}
         </AssistantMarkdown>
         {isCardStreaming && (
-          <span className={styles.makingCards}>Writing your cards</span>
+          <span className={styles.makingCards}>
+            {t('composer.writingCards')}
+          </span>
         )}
       </div>
     );
   }
 
   return (
-    <div className={styles.thinkingPill} aria-label="Thinking" role="status">
-      <span className={styles.srOnly}>Thinking</span>
+    <div
+      className={styles.thinkingPill}
+      aria-label={t('composer.thinking')}
+      role="status"
+    >
+      <span className={styles.srOnly}>{t('composer.thinking')}</span>
     </div>
   );
 }
@@ -384,6 +393,7 @@ function ComposerPill({
   onDrop,
   textareaRef: externalTextareaRef,
 }: ComposerProps) {
+  const { t } = useTranslation('chat');
   const fileInputRef = useRef<HTMLInputElement>(null);
   const internalRef = useRef<HTMLTextAreaElement>(null);
   const textareaRef = externalTextareaRef ?? internalRef;
@@ -409,7 +419,7 @@ function ComposerPill({
   return (
     <div
       role="region"
-      aria-label="Chat composer with file drop zone"
+      aria-label={t('composer.region')}
       className={`${styles.composerPill} ${isDragging ? styles.composerPillDragging : ''}`}
       onDragOver={onDragOver}
       onDragLeave={onDragLeave}
@@ -417,9 +427,11 @@ function ComposerPill({
     >
       {isDragging && (
         <div className={styles.dropOverlay}>
-          <span className={styles.dropOverlayTitle}>Drop to attach</span>
+          <span className={styles.dropOverlayTitle}>
+            {t('composer.dropToAttach')}
+          </span>
           <span className={styles.dropOverlaySub}>
-            PDF or image, up to 10 MB each
+            {t('composer.dropHint')}
           </span>
         </div>
       )}
@@ -444,7 +456,9 @@ function ComposerPill({
                   >
                     <span className={styles.spinnerSmall} />
                   </span>
-                  <span className={styles.chipSize}>Uploading</span>
+                  <span className={styles.chipSize}>
+                    {t('composer.uploading')}
+                  </span>
                 </>
               )}
               {chip.state === 'failed' && (
@@ -452,7 +466,7 @@ function ComposerPill({
                   <span
                     className={`${styles.chipSize} ${styles.chipSizeError}`}
                   >
-                    Upload failed
+                    {t('composer.uploadFailed')}
                   </span>
                   {onRetryFile != null && (
                     <button
@@ -460,7 +474,7 @@ function ComposerPill({
                       className={styles.chipRetry}
                       onClick={() => onRetryFile(chip.id)}
                     >
-                      Retry
+                      {t('composer.retry')}
                     </button>
                   )}
                 </>
@@ -473,7 +487,7 @@ function ComposerPill({
               <button
                 type="button"
                 className={styles.chipRemove}
-                aria-label={`Remove ${chip.file.name}`}
+                aria-label={t('composer.remove', { name: chip.file.name })}
                 onClick={() => onRemoveFile(chip.id)}
               >
                 ×
@@ -486,7 +500,7 @@ function ComposerPill({
         <button
           type="button"
           className={styles.attachBtn}
-          aria-label="Attach files"
+          aria-label={t('composer.attachFiles')}
           disabled={disabled || attachedFiles.length >= MAX_FILE_COUNT}
           onClick={() => fileInputRef.current?.click()}
         >
@@ -511,10 +525,10 @@ function ComposerPill({
           value={inputValue}
           onChange={(e) => onChange(e.target.value)}
           onKeyDown={handleKeyDown}
-          placeholder="What are you studying?"
+          placeholder={t('composer.studyingPlaceholder')}
           disabled={disabled}
           rows={1}
-          aria-label="Message input"
+          aria-label={t('composer.messageInput')}
         />
         <input
           ref={fileInputRef}
@@ -536,7 +550,7 @@ function ComposerPill({
           className={`${styles.sendBtn} ${canSend ? styles.sendBtnActive : ''}`}
           onClick={onSubmit}
           disabled={!canSend}
-          aria-label="Send message"
+          aria-label={t('composer.sendMessage')}
         >
           <svg
             width="16"
@@ -569,6 +583,7 @@ export default function ChatPanel({
   onConversationNotFound,
   onTemplateChange,
 }: ChatPanelProps) {
+  const { t } = useTranslation('chat');
   const { data: userLocals, refetch: refetchUserLocals } = useUserLocals();
   const hasConsented = userLocals?.user?.chat_consent_at != null;
   const [showConsentModal, setShowConsentModal] = useState(false);
@@ -685,11 +700,11 @@ export default function ChatPanel({
     if (disallowed.length > 0) {
       if (disallowed.length === 1) {
         setNetworkError(
-          `Can't attach ${disallowed[0].name}. Only PDF and image files work here.`
+          t('errors.cantAttachOne', { name: disallowed[0].name })
         );
       } else {
         setNetworkError(
-          `Can't attach ${disallowed.length} files. Only PDF and image files work here.`
+          t('errors.cantAttachMany', { count: disallowed.length })
         );
       }
       return;
@@ -698,7 +713,10 @@ export default function ChatPanel({
     const oversized = files.find((f) => f.size > MAX_FILE_BYTES);
     if (oversized != null) {
       setNetworkError(
-        `${oversized.name} is ${formatFileSize(oversized.size)}. The per-file limit is 10 MB.`
+        t('errors.oversize', {
+          name: oversized.name,
+          size: formatFileSize(oversized.size),
+        })
       );
       return;
     }
@@ -707,7 +725,7 @@ export default function ChatPanel({
     const newTotal = files.reduce((s, f) => s + f.size, currentTotal);
     if (newTotal > MAX_TOTAL_BYTES) {
       setNetworkError(
-        `That's ${formatFileSize(newTotal)} total. A message can carry up to 25 MB across all files.`
+        t('errors.totalSize', { size: formatFileSize(newTotal) })
       );
       return;
     }
@@ -771,7 +789,7 @@ export default function ChatPanel({
       try {
         response = await postMultipart('/api/chat/message', formData);
       } catch {
-        setNetworkError("Couldn't send this message. Try again.");
+        setNetworkError(t('errors.send'));
         setIsLoading(false);
         return;
       }
@@ -784,7 +802,7 @@ export default function ChatPanel({
           templateSlug: activeTemplate,
         });
       } catch {
-        setNetworkError("Couldn't send this message. Try again.");
+        setNetworkError(t('errors.send'));
         setIsLoading(false);
         return;
       }
@@ -794,13 +812,13 @@ export default function ChatPanel({
       const data = (await response.json().catch(() => ({}))) as {
         error?: string;
       };
-      setNetworkError(data.error ?? "Couldn't send this message. Try again.");
+      setNetworkError(data.error ?? t('errors.send'));
       setIsLoading(false);
       return;
     }
 
     if (response.body == null) {
-      setNetworkError("Couldn't send this message. Try again.");
+      setNetworkError(t('errors.send'));
       setIsLoading(false);
       return;
     }
@@ -840,7 +858,7 @@ export default function ChatPanel({
         return;
       }
       if (err.type === 'conversation_not_found') {
-        setNetworkError('This conversation is gone. Start a new one.');
+        setNetworkError(t('errors.conversationGone'));
         setActiveConversationId(null);
         onConversationNotFound?.();
         return;
@@ -849,7 +867,7 @@ export default function ChatPanel({
         setShowConsentModal(true);
         return;
       }
-      setNetworkError("Couldn't send this message. Try again.");
+      setNetworkError(t('errors.send'));
     };
 
     const dispatchSseEvent = (eventType: string, data: string) => {
@@ -861,7 +879,7 @@ export default function ChatPanel({
     try {
       await consumeSseEvents(response.body, dispatchSseEvent);
     } catch {
-      setNetworkError("Couldn't send this message. Try again.");
+      setNetworkError(t('errors.send'));
     } finally {
       setIsLoading(false);
       setStreamingText('');
@@ -870,7 +888,7 @@ export default function ChatPanel({
 
   function handleSaveAsDeck(cards: ChatCard[], deckName: string) {
     downloadDeck(cards, deckName, activeTemplate).catch(() => {
-      setNetworkError("Couldn't generate the deck. Try again.");
+      setNetworkError(t('errors.deckGenerate'));
     });
   }
 
@@ -889,12 +907,12 @@ export default function ChatPanel({
         conversationId: activeConversationId,
       });
       if (!response.ok) {
-        setNetworkError("Couldn't add tags. Try again.");
+        setNetworkError(t('errors.addTags'));
         return;
       }
       const result = (await response.json()) as { tags: string[][] };
       if (!Array.isArray(result.tags)) {
-        setNetworkError("Couldn't add tags. Try again.");
+        setNetworkError(t('errors.addTags'));
         return;
       }
       setMessages((prev) =>
@@ -910,11 +928,10 @@ export default function ChatPanel({
         })
       );
       const taggedCount = cardsToTag.length;
-      const cardWord = taggedCount === 1 ? 'card' : 'cards';
-      setSuccessMessage(`Tags added to ${taggedCount} ${cardWord}`);
+      setSuccessMessage(t('tags.success', { count: taggedCount }));
       window.setTimeout(() => setSuccessMessage(null), TAG_SUCCESS_DISMISS_MS);
     } catch {
-      setNetworkError("Couldn't add tags. Try again.");
+      setNetworkError(t('errors.addTags'));
     } finally {
       setTaggingIdx(null);
     }
@@ -956,7 +973,7 @@ export default function ChatPanel({
         { templateSlug: newSlug }
       );
     } catch {
-      setNetworkError("Couldn't rebuild your cards. Try again.");
+      setNetworkError(t('errors.rebuild'));
       setIsLoading(false);
       setRegeneratingIdx(null);
       return;
@@ -966,7 +983,7 @@ export default function ChatPanel({
       const data = (await response.json().catch(() => ({}))) as {
         error?: string;
       };
-      setNetworkError(data.error ?? "Couldn't rebuild your cards. Try again.");
+      setNetworkError(data.error ?? t('errors.rebuild'));
       setIsLoading(false);
       setRegeneratingIdx(null);
       return;
@@ -1007,7 +1024,7 @@ export default function ChatPanel({
         return;
       }
       if (err.type === 'conversation_not_found') {
-        setNetworkError('This conversation is gone. Start a new one.');
+        setNetworkError(t('errors.conversationGone'));
         setActiveConversationId(null);
         onConversationNotFound?.();
         return;
@@ -1016,7 +1033,7 @@ export default function ChatPanel({
         setShowConsentModal(true);
         return;
       }
-      setNetworkError("Couldn't rebuild your cards. Try again.");
+      setNetworkError(t('errors.rebuild'));
     };
 
     const dispatchRegenEvent = (eventType: string, data: string) => {
@@ -1028,7 +1045,7 @@ export default function ChatPanel({
     try {
       await consumeSseEvents(response.body, dispatchRegenEvent);
     } catch {
-      setNetworkError("Couldn't rebuild your cards. Try again.");
+      setNetworkError(t('errors.rebuild'));
     } finally {
       setIsLoading(false);
       setRegeneratingIdx(null);
@@ -1109,9 +1126,7 @@ export default function ChatPanel({
         {showEmptyState ? (
           <div className={styles.emptyState}>
             <h1 className={styles.emptyHeading}>
-              {cameFromUpload
-                ? 'What would you like to do with this file?'
-                : 'What are you studying?'}
+              {cameFromUpload ? t('heading.withFile') : t('heading.studying')}
             </h1>
             <div className={styles.emptyComposer}>
               <ComposerPill {...composerProps} />
@@ -1123,8 +1138,11 @@ export default function ChatPanel({
                 messagesUsedThisMonth > 0 && (
                   <p className={styles.usageLine}>
                     {remainingMessages === 1
-                      ? '1 message left this month — your next send uses it'
-                      : `${remainingMessages} of ${monthlyLimit} messages left this month`}
+                      ? t('usage.messagesLeftOne')
+                      : t('usage.messagesLeft', {
+                          count: remainingMessages,
+                          limit: monthlyLimit,
+                        })}
                   </p>
                 )}
             </div>
@@ -1200,7 +1218,7 @@ export default function ChatPanel({
                 <button
                   type="button"
                   className={styles.scrollPill}
-                  aria-label="Scroll to bottom"
+                  aria-label={t('composer.scrollToBottom')}
                   onClick={scrollToBottom}
                 >
                   <svg
@@ -1225,11 +1243,13 @@ export default function ChatPanel({
               {limitReached && resetDate != null && (
                 <div className={styles.limitPanel}>
                   <span>
-                    You've used all {FREE_MONTHLY_LIMIT} messages this month.
-                    Resets {formatResetDate(resetDate)}.
+                    {t('limitPanel.text', {
+                      count: FREE_MONTHLY_LIMIT,
+                      date: formatResetDate(resetDate),
+                    })}
                   </span>
                   <a href="/pricing" className={styles.limitPanelLink}>
-                    See plans
+                    {t('limitPanel.seePlans')}
                   </a>
                 </div>
               )}
@@ -1239,8 +1259,11 @@ export default function ChatPanel({
                 messagesUsedThisMonth > 0 && (
                   <p className={styles.usageLine}>
                     {remainingMessages === 1
-                      ? '1 message left this month — your next send uses it'
-                      : `${remainingMessages} of ${monthlyLimit} messages left this month`}
+                      ? t('usage.messagesLeftOne')
+                      : t('usage.messagesLeft', {
+                          count: remainingMessages,
+                          limit: monthlyLimit,
+                        })}
                   </p>
                 )}
               {networkError != null && (

--- a/web/src/components/ChatPanel/TemplateSelector.tsx
+++ b/web/src/components/ChatPanel/TemplateSelector.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   CHAT_TEMPLATE_OPTIONS,
   type ChatCardTemplate,
@@ -16,6 +17,7 @@ export function TemplateSelector({
   onChange,
   disabled,
 }: TemplateSelectorProps) {
+  const { t } = useTranslation('chat');
   const [open, setOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -43,11 +45,15 @@ export function TemplateSelector({
         className={styles.templatePill}
         aria-haspopup="listbox"
         aria-expanded={open}
-        aria-label={`Note type: ${activeOption.label}`}
+        aria-label={t('templateSelector.noteTypeAria', {
+          label: activeOption.label,
+        })}
         disabled={disabled}
         onClick={() => setOpen((v) => !v)}
       >
-        <span>Note Type: {activeOption.label}</span>
+        <span>
+          {t('templateSelector.noteTypeLabel', { label: activeOption.label })}
+        </span>
         <svg
           width="10"
           height="10"
@@ -65,7 +71,7 @@ export function TemplateSelector({
       {open && (
         <ul
           role="listbox"
-          aria-label="Note type"
+          aria-label={t('templateSelector.listboxLabel')}
           className={styles.templateMenu}
         >
           {CHAT_TEMPLATE_OPTIONS.map((opt) => (

--- a/web/src/lib/i18n/locales/de/chat.json
+++ b/web/src/lib/i18n/locales/de/chat.json
@@ -1,0 +1,102 @@
+{
+  "page": {
+    "prefilledPrompt": "Ich wollte {{filename}} konvertieren und komme nicht weiter. Was kann ich tun?",
+    "prefilledPromptFallback": "diese Datei",
+    "loadError": "Diese Unterhaltung konnte nicht geladen werden.",
+    "renameError": "Diese Unterhaltung konnte nicht umbenannt werden.",
+    "deleteError": "Diese Unterhaltung konnte nicht gelöscht werden.",
+    "pastChats": "Frühere Chats",
+    "newChat": "Neuer Chat"
+  },
+  "sidebar": {
+    "newChat": "Neuer Chat",
+    "empty": "Noch keine Unterhaltungen. Starte unten eine.",
+    "closeConversations": "Unterhaltungen schließen",
+    "conversations": "Unterhaltungen",
+    "conversationTitle": "Titel der Unterhaltung",
+    "optionsFor": "Optionen für {{title}}",
+    "rename": "Umbenennen",
+    "delete": "Löschen",
+    "justNow": "gerade eben"
+  },
+  "message": {
+    "showLess": "Weniger anzeigen",
+    "showFull": "Ganze Nachricht anzeigen",
+    "userMessage": "Nutzernachricht"
+  },
+  "composer": {
+    "writingCards": "Deine Karten werden geschrieben",
+    "thinking": "Denkt nach",
+    "dropToAttach": "Zum Anhängen loslassen",
+    "dropHint": "PDF oder Bild, je bis zu 10 MB",
+    "uploading": "Wird hochgeladen",
+    "uploadFailed": "Upload fehlgeschlagen",
+    "retry": "Erneut versuchen",
+    "remove": "{{name}} entfernen",
+    "attachFiles": "Dateien anhängen",
+    "studyingPlaceholder": "Was lernst du gerade?",
+    "messageInput": "Nachrichteneingabe",
+    "sendMessage": "Nachricht senden",
+    "region": "Chat-Editor mit Datei-Ablagebereich",
+    "scrollToBottom": "Nach unten scrollen"
+  },
+  "heading": {
+    "withFile": "Was möchtest du mit dieser Datei tun?",
+    "studying": "Was lernst du gerade?"
+  },
+  "usage": {
+    "messagesLeftOne": "1 Nachricht diesen Monat übrig — deine nächste Sendung verbraucht sie",
+    "messagesLeft": "{{count}} von {{limit}} Nachrichten diesen Monat übrig"
+  },
+  "limitPanel": {
+    "text": "Du hast diesen Monat alle {{count}} Nachrichten genutzt. Auffrischung am {{date}}.",
+    "seePlans": "Tarife ansehen"
+  },
+  "errors": {
+    "cantAttachOne": "{{name}} kann nicht angehängt werden. Hier funktionieren nur PDF- und Bilddateien.",
+    "cantAttachMany": "{{count}} Dateien können nicht angehängt werden. Hier funktionieren nur PDF- und Bilddateien.",
+    "oversize": "{{name}} ist {{size}}. Das Limit pro Datei liegt bei 10 MB.",
+    "totalSize": "Das sind insgesamt {{size}}. Eine Nachricht kann über alle Dateien hinweg bis zu 25 MB tragen.",
+    "send": "Diese Nachricht konnte nicht gesendet werden. Versuch es erneut.",
+    "conversationGone": "Diese Unterhaltung existiert nicht mehr. Starte eine neue.",
+    "rebuild": "Deine Karten konnten nicht neu erstellt werden. Versuch es erneut.",
+    "addTags": "Tags konnten nicht hinzugefügt werden. Versuch es erneut.",
+    "deckGenerate": "Der Stapel konnte nicht erstellt werden. Versuch es erneut."
+  },
+  "tags": {
+    "success_one": "Tags zu {{count}} Karte hinzugefügt",
+    "success_other": "Tags zu {{count}} Karten hinzugefügt"
+  },
+  "cardPreview": {
+    "correctAnswer": "Richtige Antwort",
+    "addTags": "Tags hinzufügen",
+    "downloadDeck": "Stapel herunterladen",
+    "nameThisDeck": "Diesen Stapel benennen",
+    "deckName": "Stapelname",
+    "save": "Speichern",
+    "cancel": "Abbrechen",
+    "saveAgain": "Erneut speichern",
+    "untitledDeck": "Unbenannter Stapel",
+    "savedAs": "Gespeichert als {{name}}.apkg",
+    "renameHint_one": "{{count}} Karte. Wird als {{filename}}.apkg gespeichert, sobald du auf Speichern klickst.",
+    "renameHint_other": "{{count}} Karten. Wird als {{filename}}.apkg gespeichert, sobald du auf Speichern klickst.",
+    "front": "Vorderseite",
+    "back": "Rückseite",
+    "tags": "Tags",
+    "addingTags": "Tags werden hinzugefügt",
+    "showFewer": "Weniger anzeigen",
+    "showAll": "Alle {{count}} Karten anzeigen",
+    "card_one": "Karte",
+    "card_other": "Karten"
+  },
+  "codeBlock": {
+    "copyCode": "Code kopieren",
+    "copied": "Kopiert",
+    "copy": "Kopieren"
+  },
+  "templateSelector": {
+    "noteTypeAria": "Notiztyp: {{label}}",
+    "noteTypeLabel": "Notiztyp: {{label}}",
+    "listboxLabel": "Notiztyp"
+  }
+}

--- a/web/src/lib/i18n/locales/de/search.json
+++ b/web/src/lib/i18n/locales/de/search.json
@@ -1,0 +1,58 @@
+{
+  "page": {
+    "titleConnected": "Notion",
+    "titleGetStarted": "Erste Schritte",
+    "subtitleConnected": "Finde eine Seite und wandle sie in einen Anki-Stapel um.",
+    "subtitleDisconnected": "Verbinde deinen Notion-Workspace oder lade Dateien hoch, um Anki-Stapel zu erstellen.",
+    "switchWorkspace": "Workspace wechseln"
+  },
+  "limit": {
+    "title": "Du hast diesen Monat alle {{limit}} Karten genutzt",
+    "body": "{{used}} / {{limit}} Karten · Auffrischung am {{resetsOn}}, dann kommen deine kostenlosen Karten zurück",
+    "startingCheckout": "Checkout wird gestartet",
+    "getDayPass": "Day Pass holen — $4",
+    "seePlans": "Tarife ansehen"
+  },
+  "connect": {
+    "title": "Verbinde deinen Notion-Workspace",
+    "body": "Durchsuche und konvertiere Seiten direkt. Wir lesen nur die Seiten, die du mit 2anki teilst.",
+    "connectButton": "Mit Notion verbinden",
+    "fallbackText": "Oder lade eine Datei hoch, die du aus Notion exportiert hast.",
+    "uploadFile": "Datei hochladen"
+  },
+  "searchBar": {
+    "label": "Notion durchsuchen",
+    "placeholder": "Notion durchsuchen"
+  },
+  "results": {
+    "scopeWorkspace": "in „{{workSpace}}“",
+    "scopeGeneric": "in deinem Notion-Workspace",
+    "noMatch": "Keine Seiten passen zu „{{query}}“ {{scope}}",
+    "noneFound": "Keine Seiten gefunden {{scope}}",
+    "emptyBodyPrefix": "Versuche einen anderen Suchbegriff oder stelle sicher, dass die Seite mit der 2anki-Integration geteilt ist — siehe ",
+    "sharingLink": "Notions Freigabeeinstellungen",
+    "emptyBodySuffix": "."
+  },
+  "entry": {
+    "remaking": "Dein Stapel wird neu erstellt — ",
+    "added": "Zu deinen Downloads hinzugefügt — ",
+    "view": "ansehen",
+    "paywallText": "Kostenloser Tarif — eine Konvertierung gleichzeitig.",
+    "upgrade": "Upgrade",
+    "paywallSuffix": " oder warte.",
+    "conflict": "Diese Seite wird bereits konvertiert.",
+    "error": "Diese Seite konnte nicht eingereiht werden. Versuch es erneut.",
+    "inProgress": "In Arbeit",
+    "convertToAnki": "In Anki konvertieren",
+    "convert": "Konvertieren",
+    "openInNotion": "{{title}} in Notion öffnen",
+    "preview": "Vorschau von {{title}}",
+    "configureRules": "Regeln für {{title}} konfigurieren"
+  },
+  "flashcardType": {
+    "new": "Neu"
+  },
+  "icon": {
+    "alt": "Symbol"
+  }
+}

--- a/web/src/lib/i18n/locales/en/chat.json
+++ b/web/src/lib/i18n/locales/en/chat.json
@@ -1,0 +1,102 @@
+{
+  "page": {
+    "prefilledPrompt": "I tried to convert {{filename}} and got stuck. What can I do?",
+    "prefilledPromptFallback": "this file",
+    "loadError": "Couldn't load this conversation.",
+    "renameError": "Couldn't rename this conversation.",
+    "deleteError": "Couldn't delete this conversation.",
+    "pastChats": "Past chats",
+    "newChat": "New chat"
+  },
+  "sidebar": {
+    "newChat": "New chat",
+    "empty": "No conversations yet. Start one below.",
+    "closeConversations": "Close conversations",
+    "conversations": "Conversations",
+    "conversationTitle": "Conversation title",
+    "optionsFor": "Options for {{title}}",
+    "rename": "Rename",
+    "delete": "Delete",
+    "justNow": "just now"
+  },
+  "message": {
+    "showLess": "Show less",
+    "showFull": "Show full message",
+    "userMessage": "User message"
+  },
+  "composer": {
+    "writingCards": "Writing your cards",
+    "thinking": "Thinking",
+    "dropToAttach": "Drop to attach",
+    "dropHint": "PDF or image, up to 10 MB each",
+    "uploading": "Uploading",
+    "uploadFailed": "Upload failed",
+    "retry": "Retry",
+    "remove": "Remove {{name}}",
+    "attachFiles": "Attach files",
+    "studyingPlaceholder": "What are you studying?",
+    "messageInput": "Message input",
+    "sendMessage": "Send message",
+    "region": "Chat composer with file drop zone",
+    "scrollToBottom": "Scroll to bottom"
+  },
+  "heading": {
+    "withFile": "What would you like to do with this file?",
+    "studying": "What are you studying?"
+  },
+  "usage": {
+    "messagesLeftOne": "1 message left this month — your next send uses it",
+    "messagesLeft": "{{count}} of {{limit}} messages left this month"
+  },
+  "limitPanel": {
+    "text": "You've used all {{count}} messages this month. Resets {{date}}.",
+    "seePlans": "See plans"
+  },
+  "errors": {
+    "cantAttachOne": "Can't attach {{name}}. Only PDF and image files work here.",
+    "cantAttachMany": "Can't attach {{count}} files. Only PDF and image files work here.",
+    "oversize": "{{name}} is {{size}}. The per-file limit is 10 MB.",
+    "totalSize": "That's {{size}} total. A message can carry up to 25 MB across all files.",
+    "send": "Couldn't send this message. Try again.",
+    "conversationGone": "This conversation is gone. Start a new one.",
+    "rebuild": "Couldn't rebuild your cards. Try again.",
+    "addTags": "Couldn't add tags. Try again.",
+    "deckGenerate": "Couldn't generate the deck. Try again."
+  },
+  "tags": {
+    "success_one": "Tags added to {{count}} card",
+    "success_other": "Tags added to {{count}} cards"
+  },
+  "cardPreview": {
+    "correctAnswer": "Correct answer",
+    "addTags": "Add tags",
+    "downloadDeck": "Download deck",
+    "nameThisDeck": "Name this deck",
+    "deckName": "Deck name",
+    "save": "Save",
+    "cancel": "Cancel",
+    "saveAgain": "Save again",
+    "untitledDeck": "Untitled deck",
+    "savedAs": "Saved as {{name}}.apkg",
+    "renameHint_one": "{{count}} card. Saves as {{filename}}.apkg once you click Save.",
+    "renameHint_other": "{{count}} cards. Saves as {{filename}}.apkg once you click Save.",
+    "front": "Front",
+    "back": "Back",
+    "tags": "Tags",
+    "addingTags": "Adding tags",
+    "showFewer": "Show fewer",
+    "showAll": "Show all {{count}} cards",
+    "card_one": "card",
+    "card_other": "cards"
+  },
+  "codeBlock": {
+    "copyCode": "Copy code",
+    "copied": "Copied",
+    "copy": "Copy"
+  },
+  "templateSelector": {
+    "noteTypeAria": "Note type: {{label}}",
+    "noteTypeLabel": "Note Type: {{label}}",
+    "listboxLabel": "Note type"
+  }
+}

--- a/web/src/lib/i18n/locales/en/search.json
+++ b/web/src/lib/i18n/locales/en/search.json
@@ -1,0 +1,58 @@
+{
+  "page": {
+    "titleConnected": "Notion",
+    "titleGetStarted": "Get started",
+    "subtitleConnected": "Find a page and convert it into an Anki deck.",
+    "subtitleDisconnected": "Connect your Notion workspace or upload files to create Anki decks.",
+    "switchWorkspace": "Switch workspace"
+  },
+  "limit": {
+    "title": "You've used all {{limit}} cards this month",
+    "body": "{{used}} / {{limit}} cards · resets {{resetsOn}}, when your free cards come back",
+    "startingCheckout": "Starting checkout",
+    "getDayPass": "Get Day Pass — $4",
+    "seePlans": "See plans"
+  },
+  "connect": {
+    "title": "Connect your Notion workspace",
+    "body": "Search and convert pages directly. We only read the pages you share with 2anki.",
+    "connectButton": "Connect to Notion",
+    "fallbackText": "Or upload a file you exported from Notion.",
+    "uploadFile": "Upload a file"
+  },
+  "searchBar": {
+    "label": "Search Notion",
+    "placeholder": "Search Notion"
+  },
+  "results": {
+    "scopeWorkspace": "in “{{workSpace}}”",
+    "scopeGeneric": "in your Notion workspace",
+    "noMatch": "No pages match “{{query}}” {{scope}}",
+    "noneFound": "No pages found {{scope}}",
+    "emptyBodyPrefix": "Try a different search term, or make sure the page is shared with the 2anki integration — see ",
+    "sharingLink": "Notion's sharing settings",
+    "emptyBodySuffix": "."
+  },
+  "entry": {
+    "remaking": "Re-making your deck — ",
+    "added": "Added to your downloads — ",
+    "view": "view",
+    "paywallText": "Free plan — one conversion at a time.",
+    "upgrade": "Upgrade",
+    "paywallSuffix": " or wait.",
+    "conflict": "Already converting this page.",
+    "error": "Couldn't queue this page. Try again.",
+    "inProgress": "In progress",
+    "convertToAnki": "Convert to Anki",
+    "convert": "Convert",
+    "openInNotion": "Open {{title}} in Notion",
+    "preview": "Preview {{title}}",
+    "configureRules": "Configure rules for {{title}}"
+  },
+  "flashcardType": {
+    "new": "New"
+  },
+  "icon": {
+    "alt": "icon"
+  }
+}

--- a/web/src/pages/Chat/CardPreview.tsx
+++ b/web/src/pages/Chat/CardPreview.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { TemplateSelector } from '../../components/ChatPanel/TemplateSelector';
 import DownloadIcon from '../../components/icons/DownloadIcon';
 import {
@@ -60,6 +61,7 @@ function sanitizeFilename(name: string): string {
 }
 
 function McqRow({ card }: { card: ChatCard }) {
+  const { t } = useTranslation('chat');
   const options = card.options ?? [];
   const correctIndex = card.correctIndex ?? -1;
   return (
@@ -82,7 +84,7 @@ function McqRow({ card }: { card: ChatCard }) {
             {i === correctIndex && (
               <span
                 className={styles.cardPreviewMcqOptionCheck}
-                aria-label="Correct answer"
+                aria-label={t('cardPreview.correctAnswer')}
               >
                 ✓
               </span>
@@ -125,9 +127,12 @@ export default function CardPreview({
   onAddTags,
   isTagging,
 }: CardPreviewProps) {
+  const { t } = useTranslation('chat');
   const [expanded, setExpanded] = useState(false);
   const [saveState, setSaveState] = useState<SaveState>('idle');
-  const [deckNameDraft, setDeckNameDraft] = useState('Untitled deck');
+  const [deckNameDraft, setDeckNameDraft] = useState(() =>
+    t('cardPreview.untitledDeck')
+  );
   const [savedName, setSavedName] = useState<string | null>(null);
   const [showHint, setShowHint] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -185,7 +190,7 @@ export default function CardPreview({
     }
   }
 
-  const cardLabel = displayCards.length === 1 ? 'card' : 'cards';
+  const cardLabel = t('cardPreview.card', { count: displayCards.length });
   const switchLabel = template == null ? null : templateSwitchLabel(template);
 
   return (
@@ -214,7 +219,7 @@ export default function CardPreview({
             className={styles.cardPreviewAddTags}
             onClick={onAddTags}
           >
-            Add tags
+            {t('cardPreview.addTags')}
           </button>
         )}
 
@@ -222,11 +227,11 @@ export default function CardPreview({
           <button
             type="button"
             className={styles.cardPreviewSave}
-            aria-label="Download deck"
+            aria-label={t('cardPreview.downloadDeck')}
             onClick={openNaming}
           >
             <DownloadIcon width={13} height={13} />
-            Download deck
+            {t('cardPreview.downloadDeck')}
           </button>
         )}
 
@@ -240,8 +245,8 @@ export default function CardPreview({
               onChange={(e) => setDeckNameDraft(e.target.value)}
               onKeyDown={handleKeyDown}
               maxLength={MAX_DECK_NAME_LENGTH}
-              placeholder="Name this deck"
-              aria-label="Deck name"
+              placeholder={t('cardPreview.nameThisDeck')}
+              aria-label={t('cardPreview.deckName')}
             />
             <button
               type="button"
@@ -249,20 +254,23 @@ export default function CardPreview({
               onClick={commitSave}
               disabled={deckNameDraft.trim().length === 0}
             >
-              Save
+              {t('cardPreview.save')}
             </button>
             <button
               type="button"
               className={styles.renameCancel}
               onClick={cancelNaming}
             >
-              Cancel
+              {t('cardPreview.cancel')}
             </button>
             {showHint && (
               <p className={styles.renameHint}>
-                {cards.length} {cardLabel}. Saves as{' '}
-                {sanitizeFilename(deckNameDraft.trim()) || 'Untitled deck'}.apkg
-                once you click Save.
+                {t('cardPreview.renameHint', {
+                  count: cards.length,
+                  filename:
+                    sanitizeFilename(deckNameDraft.trim()) ||
+                    t('cardPreview.untitledDeck'),
+                })}
               </p>
             )}
           </div>
@@ -270,13 +278,15 @@ export default function CardPreview({
 
         {saveState === 'saved' && savedName != null && (
           <div className={styles.savedLine}>
-            <span className={styles.savedFile}>Saved as {savedName}.apkg</span>
+            <span className={styles.savedFile}>
+              {t('cardPreview.savedAs', { name: savedName })}
+            </span>
             <button
               type="button"
               className={styles.savedAgainBtn}
               onClick={openNaming}
             >
-              Save again
+              {t('cardPreview.saveAgain')}
             </button>
           </div>
         )}
@@ -286,9 +296,9 @@ export default function CardPreview({
         <div
           className={`${styles.cardPreviewColumnLabels} ${hideBackColumn && !hasTags ? styles.cardPreviewColumnLabelsSingle : ''} ${!hideBackColumn && hasTags ? styles.cardPreviewColumnLabelsThree : ''}`}
         >
-          <span>Front</span>
-          {!hideBackColumn && <span>Back</span>}
-          {hasTags && <span>Tags</span>}
+          <span>{t('cardPreview.front')}</span>
+          {!hideBackColumn && <span>{t('cardPreview.back')}</span>}
+          {hasTags && <span>{t('cardPreview.tags')}</span>}
         </div>
       )}
 
@@ -316,24 +326,30 @@ export default function CardPreview({
               >
                 <div className={styles.cardPreviewFront}>
                   {(!hideBackColumn || hasTags) && (
-                    <span className={styles.cardPreviewMobileLabel}>Front</span>
+                    <span className={styles.cardPreviewMobileLabel}>
+                      {t('cardPreview.front')}
+                    </span>
                   )}
                   {card.front}
                 </div>
                 {!hideBackColumn && (
                   <div className={styles.cardPreviewBack}>
-                    <span className={styles.cardPreviewMobileLabel}>Back</span>
+                    <span className={styles.cardPreviewMobileLabel}>
+                      {t('cardPreview.back')}
+                    </span>
                     {card.back}
                   </div>
                 )}
                 {hasTags && (
                   <div className={styles.cardPreviewTags}>
-                    <span className={styles.cardPreviewMobileLabel}>Tags</span>
+                    <span className={styles.cardPreviewMobileLabel}>
+                      {t('cardPreview.tags')}
+                    </span>
                     {isTagging ? (
                       <span
                         className={styles.cardPreviewTagSkeleton}
                         role="status"
-                        aria-label="Adding tags"
+                        aria-label={t('cardPreview.addingTags')}
                       />
                     ) : (
                       <TagChips tags={card.tags ?? []} />
@@ -351,7 +367,9 @@ export default function CardPreview({
             className={styles.cardPreviewExpandBtn}
             onClick={() => setExpanded((v) => !v)}
           >
-            {expanded ? 'Show fewer' : `Show all ${displayCards.length} cards`}
+            {expanded
+              ? t('cardPreview.showFewer')
+              : t('cardPreview.showAll', { count: displayCards.length })}
           </button>
         )}
       </>

--- a/web/src/pages/Chat/ChatPage.i18n.test.tsx
+++ b/web/src/pages/Chat/ChatPage.i18n.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from '../../lib/i18n';
+import ChatPage from './ChatPage';
+
+window.HTMLElement.prototype.scrollIntoView = vi.fn();
+
+vi.mock('../../lib/hooks/useUserLocals', () => ({
+  useUserLocals: () => ({
+    data: {
+      user: { patreon: false, chat_consent_at: '2026-01-01T00:00:00.000Z' },
+    },
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock('../../lib/backend/api', () => ({
+  post: vi.fn(),
+  postMultipart: vi.fn(),
+  get: vi.fn().mockResolvedValue({ used: 0, limit: 20 }),
+  patch: vi.fn(),
+  del: vi.fn(),
+}));
+
+function renderChatPage(path = '/chat') {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/chat" element={<ChatPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('ChatPage in German', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('translates the empty-state heading and composer controls', async () => {
+    renderChatPage();
+    expect(
+      screen.getByRole('heading', { name: 'Was lernst du gerade?' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('textbox', { name: 'Nachrichteneingabe' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Nachricht senden' })
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Dateien anhängen' })
+      ).toBeInTheDocument()
+    );
+  });
+
+  it('translates the upload-origin heading', () => {
+    renderChatPage('/chat?from=upload&filename=notes.pdf');
+    expect(
+      screen.getByRole('heading', {
+        name: 'Was möchtest du mit dieser Datei tun?',
+      })
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/Chat/ChatPage.tsx
+++ b/web/src/pages/Chat/ChatPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import ChatPanel, { type Message } from '../../components/ChatPanel/ChatPanel';
 import { del, get, patch } from '../../lib/backend/api';
 import styles from './ChatPage.module.css';
@@ -42,11 +43,14 @@ interface PanelSeed {
 }
 
 export default function ChatPage() {
+  const { t } = useTranslation('chat');
   const [searchParams] = useSearchParams();
   const cameFromUpload = searchParams.get('from') === 'upload';
   const uploadFilename = searchParams.get('filename');
   const prefilledPrompt = cameFromUpload
-    ? `I tried to convert ${uploadFilename ?? 'this file'} and got stuck. What can I do?`
+    ? t('page.prefilledPrompt', {
+        filename: uploadFilename ?? t('page.prefilledPromptFallback'),
+      })
     : '';
 
   const [conversations, setConversations] = useState<ConversationSummary[]>([]);
@@ -117,7 +121,7 @@ export default function ChatPage() {
           validSlug == null ? null : (data.templateSlug as ChatCardTemplate),
       });
     } catch {
-      setLoadError("Couldn't load this conversation.");
+      setLoadError(t('page.loadError'));
     }
   }
 
@@ -143,11 +147,11 @@ export default function ChatPage() {
       const response = await patch(`/api/chat/conversations/${id}`, { title });
       if (!response.ok) {
         setConversations(previous);
-        setLoadError("Couldn't rename this conversation.");
+        setLoadError(t('page.renameError'));
       }
     } catch {
       setConversations(previous);
-      setLoadError("Couldn't rename this conversation.");
+      setLoadError(t('page.renameError'));
     }
   }
 
@@ -164,11 +168,11 @@ export default function ChatPage() {
       if (response == null) return;
       if (!response.ok) {
         setConversations(previous);
-        setLoadError("Couldn't delete this conversation.");
+        setLoadError(t('page.deleteError'));
       }
     } catch {
       setConversations(previous);
-      setLoadError("Couldn't delete this conversation.");
+      setLoadError(t('page.deleteError'));
     }
   }
 
@@ -209,14 +213,14 @@ export default function ChatPage() {
               <line x1="3" y1="12" x2="21" y2="12" />
               <line x1="3" y1="18" x2="21" y2="18" />
             </svg>
-            Past chats
+            {t('page.pastChats')}
           </button>
           <button
             type="button"
             className={styles.mobileBarNew}
             onClick={handleNewConversation}
           >
-            New chat
+            {t('page.newChat')}
           </button>
         </div>
         {loadError != null && (

--- a/web/src/pages/Chat/CodeBlock.tsx
+++ b/web/src/pages/Chat/CodeBlock.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import styles from './CodeBlock.module.css';
 
 interface CodeBlockProps {
@@ -7,6 +8,7 @@ interface CodeBlockProps {
 }
 
 export default function CodeBlock({ language, code }: CodeBlockProps) {
+  const { t } = useTranslation('chat');
   const [copied, setCopied] = useState(false);
 
   function handleCopy() {
@@ -24,9 +26,9 @@ export default function CodeBlock({ language, code }: CodeBlockProps) {
           type="button"
           className={styles.copyBtn}
           onClick={handleCopy}
-          aria-label="Copy code"
+          aria-label={t('codeBlock.copyCode')}
         >
-          {copied ? 'Copied' : 'Copy'}
+          {copied ? t('codeBlock.copied') : t('codeBlock.copy')}
         </button>
       </div>
       <pre className={styles.pre}>

--- a/web/src/pages/Chat/ConversationsSidebar.tsx
+++ b/web/src/pages/Chat/ConversationsSidebar.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import styles from './ConversationsSidebar.module.css';
 
 export interface ConversationSummary {
@@ -26,12 +28,12 @@ function focusableElements(root: HTMLElement): HTMLElement[] {
   ).filter((el) => !el.hasAttribute('disabled'));
 }
 
-function formatRelativeTime(iso: string): string {
+function formatRelativeTime(iso: string, t: TFunction): string {
   const then = new Date(iso).getTime();
   if (Number.isNaN(then)) return '';
   const diffMs = Date.now() - then;
   const minutes = Math.floor(diffMs / 60_000);
-  if (minutes < 1) return 'just now';
+  if (minutes < 1) return t('sidebar.justNow');
   if (minutes < 60) return `${minutes}m`;
   const hours = Math.floor(minutes / 60);
   if (hours < 24) return `${hours}h`;
@@ -53,6 +55,7 @@ export default function ConversationsSidebar({
   isOpen,
   onClose,
 }: Props) {
+  const { t } = useTranslation('chat');
   const [menuOpenFor, setMenuOpenFor] = useState<number | null>(null);
   const [renamingId, setRenamingId] = useState<number | null>(null);
   const [renameDraft, setRenameDraft] = useState('');
@@ -139,7 +142,7 @@ export default function ConversationsSidebar({
         <button
           type="button"
           className={styles.scrim}
-          aria-label="Close conversations"
+          aria-label={t('sidebar.closeConversations')}
           onClick={onClose}
         />
       )}
@@ -147,14 +150,14 @@ export default function ConversationsSidebar({
         ref={asideRef}
         id="conversations-sidebar"
         className={`${styles.sidebar} ${isOpen ? styles.sidebarOpen : ''}`}
-        aria-label="Conversations"
+        aria-label={t('sidebar.conversations')}
       >
         <button type="button" className={styles.newChatBtn} onClick={onNew}>
-          New chat
+          {t('sidebar.newChat')}
         </button>
 
         {conversations.length === 0 ? (
-          <p className={styles.empty}>No conversations yet. Start one below.</p>
+          <p className={styles.empty}>{t('sidebar.empty')}</p>
         ) : (
           <ul className={styles.list}>
             {conversations.map((c) => {
@@ -182,7 +185,7 @@ export default function ConversationsSidebar({
                           cancelRename();
                         }
                       }}
-                      aria-label="Conversation title"
+                      aria-label={t('sidebar.conversationTitle')}
                     />
                   ) : (
                     <button
@@ -193,7 +196,7 @@ export default function ConversationsSidebar({
                     >
                       <span className={styles.itemTitle}>{c.title}</span>
                       <span className={styles.itemMeta}>
-                        {formatRelativeTime(c.updatedAt)}
+                        {formatRelativeTime(c.updatedAt, t)}
                       </span>
                     </button>
                   )}
@@ -212,7 +215,7 @@ export default function ConversationsSidebar({
                             prev === c.id ? null : c.id
                           );
                         }}
-                        aria-label={`Options for ${c.title}`}
+                        aria-label={t('sidebar.optionsFor', { title: c.title })}
                         aria-haspopup="menu"
                         aria-expanded={menuOpenFor === c.id}
                       >
@@ -227,7 +230,7 @@ export default function ConversationsSidebar({
                             className={styles.menuItem}
                             onClick={() => startRename(c.id, c.title)}
                           >
-                            Rename
+                            {t('sidebar.rename')}
                           </button>
                           <button
                             type="button"
@@ -238,7 +241,7 @@ export default function ConversationsSidebar({
                               onDelete(c.id);
                             }}
                           >
-                            Delete
+                            {t('sidebar.delete')}
                           </button>
                         </div>
                       )}

--- a/web/src/pages/SearchPage/SearchPage.i18n.test.tsx
+++ b/web/src/pages/SearchPage/SearchPage.i18n.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import i18n from '../../lib/i18n';
+import ConnectNotion from './components/ConnectNotion';
+import ListSearchResults from './components/ListSearchResults';
+
+describe('Search surfaces in German', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('de');
+  });
+
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('translates the Connect Notion card', () => {
+    render(<ConnectNotion ready connectionLink="https://example.test/oauth" />);
+    expect(
+      screen.getByText('Verbinde deinen Notion-Workspace')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Mit Notion verbinden' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Datei hochladen' })
+    ).toBeInTheDocument();
+  });
+
+  it('translates the empty search result with the workspace scope', () => {
+    render(
+      <ListSearchResults
+        results={[]}
+        setFavorites={vi.fn()}
+        setError={vi.fn()}
+        workSpace="Pristine’s Notion"
+      />
+    );
+    expect(
+      screen.getByText('Keine Seiten gefunden in „Pristine’s Notion“')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Notions Freigabeeinstellungen' })
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/SearchPage/SearchPage.tsx
+++ b/web/src/pages/SearchPage/SearchPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { ErrorPresenter } from '../../components/errors/ErrorPresenter';
 import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
 import { SkeletonList } from '../../components/Skeleton/Skeleton';
@@ -18,6 +19,7 @@ interface SearchPageProps {
 }
 
 export function SearchPage({ setError }: Readonly<SearchPageProps>) {
+  const { t } = useTranslation('search');
   const notionData = useNotionData(get2ankiApi());
   const { data: userLocals } = useUserLocals();
   const isAuthenticated = userLocals?.user?.id != null;
@@ -48,10 +50,12 @@ export function SearchPage({ setError }: Readonly<SearchPageProps>) {
     }
   };
 
-  const headerTitle = notionData.connected ? 'Notion' : 'Get started';
+  const headerTitle = notionData.connected
+    ? t('page.titleConnected')
+    : t('page.titleGetStarted');
   const headerSubtitle = notionData.connected
-    ? 'Find a page and convert it into an Anki deck.'
-    : 'Connect your Notion workspace or upload files to create Anki decks.';
+    ? t('page.subtitleConnected')
+    : t('page.subtitleDisconnected');
 
   let content;
   if (notionData.loading) {
@@ -87,11 +91,10 @@ export function SearchPage({ setError }: Readonly<SearchPageProps>) {
           </svg>
         </span>
         <p className={searchStyles.limitLockTitle}>
-          You&apos;ve used all {limit} cards this month
+          {t('limit.title', { limit })}
         </p>
         <p className={searchStyles.limitLockBody}>
-          {used} / {limit} cards · resets {resetsOn}, when your free cards come
-          back
+          {t('limit.body', { used, limit, resetsOn })}
         </p>
         <div className={searchStyles.limitLockActions}>
           <button
@@ -100,13 +103,15 @@ export function SearchPage({ setError }: Readonly<SearchPageProps>) {
             onClick={handleDayPass}
             disabled={dayPassPending}
           >
-            {dayPassPending ? 'Starting checkout' : 'Get Day Pass — $4'}
+            {dayPassPending
+              ? t('limit.startingCheckout')
+              : t('limit.getDayPass')}
           </button>
           <Link
             to="/limit?ref=notion-limit-wall"
             className={searchStyles.limitLockSecondary}
           >
-            See plans
+            {t('limit.seePlans')}
           </Link>
         </div>
       </div>
@@ -142,7 +147,7 @@ export function SearchPage({ setError }: Readonly<SearchPageProps>) {
             href={notionData.connectionLink}
             className={searchStyles.workspaceSwitch}
           >
-            Switch workspace
+            {t('page.switchWorkspace')}
           </a>
         </div>
       )}

--- a/web/src/pages/SearchPage/components/BlockIcon.tsx
+++ b/web/src/pages/SearchPage/components/BlockIcon.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next';
+
 interface BlockIconProp {
   icon?: string;
 }
@@ -6,12 +8,13 @@ export const isIconFileUrl = (icon: string) => icon.includes('http');
 export const isIconDataUrl = (icon: string) => icon.includes('data:image');
 
 export function BlockIcon({ icon }: Readonly<BlockIconProp>) {
+  const { t } = useTranslation('search');
   if (!icon) {
     return null;
   }
 
   if (isIconFileUrl(icon) || isIconDataUrl(icon)) {
-    return <img width={32} height={32} src={icon} alt="icon" />;
+    return <img width={32} height={32} src={icon} alt={t('icon.alt')} />;
   }
 
   return <span>{icon}</span>;

--- a/web/src/pages/SearchPage/components/ConnectNotion.tsx
+++ b/web/src/pages/SearchPage/components/ConnectNotion.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import shared from '../../../styles/shared.module.css';
 import styles from './ConnectNotion.module.css';
 
@@ -10,29 +11,25 @@ export default function ConnectNotion({
   ready,
   connectionLink,
 }: Readonly<Props>) {
+  const { t } = useTranslation('search');
   if (!ready) return null;
 
   return (
     <div className={styles.wrapper}>
       <div className={styles.card}>
-        <h3 className={styles.title}>Connect your Notion workspace</h3>
-        <p className={styles.body}>
-          Search and convert pages directly. We only read the pages you share
-          with 2anki.
-        </p>
+        <h3 className={styles.title}>{t('connect.title')}</h3>
+        <p className={styles.body}>{t('connect.body')}</p>
         <a className={shared.btnPrimary} href={connectionLink}>
-          Connect to Notion
+          {t('connect.connectButton')}
         </a>
       </div>
       <div className={styles.fallback}>
-        <p className={styles.fallbackText}>
-          Or upload a file you exported from Notion.
-        </p>
+        <p className={styles.fallbackText}>{t('connect.fallbackText')}</p>
         <a
           className={`${shared.btnSecondary} ${styles.fallbackAction}`}
           href="/upload"
         >
-          Upload a file
+          {t('connect.uploadFile')}
         </a>
       </div>
     </div>

--- a/web/src/pages/SearchPage/components/FlashcardType.tsx
+++ b/web/src/pages/SearchPage/components/FlashcardType.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import styles from '../../../styles/shared.module.css';
 
 interface FlashcardTypeProps {
@@ -15,6 +16,7 @@ export default function FlashcardType({
   active,
   isNew = false,
 }: Readonly<FlashcardTypeProps>) {
+  const { t } = useTranslation('search');
   return (
     <button
       type="button"
@@ -22,7 +24,9 @@ export default function FlashcardType({
       className={`${styles.chip} ${active ? styles.chipActive : ''}`}
     >
       {label ?? name}
-      {isNew ? <span className={styles.chipNewBadge}>New</span> : null}
+      {isNew ? (
+        <span className={styles.chipNewBadge}>{t('flashcardType.new')}</span>
+      ) : null}
     </button>
   );
 }

--- a/web/src/pages/SearchPage/components/ListSearchResults.tsx
+++ b/web/src/pages/SearchPage/components/ListSearchResults.tsx
@@ -1,4 +1,5 @@
 import { Dispatch, SetStateAction, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ErrorHandlerType } from '../../../components/errors/helpers/getErrorMessage';
 import NotionObject from '../../../lib/interfaces/NotionObject';
 import SearchObjectEntry from './SearchObjectEntry';
@@ -26,6 +27,7 @@ function relevanceRank(title: string, query: string): number {
 export default function ListSearchResults(
   props: Readonly<ListSearchResultsProps>
 ): React.ReactNode {
+  const { t } = useTranslation('search');
   const {
     results,
     handleEmpty = true,
@@ -50,24 +52,25 @@ export default function ListSearchResults(
   const isEmpty = orderedResults.length < 1;
 
   if (isEmpty && handleEmpty) {
-    const scope = workSpace ? `in “${workSpace}”` : 'in your Notion workspace';
+    const scope = workSpace
+      ? t('results.scopeWorkspace', { workSpace })
+      : t('results.scopeGeneric');
     const headline = searchQuery
-      ? `No pages match “${searchQuery}” ${scope}`
-      : `No pages found ${scope}`;
+      ? t('results.noMatch', { query: searchQuery, scope })
+      : t('results.noneFound', { scope });
     return (
       <div className={styles.emptyState}>
         <p data-hj-suppress>{headline}</p>
         <p className={styles.secondaryText}>
-          Try a different search term, or make sure the page is shared with the
-          2anki integration — see{' '}
+          {t('results.emptyBodyPrefix')}
           <a
             target="_blank"
             rel="noreferrer"
             href="https://www.notion.so/help/guides/understanding-notions-sharing-settings"
           >
-            Notion&apos;s sharing settings
+            {t('results.sharingLink')}
           </a>
-          .
+          {t('results.emptyBodySuffix')}
         </p>
       </div>
     );

--- a/web/src/pages/SearchPage/components/SearchBar.tsx
+++ b/web/src/pages/SearchPage/components/SearchBar.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import sharedStyles from '../../../styles/shared.module.css';
 import searchStyles from '../SearchPage.module.css';
 
@@ -14,17 +15,18 @@ function SearchBar({
   onSearchClicked,
   inProgress,
 }: Readonly<SearchBarProps>) {
+  const { t } = useTranslation('search');
   return (
     <div>
       <label className={sharedStyles.srOnly} htmlFor="notion-search-input">
-        Search Notion
+        {t('searchBar.label')}
       </label>
       <input
         id="notion-search-input"
         value={value}
         type="text"
         className={searchStyles.searchInput}
-        placeholder="Search Notion"
+        placeholder={t('searchBar.placeholder')}
         aria-busy={inProgress}
         data-searching={inProgress ? 'true' : 'false'}
         onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/web/src/pages/SearchPage/components/SearchObjectEntry/index.tsx
+++ b/web/src/pages/SearchPage/components/SearchObjectEntry/index.tsx
@@ -1,5 +1,6 @@
 import { Dispatch, SetStateAction, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { ErrorHandlerType } from '../../../../components/errors/helpers/getErrorMessage';
 import DotsHorizontal from '../../../../components/icons/DotsHorizontal';
 import EyeIcon from '../../../../components/icons/EyeIcon';
@@ -36,6 +37,7 @@ const getType = (data: string | { object: string }): string | null => {
 
 function SearchObjectEntry(props: Readonly<Props>) {
   const { title, icon, url, id, type, setError } = props;
+  const { t } = useTranslation('search');
   const navigate = useNavigate();
   const location = useLocation();
   const [status, setStatus] = useState<ConvertStatus>('idle');
@@ -93,27 +95,22 @@ function SearchObjectEntry(props: Readonly<Props>) {
       <div className={styles.objectActions}>
         {status === 'queued' && (
           <span className={styles.convertStatus}>
-            {restarted
-              ? 'Re-making your deck — '
-              : 'Added to your downloads — '}
-            <Link to="/downloads">view</Link>
+            {restarted ? t('entry.remaking') : t('entry.added')}
+            <Link to="/downloads">{t('entry.view')}</Link>
           </span>
         )}
         {status === 'paywall' && (
           <span className={styles.convertStatus}>
-            Free plan — one conversion at a time.{' '}
-            <Link to="/pricing">Upgrade</Link> or wait.
+            {t('entry.paywallText')}{' '}
+            <Link to="/pricing">{t('entry.upgrade')}</Link>
+            {t('entry.paywallSuffix')}
           </span>
         )}
         {status === 'conflict' && (
-          <span className={styles.convertStatus}>
-            Already converting this page.
-          </span>
+          <span className={styles.convertStatus}>{t('entry.conflict')}</span>
         )}
         {status === 'error' && (
-          <span className={styles.convertStatus}>
-            Couldn&apos;t queue this page. Try again.
-          </span>
+          <span className={styles.convertStatus}>{t('entry.error')}</span>
         )}
         <button
           type="button"
@@ -121,10 +118,14 @@ function SearchObjectEntry(props: Readonly<Props>) {
           onClick={handleConvert}
           disabled={isConverting || isQueued}
           aria-label={
-            isConverting || isQueued ? 'In progress' : 'Convert to Anki'
+            isConverting || isQueued
+              ? t('entry.inProgress')
+              : t('entry.convertToAnki')
           }
         >
-          {isConverting || isQueued ? 'In progress' : 'Convert'}
+          {isConverting || isQueued
+            ? t('entry.inProgress')
+            : t('entry.convert')}
         </button>
         <div className={styles.secondaryActions}>
           <a
@@ -132,8 +133,8 @@ function SearchObjectEntry(props: Readonly<Props>) {
             target="_blank"
             rel="noreferrer"
             className={styles.iconLink}
-            aria-label={`Open ${title} in Notion`}
-            title={`Open ${title} in Notion`}
+            aria-label={t('entry.openInNotion', { title })}
+            title={t('entry.openInNotion', { title })}
           >
             <img
               src="/icons/Notion_app_logo.png"
@@ -149,8 +150,8 @@ function SearchObjectEntry(props: Readonly<Props>) {
                 : `/preview/${encodeURIComponent(id)}`
             }
             className={styles.iconLink}
-            aria-label={`Preview ${title}`}
-            title={`Preview ${title}`}
+            aria-label={t('entry.preview', { title })}
+            title={t('entry.preview', { title })}
           >
             <EyeIcon width={20} height={20} />
           </Link>
@@ -158,8 +159,8 @@ function SearchObjectEntry(props: Readonly<Props>) {
             type="button"
             className={styles.iconBtn}
             onClick={openRules}
-            aria-label={`Configure rules for ${title}`}
-            title={`Configure rules for ${title}`}
+            aria-label={t('entry.configureRules', { title })}
+            title={t('entry.configureRules', { title })}
           >
             <DotsHorizontal width={20} height={20} />
           </button>

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-16-german-chat-search.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-16-german-chat-search.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-16-german-chat-search",
+  "date": "2026-07-16",
+  "type": "feature",
+  "title": "Chat and Notion search now available in German"
+}


### PR DESCRIPTION
## What
Adds German (`de`) translations for the Chat and Notion search surfaces. Introduces two new i18n namespaces (`chat`, `search`), each with `en`/`de` JSON, and wires every remaining user-facing string in `pages/Chat/**`, `components/ChatPanel/**`, and `pages/SearchPage/**` through `react-i18next` (`useTranslation('chat')` / `useTranslation('search')`) — JSX text, placeholders, aria-labels, titles, button labels, and toast/error messages.

## Why
Part of the app-wide German localization effort. Chat and Notion search were still English-only; German (du-form) users now get these surfaces in their language, matching the voice already established in `locales/de/common.json`.

## How
- New namespace files auto-load via the existing `locales/*/*.json` glob in `lib/i18n/index.ts` — no edit to `index.ts` or `common.json`.
- English namespace values mirror the current strings verbatim, so all existing English-assuming tests stay green.
- Interpolation (`{{count}}`, `{{name}}`, `{{scope}}`, `{{title}}`, …) and i18next plurals (`_one`/`_other`) replace the old template-literal string building for card counts, tag counts, usage lines, and empty-state scopes.
- `ConversationsSidebar`'s relative-time helper now takes `t` for its "just now" label; the compact `Nm`/`Nh`/`Nd` unit suffixes stay as-is (locale-neutral abbreviations).

## Measuring success
No dedicated metric — this is localization coverage, not a funnel change. Confirm in production by switching the language picker to Deutsch and opening `/chat` and `/notion`: strings render in German with no missing-key fallbacks (react-i18next would surface the raw key on a miss).

## Testing
- Unit tests added: `ChatPage.i18n.test.tsx` (renders `/chat` in `de`, asserts the empty-state heading, composer aria-labels, and upload-origin heading), `SearchPage.i18n.test.tsx` (Connect Notion card + empty search result with workspace scope in `de`).
- Full web vitest suite green: 277 files, 2291 tests. Web typecheck green. oxlint clean on touched files. oxfmt applied.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: `pnpm --filter 2anki-web test:golden-path` passed (2/2) — landing + signed-in dashboard at 375px, no console errors.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-07-16-german-chat-search.json` — "Chat and Notion search now available in German"

## Strings intentionally left English
- `lib/chat/templates.ts` note-type `label`/`fieldHint` and `templateSwitchLabel` (out of scope — `lib/chat/**`), so the note-type dropdown shows a German "Notiztyp:" wrapper around English option labels. Flag for the templates owner.
- `SearchObjectEntry`'s `new Error('Authentication required')` — internal error passed to the shared error handler, not rendered directly; left untouched to avoid breaking any message matching.
- Protected verbatim in both locales: Notion, Anki, AnkiWeb, 2anki, Quizlet, file formats (PDF/CSV/HTML/Markdown), the `$4` Day Pass price, and the monthly-limit phrasing.
- CodeBlock's `plaintext` language fallback (technical identifier).

## Risks
Low. Purely additive namespaces + string swaps; no behavior or data changes. If an English value drifted from a test assertion it would fail loudly — the full suite is green. Rollback is reverting the branch.

## Goal alignment
None on the funnel directly — internal localization coverage. Supports the broader German-market reach effort by removing English-only friction on two paid-relevant surfaces (Chat is a paid AI surface; Notion search feeds the core conversion path).

## Sonar
Sonar not run locally (no `SONAR_TOKEN` on this box) — Automatic Analysis covers the push. Changes are string swaps + small helper-signature tweaks; no new complexity hotspots expected.
