### PR TITLE
fix: localize in-product monthly card-limit copy

### DIFF
--- a/web/src/lib/i18n/locales/de/account.json
+++ b/web/src/lib/i18n/locales/de/account.json
@@ -98,7 +98,7 @@
     "lifetimeMeta": "Alle aktuellen und künftigen Funktionen.",
     "premiumMeta": "Unbegrenzte Karten, alle Formate.",
     "free": "Kostenlos",
-    "freeMeta": "100 cards per month.",
+    "freeMeta": "100 Karten pro Monat.",
     "seePlans": "Tarife ansehen"
   },
   "checkout": {

--- a/web/src/lib/i18n/locales/de/common.json
+++ b/web/src/lib/i18n/locales/de/common.json
@@ -306,9 +306,9 @@
   "pricing": {
     "kicker": "Tarife",
     "title": "Preise",
-    "contextBanner": "Du nutzt den kostenlosen Tarif — 100 cards per month.",
+    "contextBanner": "Du nutzt den kostenlosen Tarif — 100 Karten pro Monat.",
     "introUS": "Gemacht für verteiltes Lernen — MCAT, USMLE, Anwaltsexamen und Sprachprüfungen. Verwandle Notion-Seiten, PDFs und Fotos mit KI in Anki-Stapel — kein Konto nötig, um zu starten.",
-    "introDefault": "Verwandle Notion-Seiten, PDFs und Fotos mit KI in Anki-Stapel — kein Konto nötig, um zu starten. Melde dich kostenlos an für 100 cards per month und zahle dann einmalig pro Tag oder Woche.",
+    "introDefault": "Verwandle Notion-Seiten, PDFs und Fotos mit KI in Anki-Stapel — kein Konto nötig, um zu starten. Melde dich kostenlos an für 100 Karten pro Monat und zahle dann einmalig pro Tag oder Woche.",
     "tryFree": "Kostenlos einen Stapel konvertieren",
     "socialProof": "Von über 19 000 Lernenden weltweit genutzt",
     "payOnceSection": "Einmal zahlen — kein Abo",

--- a/web/src/lib/i18n/locales/de/de.test.ts
+++ b/web/src/lib/i18n/locales/de/de.test.ts
@@ -1,0 +1,36 @@
+import i18next, { type i18n as I18nInstance } from 'i18next';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { i18nInitOptions } from '../../index';
+
+async function createGermanInstance(): Promise<I18nInstance> {
+  const instance = i18next.createInstance();
+  await instance.init({ ...i18nInitOptions, lng: 'de' });
+  return instance;
+}
+
+describe('German monthly card-limit copy', () => {
+  let de: I18nInstance;
+
+  beforeAll(async () => {
+    de = await createGermanInstance();
+  });
+
+  it('renders the pricing context banner in German while keeping the digit 100', () => {
+    const banner = de.t('pricing.contextBanner');
+    expect(banner).toContain('100 Karten pro Monat');
+    expect(banner).not.toContain('100 cards per month');
+  });
+
+  it('renders the intro default with the German card-limit phrasing', () => {
+    const intro = de.t('pricing.introDefault');
+    expect(intro).toContain('100 Karten pro Monat');
+    expect(intro).not.toContain('100 cards per month');
+  });
+
+  it('renders the free-plan account meta in German', () => {
+    expect(de.t('planDetails.freeMeta', { ns: 'account' })).toBe(
+      '100 Karten pro Monat.'
+    );
+  });
+});

--- a/web/src/lib/i18n/locales/fr/account.json
+++ b/web/src/lib/i18n/locales/fr/account.json
@@ -98,7 +98,7 @@
     "lifetimeMeta": "Toutes les fonctionnalités actuelles et futures.",
     "premiumMeta": "Cartes illimitées, tous les formats.",
     "free": "Gratuit",
-    "freeMeta": "100 cards per month.",
+    "freeMeta": "100 cartes par mois.",
     "seePlans": "Voir les offres"
   },
   "checkout": {

--- a/web/src/lib/i18n/locales/fr/common.json
+++ b/web/src/lib/i18n/locales/fr/common.json
@@ -306,9 +306,9 @@
   "pricing": {
     "kicker": "Offres",
     "title": "Tarifs",
-    "contextBanner": "Tu es sur l'offre gratuite — 100 cards per month.",
+    "contextBanner": "Tu es sur l'offre gratuite — 100 cartes par mois.",
     "introUS": "Conçu pour la répétition espacée — MCAT, USMLE, examen du barreau et apprentissage des langues. Transforme des pages Notion, des PDF et des photos en paquets Anki avec l'IA — aucun compte nécessaire pour commencer.",
-    "introDefault": "Transforme des pages Notion, des PDF et des photos en paquets Anki avec l'IA — aucun compte nécessaire pour commencer. Inscris-toi gratuitement pour 100 cards per month, puis paie une seule fois à la journée ou à la semaine.",
+    "introDefault": "Transforme des pages Notion, des PDF et des photos en paquets Anki avec l'IA — aucun compte nécessaire pour commencer. Inscris-toi gratuitement pour 100 cartes par mois, puis paie une seule fois à la journée ou à la semaine.",
     "tryFree": "Convertir un paquet gratuitement",
     "socialProof": "Adopté par plus de 19 000 apprenants dans le monde",
     "payOnceSection": "Paie une seule fois — sans abonnement",

--- a/web/src/lib/i18n/locales/ja/account.json
+++ b/web/src/lib/i18n/locales/ja/account.json
@@ -98,7 +98,7 @@
     "lifetimeMeta": "現在および今後のすべての機能。",
     "premiumMeta": "無制限のカード、すべての形式。",
     "free": "無料",
-    "freeMeta": "100 cards per month.",
+    "freeMeta": "毎月100枚のカード。",
     "seePlans": "プランを見る"
   },
   "checkout": {

--- a/web/src/lib/i18n/locales/ja/common.json
+++ b/web/src/lib/i18n/locales/ja/common.json
@@ -304,9 +304,9 @@
   "pricing": {
     "kicker": "プラン",
     "title": "料金",
-    "contextBanner": "無料プランをご利用中です — 100 cards per month.",
+    "contextBanner": "無料プランをご利用中です — 毎月100枚のカード。",
     "introUS": "間隔反復学習のために作られました — MCAT、USMLE、司法試験、語学対策に。Notion ページ、PDF、写真を AI で Anki デッキに変換 — アカウントなしで始められます。",
-    "introDefault": "Notion ページ、PDF、写真を AI で Anki デッキに変換 — アカウントなしで始められます。無料登録で 100 cards per month、その後は 1 日または 1 週間ごとに一度だけお支払いください。",
+    "introDefault": "Notion ページ、PDF、写真を AI で Anki デッキに変換 — アカウントなしで始められます。無料登録で毎月100枚のカード、その後は 1 日または 1 週間ごとに一度だけお支払いください。",
     "tryFree": "デッキを無料で変換",
     "socialProof": "世界中の 19,000 人以上の学習者に利用されています",
     "payOnceSection": "一度だけのお支払い — サブスクリプションなし",

--- a/web/src/lib/i18n/locales/nl/account.json
+++ b/web/src/lib/i18n/locales/nl/account.json
@@ -98,7 +98,7 @@
     "lifetimeMeta": "Alle huidige en toekomstige functies.",
     "premiumMeta": "Onbeperkt kaarten, alle formaten.",
     "free": "Free",
-    "freeMeta": "100 cards per month.",
+    "freeMeta": "100 kaarten per maand.",
     "seePlans": "Bekijk abonnementen"
   },
   "checkout": {

--- a/web/src/lib/i18n/locales/nl/common.json
+++ b/web/src/lib/i18n/locales/nl/common.json
@@ -306,9 +306,9 @@
   "pricing": {
     "kicker": "Abonnementen",
     "title": "Prijzen",
-    "contextBanner": "Je zit op het gratis abonnement — 100 cards per month.",
+    "contextBanner": "Je zit op het gratis abonnement — 100 kaarten per maand.",
     "introUS": "Gemaakt voor spaced repetition — MCAT, USMLE, toetsen en taalstudie. Zet Notion-pagina's, PDF's en foto's om in Anki-decks met AI — geen account nodig om te beginnen.",
-    "introDefault": "Zet Notion-pagina's, PDF's en foto's om in Anki-decks met AI — geen account nodig om te beginnen. Meld je gratis aan voor 100 cards per month, en betaal daarna eenmalig per dag of per week.",
+    "introDefault": "Zet Notion-pagina's, PDF's en foto's om in Anki-decks met AI — geen account nodig om te beginnen. Meld je gratis aan voor 100 kaarten per maand, en betaal daarna eenmalig per dag of per week.",
     "tryFree": "Zet gratis een deck om",
     "socialProof": "Vertrouwd door 19.000+ lerenden wereldwijd",
     "payOnceSection": "Betaal eenmalig — geen abonnement",

--- a/web/src/lib/i18n/locales/nl/nl.test.ts
+++ b/web/src/lib/i18n/locales/nl/nl.test.ts
@@ -92,6 +92,6 @@ describe('Dutch (nl) locale parity', () => {
     const common = flatten(nlCommon);
     expect(common['pricing.pass.getDayPass']).toBe('Get Day Pass');
     expect(common['pricing.unlimited.getUnlimited']).toBe('Get Unlimited');
-    expect(common['pricing.contextBanner']).toContain('100 cards per month');
+    expect(common['pricing.contextBanner']).toContain('100 kaarten per maand');
   });
 });

--- a/web/src/lib/i18n/locales/nl/tools.json
+++ b/web/src/lib/i18n/locales/nl/tools.json
@@ -350,7 +350,7 @@
     "title": "Mindmaps",
     "subtitle": "Bouw een map en download hem daarna als Anki-deck.",
     "newMap": "Nieuwe map",
-    "monthlyLimit": "Your monthly limit: 3 mindmaps. Upgrade voor onbeperkt.",
+    "monthlyLimit": "Je maandlimiet: 3 mindmaps. Upgrade voor onbeperkt.",
     "noMapsYet": "Nog geen mindmaps.",
     "untitled": "Naamloos",
     "deleteAria": "{{title}} verwijderen",

--- a/web/src/lib/i18n/locales/pl/account.json
+++ b/web/src/lib/i18n/locales/pl/account.json
@@ -98,7 +98,7 @@
     "lifetimeMeta": "Wszystkie obecne i przyszłe funkcje.",
     "premiumMeta": "Nieograniczone karty, wszystkie formaty.",
     "free": "Darmowy",
-    "freeMeta": "100 cards per month.",
+    "freeMeta": "100 kart miesięcznie.",
     "seePlans": "Zobacz plany"
   },
   "checkout": {

--- a/web/src/lib/i18n/locales/pt/account.json
+++ b/web/src/lib/i18n/locales/pt/account.json
@@ -98,7 +98,7 @@
     "lifetimeMeta": "Todos os recursos atuais e futuros.",
     "premiumMeta": "Cartões ilimitados, todos os formatos.",
     "free": "Free",
-    "freeMeta": "100 cards per month.",
+    "freeMeta": "100 cartões por mês.",
     "seePlans": "Ver planos"
   },
   "checkout": {

--- a/web/src/lib/i18n/locales/pt/common.json
+++ b/web/src/lib/i18n/locales/pt/common.json
@@ -306,9 +306,9 @@
   "pricing": {
     "kicker": "Planos",
     "title": "Preços",
-    "contextBanner": "Você está no plano grátis — 100 cards per month.",
+    "contextBanner": "Você está no plano grátis — 100 cartões por mês.",
     "introUS": "Feito para repetição espaçada — MCAT, USMLE, exame da OAB e estudo de idiomas. Transforme páginas do Notion, PDFs e fotos em baralhos do Anki com IA — sem precisar de conta para começar.",
-    "introDefault": "Transforme páginas do Notion, PDFs e fotos em baralhos do Anki com IA — sem precisar de conta para começar. Cadastre-se grátis para 100 cards per month e depois pague uma vez por dia ou por semana.",
+    "introDefault": "Transforme páginas do Notion, PDFs e fotos em baralhos do Anki com IA — sem precisar de conta para começar. Cadastre-se grátis para 100 cartões por mês e depois pague uma vez por dia ou por semana.",
     "tryFree": "Converter um baralho grátis",
     "socialProof": "Confiado por mais de 19.000 estudantes no mundo todo",
     "payOnceSection": "Pague uma vez — sem assinatura",

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-17-localized-limit-copy.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-17-localized-limit-copy.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-17-localized-limit-copy",
+  "date": "2026-07-17",
+  "type": "fix",
+  "title": "The monthly card-limit messages now read in your language"
+}


### PR DESCRIPTION
## What
Localizes the in-product monthly card-limit copy into the languages where it still read English. The free-plan limit strings — the `/pricing` context banner, the landing intro default, the account plan meta, and the mindmap monthly-limit line — kept an English fragment ("100 cards per month", "Your monthly limit") in de, fr, ja, nl, pl, and pt. This translates the surrounding words while keeping the digit **100** and every interpolation intact.

## Why
A German or Japanese learner on the free plan saw a sentence that switched to English mid-way ("Du nutzt den kostenlosen Tarif — 100 cards per month."). VOICE.md's protected-string row says the in-product personal/limit phrasing *should* be localized so it reads native (keep the digit, translate the words); only the `/pricing` marketing string stays verbatim English for SEO. es, it, and ru were already localized — this finishes the other locales for consistency.

## How
Only locale JSON *values* changed (plus one test). Keys localized:
- `common.json` — `pricing.contextBanner`, `pricing.introDefault` (de, fr, ja, nl, pt)
- `account.json` — `planDetails.freeMeta` (de, fr, ja, nl, pl, pt)
- `tools.json` — `mindmaps.monthlyLimit` (nl only — it still had "Your monthly limit")

The digit 100 and all `{{...}}` interpolation are preserved. Japanese uses the 枚 card counter ("毎月100枚のカード"), matching `pricingtable.json`. The `/pricing` marketing table (`pricingtable.json`, all 10 locales) is **untouched** — it keeps "100 cards per month" verbatim by design. `accountx.json` LimitPage strings were already fully localized via `{{count}}` and needed no change.

The old `nl.test.ts` assertion treated the context banner as a protected verbatim string; updated it to assert the localized Dutch phrasing (still checking the digit survives). Added `de/de.test.ts` — a render test that resolves `t('pricing.contextBanner')` / `t('pricing.introDefault')` / `t('planDetails.freeMeta')` under `de` and asserts the German phrasing renders with the digit 100 and no leftover English.

## Measuring success
No metric — this is a copy correctness fix in already-translated surfaces. Confirmed via grep: no non-`en`, non-`pricingtable` locale JSON contains "100 cards per month" / "Your monthly limit" / "cards a month" after the change.

## Testing
- Unit tests added: `web/src/lib/i18n/locales/de/de.test.ts` (3 assertions: banner, intro, plan meta render in German, digit 100 preserved).
- Updated: `nl.test.ts` banner assertion.
- `pnpm --filter 2anki-web test src/lib/i18n` — 10 files, 193 passed (locale-completeness tests still green; more translated strings only help the >0.9 threshold).
- `tsc --noEmit` clean; `oxlint` clean; `oxfmt --check` clean.
- `test:golden-path` — 2 passed.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: verified via `pnpm --filter 2anki-web test:golden-path` (2 passed, 375px viewport, no console errors).

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-07-17-localized-limit-copy.json` — "The monthly card-limit messages now read in your language"

## Sonar
Sonar not run locally (no `SONAR_TOKEN` on this box); Automatic Analysis covers the push. Change is locale JSON values + one small test — no new logic, no security surface.

## Risks
Low. Only translation strings and one test change; no code paths touched. The `/pricing` marketing string is explicitly left English. Rollback is a revert.

## Goal alignment
None — internal copy-quality fix in already-shipped, already-translated surfaces. Improves the free-plan experience for non-English learners (the free tier is the top of the acquisition funnel), but no funnel metric is directly attributed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs4pvvQ4BKVpvEtGA9GXTn
