### PR TITLE
fix: exclude empty-deck outcomes from conversion success rate

### DIFF
--- a/src/data_layer/JobsMetricsRepository.test.ts
+++ b/src/data_layer/JobsMetricsRepository.test.ts
@@ -1,6 +1,7 @@
 import knex, { Knex } from 'knex';
 
 import { JobsMetricsRepository } from './JobsMetricsRepository';
+import { EMPTY_DECK_FAILURE_REASON } from '../usecases/jobs/jobFailureReason';
 
 async function makeDb(): Promise<Knex> {
   const db = knex({
@@ -183,6 +184,40 @@ describe('JobsMetricsRepository — counts cover the real Notion job types', () 
     expect(rate).toBeCloseTo((2 / 3) * 100, 5);
   });
 
+  it('excludes empty-deck outcomes from the free success-rate denominator', async () => {
+    await insertJob(db, {
+      owner: 'free-user',
+      object_id: 'ed-1',
+      type: 'page',
+      status: 'done',
+    });
+    await insertJob(db, {
+      owner: 'free-user',
+      object_id: 'ed-2',
+      type: 'database',
+      status: 'done',
+    });
+    await insertJob(db, {
+      owner: 'free-user',
+      object_id: 'ed-3',
+      type: 'page',
+      status: 'failed',
+      job_reason_failure: 'Notion timeout',
+    });
+    await insertJob(db, {
+      owner: 'free-user',
+      object_id: 'ed-4',
+      type: 'page',
+      status: 'failed',
+      job_reason_failure: EMPTY_DECK_FAILURE_REASON,
+    });
+
+    const rate = await repo.computeFreeSuccessRate7d(sevenDaysAgo);
+
+    // 2 done, 1 technical failure, 1 empty-deck excluded -> 2/3, not 2/4.
+    expect(rate).toBeCloseTo((2 / 3) * 100, 5);
+  });
+
   it('counts monthly-limit plan blocks per tier', async () => {
     await insertJob(db, {
       owner: 'free-user',
@@ -345,6 +380,17 @@ describe('JobsMetricsRepository — tier join emits portable SQL on Postgres', (
     const sql = getSql();
     expect(sql).toContain('NOT LIKE');
     expect(sql).toContain('"code":"monthly_limit"');
+  });
+
+  it('keeps empty-deck outcomes out of the success-rate denominator', async () => {
+    const getSql = captureCompiledSql(pg);
+    const repo = new JobsMetricsRepository(pg);
+    const sevenDaysAgo = new Date('2026-05-01T00:00:00.000Z');
+
+    await repo.computeFreeSuccessRate7d(sevenDaysAgo).catch(() => undefined);
+
+    const sql = getSql();
+    expect(sql).toContain('No cards in this deck yet.');
   });
 
   it('matches plan-limit failures on the durable reason code for the blocked count', async () => {

--- a/src/data_layer/JobsMetricsRepository.ts
+++ b/src/data_layer/JobsMetricsRepository.ts
@@ -30,6 +30,12 @@ const FREE_CUSTOMER_FILTER =
   "(users.stripe_customer_id IS NULL OR users.stripe_customer_id = '')";
 
 const PLAN_LIMIT_REASON_PATTERN = '%"code":"monthly_limit"%';
+// Empty-deck outcomes are not engine failures: the conversion ran fine, the
+// input simply had no card-yielding toggles. Excluded from the success-rate
+// denominator alongside plan blocks so user-content outcomes don't trip the
+// pipeline-health floor. Prefix matches EMPTY_DECK_FAILURE_REASON, the same
+// prefix normalizeFailureReasons keys the empty_deck code on.
+const EMPTY_DECK_REASON_PATTERN = 'No cards in this deck yet.%';
 
 export class JobsMetricsRepository implements IJobsMetricsRepository {
   constructor(private readonly database: Knex) {}
@@ -74,8 +80,8 @@ export class JobsMetricsRepository implements IJobsMetricsRepository {
           ['done']
         ),
         this.database.raw(
-          'COUNT(CASE WHEN jobs.status = ? AND (jobs.job_reason_failure IS NULL OR jobs.job_reason_failure NOT LIKE ?) THEN 1 END) as technical',
-          ['failed', PLAN_LIMIT_REASON_PATTERN]
+          'COUNT(CASE WHEN jobs.status = ? AND (jobs.job_reason_failure IS NULL OR (jobs.job_reason_failure NOT LIKE ? AND jobs.job_reason_failure NOT LIKE ?)) THEN 1 END) as technical',
+          ['failed', PLAN_LIMIT_REASON_PATTERN, EMPTY_DECK_REASON_PATTERN]
         )
       )
       .first();


### PR DESCRIPTION
The 90% conversion success-rate floor breached at 83.1%. Investigation against prod: not a pipeline regression — the 7-day rate was dragged down almost entirely by **11 empty-deck outcomes from one user on Jul 15** (a Notion page with no card-yielding toggles, retried repeatedly). Daily rate is otherwise 90-100% (Jul 16 was 30/30).

The success-rate query already excludes monthly_limit plan blocks from the denominator, but not empty-deck outcomes. An empty deck is a user-content outcome (engine ran fine, input had no toggles), not an engine failure, so it should not trip a pipeline-health floor. This extends the existing exclusion to empty_deck, matching the durable EMPTY_DECK_FAILURE_REASON prefix (the same prefix normalizeFailureReasons keys the empty_deck code on).

Effect: the floor now reflects real engine health (~97%+), and one user retrying an empty page no longer trips a false alert.

Tests: pg-dialect SQL-shape assertion + a better-sqlite3 integration test (2 done + 1 technical failure + 1 empty-deck -> 2/3, not 2/4). tsc clean, 16/16 repo tests pass.

Browser check: not applicable — server-only ops metric, no web/src changes.

No changelog entry — internal ops metric, no user-visible behavior change. Sonar not run locally; Automatic Analysis covers the push.