### PR TITLE
feat: add language slots and picker options for 8 more languages

### DIFF
--- a/web/src/components/LanguagePicker/LanguagePicker.test.tsx
+++ b/web/src/components/LanguagePicker/LanguagePicker.test.tsx
@@ -16,13 +16,24 @@ describe('LanguagePicker', () => {
     localStorage.clear();
   });
 
-  it('renders English and Deutsch options', () => {
+  it('renders every supported language by its native name', () => {
     render(<LanguagePicker />);
     const select = screen.getByRole('combobox', { name: 'Language' });
     const options = Array.from(select.querySelectorAll('option')).map(
       (option) => option.textContent
     );
-    expect(options).toEqual(['English', 'Deutsch']);
+    expect(options).toEqual([
+      'English',
+      'Deutsch',
+      'Español',
+      '日本語',
+      'Français',
+      'Português',
+      'Русский',
+      'Italiano',
+      'Nederlands',
+      'Polski',
+    ]);
   });
 
   it('changes the active language to German on selection', () => {

--- a/web/src/components/LanguagePicker/LanguagePicker.tsx
+++ b/web/src/components/LanguagePicker/LanguagePicker.tsx
@@ -1,7 +1,11 @@
 import { type ChangeEvent, useId } from 'react';
 import { useTranslation } from 'react-i18next';
 import { track } from '../../lib/analytics/track';
-import { SUPPORTED_LANGUAGES, type SupportedLanguage } from '../../lib/i18n';
+import {
+  LANGUAGE_ENDONYMS,
+  SUPPORTED_LANGUAGES,
+  type SupportedLanguage,
+} from '../../lib/i18n';
 import { scheduleSync } from '../../lib/data_layer/userPreferencesSync';
 import styles from './LanguagePicker.module.css';
 
@@ -29,10 +33,11 @@ export function LanguagePicker({ variant = 'compact' }: LanguagePickerProps) {
     track('language_changed', { language: next });
   }
 
-  const options: { value: SupportedLanguage; label: string }[] = [
-    { value: 'en', label: t('language.english') },
-    { value: 'de', label: t('language.german') },
-  ];
+  const options: { value: SupportedLanguage; label: string }[] =
+    SUPPORTED_LANGUAGES.map((value) => ({
+      value,
+      label: LANGUAGE_ENDONYMS[value],
+    }));
 
   if (variant === 'labeled') {
     return (

--- a/web/src/lib/i18n/index.ts
+++ b/web/src/lib/i18n/index.ts
@@ -2,8 +2,34 @@ import i18n, { type InitOptions, type Resource } from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 
-export const SUPPORTED_LANGUAGES = ['en', 'de'] as const;
+export const SUPPORTED_LANGUAGES = [
+  'en',
+  'de',
+  'es',
+  'ja',
+  'fr',
+  'pt',
+  'ru',
+  'it',
+  'nl',
+  'pl',
+] as const;
 export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+
+// Native language names (endonyms) shown in the picker. Endonyms are the same
+// regardless of the viewer's language, so they need no translation keys.
+export const LANGUAGE_ENDONYMS: Record<SupportedLanguage, string> = {
+  en: 'English',
+  de: 'Deutsch',
+  es: 'Español',
+  ja: '日本語',
+  fr: 'Français',
+  pt: 'Português',
+  ru: 'Русский',
+  it: 'Italiano',
+  nl: 'Nederlands',
+  pl: 'Polski',
+};
 
 export const LANGUAGE_STORAGE_KEY = '2anki-language';
 


### PR DESCRIPTION
## What
Adds language slots for the next 8 languages (Spanish, Japanese, French, Portuguese, Russian, Italian, Dutch, Polish) to `SUPPORTED_LANGUAGES`, and makes the `LanguagePicker` render every supported language by its native endonym (English, Deutsch, Español, 日本語, Français, Português, Русский, Italiano, Nederlands, Polski).

## Why
Foundation for the top-10-languages rollout. Splitting this out means the 8 per-language translation PRs only add their own `locales/<lang>/*.json` files — no shared-file collisions on the picker or the supported-languages list.

## Behavior until translations land
Each new locale falls back to English per-key (`fallbackLng: 'en'`) until its catalog PR merges, so no broken/empty state ships. Auto-detect routes a browser locale to its language only once that language's catalog exists; before that it resolves to English exactly as it did before this PR.

## Verification
- Web typecheck clean
- LanguagePicker + i18n vitest: 7 passed (picker asserts all 10 native names)
- Golden-path 2/2, no console errors at 375px

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px

No changelog entry — this adds language slots and picker options only; the user-visible translations ship in the per-language PRs that follow, each with its own entry. Sonar not run locally; Automatic Analysis covers the push.
