### PR TITLE
fix: register language_changed as a known analytics event

### DIFF
--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -91,6 +91,7 @@ export const KNOWN_EVENTS = new Set([
   'subscription_paused',
   'subscription_pause_resumed',
   'subscription_cancelled_during_pause',
+  'language_changed',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;


### PR DESCRIPTION
The language picker fires language_changed, but the server allowlist (KNOWN_EVENTS) did not include it, so every language switch logged `[events] unknown event received: language_changed` and stored the event flagged unknown. Adds it to the allowlist so language-switch telemetry records cleanly (needed to see which of the 10 languages get real usage).

Server-only, one-line data change. tsc clean; 107 event tests pass.

Browser check: not applicable — server-only, no web/src changes.

No changelog entry — internal telemetry, no user-visible behavior change. Sonar not run locally; Automatic Analysis covers the push.