### PR TITLE
fix: download each Chat turn's cards in its own note type

### DIFF
--- a/web/src/components/ChatPanel/ChatPanel.test.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.test.tsx
@@ -273,6 +273,153 @@ describe('ChatPanel — CardPreview integration', () => {
   });
 });
 
+describe('ChatPanel — per-turn deck download and naming', () => {
+  beforeEach(() => {
+    mockPost.mockReset();
+    mockGet.mockResolvedValue({ used: 0, limit: 20 });
+    mockPatch.mockResolvedValue({ ok: true, status: 204 });
+    Object.assign(global, {
+      URL: {
+        createObjectURL: vi.fn(() => 'blob:test'),
+        revokeObjectURL: vi.fn(),
+      },
+    });
+  });
+
+  it('downloads an MCQ turn as mcq even when the selector defaults to Basic', async () => {
+    mockPost.mockResolvedValueOnce({
+      ok: true,
+      blob: () => Promise.resolve(new Blob()),
+    });
+    renderChatPanel({
+      initialMessages: [
+        {
+          role: 'assistant',
+          content: '',
+          cards: [
+            {
+              front: 'Which enzyme hydrolyses starch?',
+              back: '',
+              options: ['Lipase', 'Amylase', 'Protease', 'Lactase'],
+              correctIndex: 1,
+            },
+          ],
+        },
+      ],
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Download deck' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith(
+        '/api/chat/deck',
+        expect.objectContaining({ templateSlug: 'mcq' })
+      );
+    });
+  });
+
+  it('prefills the deck name from a Deck: line in the assistant message', () => {
+    renderChatPanel({
+      initialMessages: [
+        {
+          role: 'assistant',
+          content: '',
+          contentBefore: 'Deck: Japanese — Time Words',
+          cards: [{ front: 'Q1', back: 'A1' }],
+        },
+      ],
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Download deck' }));
+    const input = screen.getByRole('textbox', {
+      name: 'Deck name',
+    }) as HTMLInputElement;
+    expect(input.value).toBe('Japanese — Time Words');
+  });
+
+  it('falls back to the conversation title when there is no Deck line', () => {
+    renderChatPanel({
+      initialMessages: [
+        {
+          role: 'assistant',
+          content: '',
+          contentBefore: 'Here are your cards.',
+          cards: [{ front: 'Q1', back: 'A1' }],
+        },
+      ],
+      initialTitle: 'Cell Biology chat',
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Download deck' }));
+    const input = screen.getByRole('textbox', {
+      name: 'Deck name',
+    }) as HTMLInputElement;
+    expect(input.value).toBe('Cell Biology chat');
+  });
+});
+
+describe('ChatPanel — reselecting the current note type', () => {
+  beforeEach(() => {
+    mockPost.mockReset();
+    mockGet.mockResolvedValue({ used: 0, limit: 20 });
+    mockPatch.mockResolvedValue({ ok: true, status: 204 });
+  });
+
+  it('regenerates when the reselected note type does not match the current cards', async () => {
+    mockPost.mockResolvedValueOnce(
+      makeSseResponse([
+        {
+          event: 'done',
+          data: {
+            content: 'Reply',
+            conversationId: 7,
+            cards: [{ front: 'The capital is {{c1::Oslo}}', back: '' }],
+          },
+        },
+      ])
+    );
+    renderChatPanel({
+      initialMessages: [
+        { role: 'user', content: 'furigana deck' },
+        {
+          role: 'assistant',
+          content: 'Reply',
+          cards: [{ front: 'Capital?', back: 'Oslo' }],
+        },
+      ],
+      initialTemplateSlug: 'cloze',
+      initialConversationId: 7,
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Note type: Basic' }));
+    fireEvent.click(
+      screen.getByRole('option', { name: /Cloze/ }).querySelector('button')!
+    );
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith(
+        '/api/chat/conversations/7/regenerate',
+        { templateSlug: 'cloze' }
+      );
+    });
+  });
+
+  it('does not regenerate when the reselected note type already matches the cards', () => {
+    renderChatPanel({
+      initialMessages: [
+        { role: 'user', content: 'cloze deck' },
+        {
+          role: 'assistant',
+          content: 'Reply',
+          cards: [{ front: 'The capital is {{c1::Oslo}}', back: '' }],
+        },
+      ],
+      initialTemplateSlug: 'cloze',
+      initialConversationId: 7,
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Note type: Cloze' }));
+    fireEvent.click(
+      screen.getByRole('option', { name: /Cloze/ }).querySelector('button')!
+    );
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+});
+
 describe('ChatPanel — add tags feedback', () => {
   beforeEach(() => {
     mockPost.mockReset();

--- a/web/src/components/ChatPanel/ChatPanel.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.tsx
@@ -4,7 +4,9 @@ import { get, patch, post, postMultipart } from '../../lib/backend/api';
 import {
   type ChatCardTemplate,
   DEFAULT_TEMPLATE,
+  effectiveTemplateForCards,
   isPureClientReshape,
+  suggestDeckName,
 } from '../../lib/chat/templates';
 import { useUserLocals } from '../../lib/hooks/useUserLocals';
 import AssistantMarkdown from '../../pages/Chat/AssistantMarkdown';
@@ -58,6 +60,7 @@ export interface ChatPanelProps {
   initialConversationId?: number | null;
   initialMessages?: Message[];
   initialTemplateSlug?: ChatCardTemplate | null;
+  initialTitle?: string;
   onConversationCreated?: (id: number, title: string) => void;
   onConversationNotFound?: () => void;
   onTemplateChange?: (slug: ChatCardTemplate) => void;
@@ -269,6 +272,20 @@ function UserMessage({
   );
 }
 
+function messageDeckName(
+  message: Message,
+  conversationTitle?: string
+): string | undefined {
+  const messageText = [
+    message.contentBefore,
+    message.content,
+    message.contentAfter,
+  ]
+    .filter((s): s is string => s != null)
+    .join('\n');
+  return suggestDeckName(messageText, conversationTitle) ?? undefined;
+}
+
 function AssistantMessage({
   message,
   onSave,
@@ -279,6 +296,7 @@ function AssistantMessage({
   isRegenerating,
   onAddTags,
   isTagging,
+  conversationTitle,
 }: {
   message: Message;
   onSave?: (cards: ChatCard[], deckName: string) => void;
@@ -289,6 +307,7 @@ function AssistantMessage({
   isRegenerating?: boolean;
   onAddTags?: () => void;
   isTagging?: boolean;
+  conversationTitle?: string;
 }) {
   const hasCards = message.cards != null && message.cards.length > 0;
   const selectorOnlyPreview =
@@ -319,6 +338,7 @@ function AssistantMessage({
           isRegenerating={isRegenerating}
           onAddTags={onAddTags}
           isTagging={isTagging}
+          suggestedDeckName={messageDeckName(message, conversationTitle)}
         />
       )}
       {message.contentAfter != null && (
@@ -579,6 +599,7 @@ export default function ChatPanel({
   initialConversationId,
   initialMessages,
   initialTemplateSlug,
+  initialTitle,
   onConversationCreated,
   onConversationNotFound,
   onTemplateChange,
@@ -593,6 +614,9 @@ export default function ChatPanel({
     number | null
   >(initialConversationId ?? null);
   const [messages, setMessages] = useState<Message[]>(initialMessages ?? []);
+  const [conversationTitle, setConversationTitle] = useState(
+    initialTitle ?? ''
+  );
   const [activeTemplate, setActiveTemplate] = useState<ChatCardTemplate>(
     initialTemplateSlug ?? DEFAULT_TEMPLATE
   );
@@ -844,6 +868,9 @@ export default function ChatPanel({
       lastSavedDraftRef.current = '';
       const provisionalTitle =
         content.length > 60 ? `${content.slice(0, 60).trimEnd()}…` : content;
+      setConversationTitle((prev) =>
+        prev.trim().length > 0 ? prev : provisionalTitle
+      );
       onConversationCreated?.(result.conversationId, provisionalTitle);
       if (result.cards != null && result.cards.length > 0) {
         onCardsGenerated?.(result.cards);
@@ -887,7 +914,8 @@ export default function ChatPanel({
   }
 
   function handleSaveAsDeck(cards: ChatCard[], deckName: string) {
-    downloadDeck(cards, deckName, activeTemplate).catch(() => {
+    const templateForCards = effectiveTemplateForCards(cards, activeTemplate);
+    downloadDeck(cards, deckName, templateForCards).catch(() => {
       setNetworkError(t('errors.deckGenerate'));
     });
   }
@@ -938,7 +966,20 @@ export default function ChatPanel({
   }
 
   function handleTemplateChange(slug: ChatCardTemplate) {
-    if (slug === activeTemplate) return;
+    const lastAssistant = findLastAssistantIdx(messages);
+    const lastTurnCards =
+      lastAssistant === -1 ? [] : (messages[lastAssistant].cards ?? []);
+    const cardsMatchSlug =
+      effectiveTemplateForCards(lastTurnCards, activeTemplate) === slug;
+
+    if (slug === activeTemplate) {
+      if (cardsMatchSlug) return;
+      if (lastAssistant !== -1 && !isLoading) {
+        regenerateLastTurn(slug, lastAssistant);
+      }
+      return;
+    }
+
     const reshapeOnly = isPureClientReshape(activeTemplate, slug);
     setActiveTemplate(slug);
     onTemplateChange?.(slug);
@@ -948,7 +989,6 @@ export default function ChatPanel({
       }).catch(() => {});
     }
     if (reshapeOnly) return;
-    const lastAssistant = findLastAssistantIdx(messages);
     if (lastAssistant !== -1 && !isLoading) {
       regenerateLastTurn(slug, lastAssistant);
     }
@@ -1199,6 +1239,7 @@ export default function ChatPanel({
                             : undefined
                         }
                         isTagging={i === taggingIdx}
+                        conversationTitle={conversationTitle}
                       />
                     );
                   });

--- a/web/src/lib/chat/templates.test.ts
+++ b/web/src/lib/chat/templates.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   effectiveTemplateForCards,
   isPureClientReshape,
+  parseDeckName,
+  suggestDeckName,
   templateSwitchLabel,
 } from './templates';
 
@@ -67,6 +69,57 @@ describe('isPureClientReshape', () => {
     expect(isPureClientReshape('basic', 'cloze')).toBe(false);
     expect(isPureClientReshape('cloze', 'basic')).toBe(false);
     expect(isPureClientReshape('basic-and-reversed', 'mcq')).toBe(false);
+  });
+});
+
+describe('parseDeckName', () => {
+  it('extracts the name from a Deck: line', () => {
+    expect(parseDeckName('Here are your cards.\nDeck: Foo Bar')).toBe(
+      'Foo Bar'
+    );
+  });
+
+  it('extracts a name with an em dash and unicode', () => {
+    expect(parseDeckName('Deck: Japanese — Time Words')).toBe(
+      'Japanese — Time Words'
+    );
+  });
+
+  it('strips surrounding markdown emphasis', () => {
+    expect(parseDeckName('Deck: **Organic Chemistry**')).toBe(
+      'Organic Chemistry'
+    );
+  });
+
+  it('matches case-insensitively and trims whitespace', () => {
+    expect(parseDeckName('deck:   Cell Biology   ')).toBe('Cell Biology');
+  });
+
+  it('returns null when there is no Deck line', () => {
+    expect(parseDeckName('Here are some flashcards for you.')).toBeNull();
+  });
+
+  it('returns null for an empty Deck line', () => {
+    expect(parseDeckName('Deck:   ')).toBeNull();
+  });
+});
+
+describe('suggestDeckName', () => {
+  it('prefers the Deck line over the conversation title', () => {
+    expect(suggestDeckName('Deck: Foo Bar', 'Some conversation')).toBe(
+      'Foo Bar'
+    );
+  });
+
+  it('falls back to the conversation title when there is no Deck line', () => {
+    expect(suggestDeckName('Just some cards.', 'Cell Biology chat')).toBe(
+      'Cell Biology chat'
+    );
+  });
+
+  it('returns null when neither a Deck line nor a title is present', () => {
+    expect(suggestDeckName('Just some cards.', null)).toBeNull();
+    expect(suggestDeckName('Just some cards.', '   ')).toBeNull();
   });
 });
 

--- a/web/src/lib/chat/templates.ts
+++ b/web/src/lib/chat/templates.ts
@@ -79,3 +79,24 @@ export function effectiveTemplateForCards(
     return 'basic';
   return selected;
 }
+
+const DECK_LINE = /^[ \t]*Deck:[ \t]*(.+?)[ \t]*$/im;
+const EMPHASIS_EDGES = /^[*_`]+|[*_`]+$/g;
+
+export function parseDeckName(text: string): string | null {
+  if (typeof text !== 'string') return null;
+  const match = DECK_LINE.exec(text);
+  if (match == null) return null;
+  const name = match[1].replace(EMPHASIS_EDGES, '').trim();
+  return name.length > 0 ? name : null;
+}
+
+export function suggestDeckName(
+  messageText: string,
+  conversationTitle?: string | null
+): string | null {
+  const fromDeckLine = parseDeckName(messageText);
+  if (fromDeckLine != null) return fromDeckLine;
+  const title = conversationTitle?.trim();
+  return title != null && title.length > 0 ? title : null;
+}

--- a/web/src/pages/Chat/CardPreview.tsx
+++ b/web/src/pages/Chat/CardPreview.tsx
@@ -31,6 +31,7 @@ interface CardPreviewProps {
   isRegenerating?: boolean;
   onAddTags?: () => void;
   isTagging?: boolean;
+  suggestedDeckName?: string;
 }
 
 const MAX_VISIBLE_TAGS = 3;
@@ -126,12 +127,13 @@ export default function CardPreview({
   isRegenerating,
   onAddTags,
   isTagging,
+  suggestedDeckName,
 }: CardPreviewProps) {
   const { t } = useTranslation('chat');
   const [expanded, setExpanded] = useState(false);
   const [saveState, setSaveState] = useState<SaveState>('idle');
-  const [deckNameDraft, setDeckNameDraft] = useState(() =>
-    t('cardPreview.untitledDeck')
+  const [deckNameDraft, setDeckNameDraft] = useState(
+    () => suggestedDeckName ?? t('cardPreview.untitledDeck')
   );
   const [savedName, setSavedName] = useState<string | null>(null);
   const [showHint, setShowHint] = useState(false);

--- a/web/src/pages/Chat/ChatPage.tsx
+++ b/web/src/pages/Chat/ChatPage.tsx
@@ -40,6 +40,7 @@ interface PanelSeed {
   messages: Message[];
   draft: string;
   templateSlug: ChatCardTemplate | null;
+  title: string;
 }
 
 export default function ChatPage() {
@@ -63,6 +64,7 @@ export default function ChatPage() {
     messages: [],
     draft: prefilledPrompt,
     templateSlug: null,
+    title: '',
   });
   const [loadError, setLoadError] = useState<string | null>(null);
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -119,6 +121,7 @@ export default function ChatPage() {
         draft: data.draft ?? '',
         templateSlug:
           validSlug == null ? null : (data.templateSlug as ChatCardTemplate),
+        title: data.title ?? '',
       });
     } catch {
       setLoadError(t('page.loadError'));
@@ -134,6 +137,7 @@ export default function ChatPage() {
       messages: [],
       draft: '',
       templateSlug: null,
+      title: '',
     });
     setLoadError(null);
   }
@@ -241,6 +245,7 @@ export default function ChatPage() {
           initialConversationId={panelSeed.conversationId}
           initialMessages={panelSeed.messages}
           initialTemplateSlug={panelSeed.templateSlug}
+          initialTitle={panelSeed.title}
           onConversationCreated={(id, title) => {
             upsertConversation(id, title);
             setActiveConversationId(id);

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-17-chat-per-turn-decks.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-17-chat-per-turn-decks.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-17-chat-per-turn-decks",
+  "date": "2026-07-17",
+  "type": "fix",
+  "title": "In Chat, download each answer's cards in its own note type, with a suggested deck name"
+}


### PR DESCRIPTION
## What
Three Chat card/download fixes so users can build several card sets of different note types in one conversation and download each in its own type.

## Why
Building multiple decks in one Chat thread was broken in three ways:
- **Per-turn type (the core bug):** `handleSaveAsDeck` used the conversation-global `activeTemplate`, so downloading an earlier MCQ answer while the selector sat on Basic exported it as Basic.
- **Re-select rebuild:** when the AI overrode the requested template (e.g. produced Basic front/back for a Cloze ask), the pill showed the stored template, so clicking it was a no-op and the user could never force the rebuild.
- **Deck-name prefill:** downloads always defaulted to "Untitled", ignoring the `Deck:` line the AI usually emits and the conversation title.

## How
Client + pure-helper only — no server, regenerate, or template API changes, no validation weakened.
- **A.** `handleSaveAsDeck` now derives the note type from the specific turn's cards via `effectiveTemplateForCards(cards, activeTemplate)` and passes that to `downloadDeck`. MCQ/Cloze turns resolve unambiguously to their own type regardless of the selector.
- **B.** `handleTemplateChange` compares `effectiveTemplateForCards(lastTurnCards, activeTemplate)` to the clicked slug. It keeps the no-op only when the cards already match; when they don't (AI override case), it runs `regenerateLastTurn` even though `slug === activeTemplate`.
- **C.** New pure helpers `parseDeckName` / `suggestDeckName` in `templates.ts` parse a `Deck: <name>` line, else fall back to the conversation title, else null. `CardPreview` seeds its editable deck-name field from that instead of "Untitled". The title is threaded from `ChatPage` (loaded conversation) and, for a fresh chat, from the provisional title set on the first turn.

## Measuring success
`/api/chat/deck` request logs: `templateSlug` on a download now matches the downloaded turn's card shape (mcq/cloze) rather than always tracking the selector. No new metric wired — this is a correctness fix on an existing surface.

## Testing
- Unit tests added:
  - `templates.test.ts`: `parseDeckName` (Deck line, em dash/unicode, markdown emphasis, case-insensitive, empty → null) and `suggestDeckName` (Deck line over title, title fallback, null).
  - `ChatPanel.test.tsx`: MCQ turn downloads with `templateSlug: 'mcq'` while the selector defaults to Basic; deck name prefilled from a `Deck:` line and from the conversation title; reselecting a note type regenerates when cards don't match and is a no-op when they do.
- `pnpm --filter 2anki-web test` (templates + ChatPanel + Chat pages): green. Typecheck green. Lint clean on changed files.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: `pnpm --filter 2anki-web test:golden-path` — 2 passed.

## Changelog
`2026-07-17-chat-per-turn-decks.json` — "In Chat, download each answer's cards in its own note type, with a suggested deck name"

## Risks
Low, client-only. A basic-shaped turn whose original selector was basic-and-reversed downloads as basic-and-reversed when that selector is active (shape is identical, no way to distinguish) — same as before this change. No server/validation changes.

Sonar: no `SONAR_TOKEN` on this box — Automatic Analysis covers the push.

## Goal alignment
Retention/quality on the Chat surface: users converting several sets in one thread now get correct decks and a sensible filename, removing a re-download-and-rename friction point. No direct funnel metric; correctness on an existing paid-relevant surface.
