### PR TITLE
fix: keep chat attachment text across follow-up turns

### DIFF
--- a/migrations/20260921000000_add_attachment_text_to_chat_messages.js
+++ b/migrations/20260921000000_add_attachment_text_to_chat_messages.js
@@ -1,0 +1,11 @@
+module.exports.up = async function (knex) {
+  await knex.schema.alterTable('chat_messages', (table) => {
+    table.text('attachment_text').nullable();
+  });
+};
+
+module.exports.down = async function (knex) {
+  await knex.schema.alterTable('chat_messages', (table) => {
+    table.dropColumn('attachment_text');
+  });
+};

--- a/src/data_layer/ChatMessagesRepository.ts
+++ b/src/data_layer/ChatMessagesRepository.ts
@@ -6,6 +6,7 @@ export interface ChatMessageRow {
   conversation_id: number | null;
   role: 'user' | 'assistant';
   content: string;
+  attachment_text: string | null;
   created_at: Date;
 }
 
@@ -14,11 +15,22 @@ export interface ChatMessageInsert {
   conversationId: number | null;
   role: 'user' | 'assistant';
   content: string;
+  attachmentText?: string | null;
+}
+
+export interface ChatHistoryMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  attachmentText: string | null;
 }
 
 export interface IChatMessagesRepository {
   insert(entry: ChatMessageInsert): Promise<void>;
   countThisMonth(userId: number): Promise<number>;
+  listForConversation(input: {
+    userId: number;
+    conversationId: number;
+  }): Promise<ChatHistoryMessage[]>;
   findLatestAssistantInConversation(input: {
     userId: number;
     conversationId: number;
@@ -42,6 +54,7 @@ export class ChatMessagesRepository implements IChatMessagesRepository {
       conversation_id: entry.conversationId,
       role: entry.role,
       content: entry.content,
+      attachment_text: entry.attachmentText ?? null,
     });
   }
 
@@ -57,6 +70,31 @@ export class ChatMessagesRepository implements IChatMessagesRepository {
       .first();
 
     return Number(result?.count ?? 0);
+  }
+
+  async listForConversation(input: {
+    userId: number;
+    conversationId: number;
+  }): Promise<ChatHistoryMessage[]> {
+    const rows = await this.database(this.table)
+      .where({
+        user_id: input.userId,
+        conversation_id: input.conversationId,
+      })
+      .orderBy('created_at', 'asc')
+      .orderBy('id', 'asc')
+      .select<
+        {
+          role: 'user' | 'assistant';
+          content: string;
+          attachment_text: string | null;
+        }[]
+      >('role', 'content', 'attachment_text');
+    return rows.map((row) => ({
+      role: row.role,
+      content: row.content,
+      attachmentText: row.attachment_text,
+    }));
   }
 
   async findLatestAssistantInConversation(input: {
@@ -103,6 +141,7 @@ export class InMemoryChatMessagesRepository implements IChatMessagesRepository {
     conversation_id: number | null;
     role: 'user' | 'assistant';
     content: string;
+    attachment_text: string | null;
     created_at: Date;
   }> = [];
   private nextId = 1;
@@ -114,6 +153,7 @@ export class InMemoryChatMessagesRepository implements IChatMessagesRepository {
       conversation_id: entry.conversationId,
       role: entry.role,
       content: entry.content,
+      attachment_text: entry.attachmentText ?? null,
       created_at: new Date(),
     });
   }
@@ -126,6 +166,27 @@ export class InMemoryChatMessagesRepository implements IChatMessagesRepository {
     return this.rows.filter(
       (r) => r.user_id === userId && r.created_at >= firstOfMonth
     ).length;
+  }
+
+  async listForConversation(input: {
+    userId: number;
+    conversationId: number;
+  }): Promise<ChatHistoryMessage[]> {
+    return this.rows
+      .filter(
+        (r) =>
+          r.user_id === input.userId &&
+          r.conversation_id === input.conversationId
+      )
+      .sort((a, b) => {
+        const t = a.created_at.getTime() - b.created_at.getTime();
+        return t === 0 ? a.id - b.id : t;
+      })
+      .map((r) => ({
+        role: r.role,
+        content: r.content,
+        attachmentText: r.attachment_text,
+      }));
   }
 
   async findLatestAssistantInConversation(input: {

--- a/src/data_layer/public/ChatMessages.ts
+++ b/src/data_layer/public/ChatMessages.ts
@@ -20,6 +20,8 @@ export default interface ChatMessages {
   created_at: Date;
 
   conversation_id: ConversationsId | null;
+
+  attachment_text: string | null;
 }
 
 /** Represents the initializer for the table public.chat_messages */
@@ -37,6 +39,8 @@ export interface ChatMessagesInitializer {
   created_at?: Date;
 
   conversation_id?: ConversationsId | null;
+
+  attachment_text?: string | null;
 }
 
 /** Represents the mutator for the table public.chat_messages */
@@ -52,4 +56,6 @@ export interface ChatMessagesMutator {
   created_at?: Date;
 
   conversation_id?: ConversationsId | null;
+
+  attachment_text?: string | null;
 }

--- a/src/usecases/chat/ChatUseCase.test.ts
+++ b/src/usecases/chat/ChatUseCase.test.ts
@@ -791,6 +791,109 @@ describe('ChatUseCase', () => {
     });
   });
 
+  describe('attachment memory across turns', () => {
+    function historyText(stream: jest.Mock, callIndex: number): string {
+      const callArg = stream.mock.calls[callIndex][0];
+      const priorMessages = callArg.messages.slice(0, -1);
+      return priorMessages
+        .map((m: { content: unknown }) =>
+          typeof m.content === 'string' ? m.content : ''
+        )
+        .join('\n');
+    }
+
+    it('retains the attachment text on a follow-up turn in the same conversation', async () => {
+      const { anthropic, useCase } = buildUseCase('answer');
+
+      const first = await useCase.execute({
+        user: FREE_USER,
+        content: 'Make cards from this',
+        conversationHistory: [],
+        attachments: [
+          {
+            mimeType: MARKDOWN_MIME,
+            data: Buffer.from(
+              '# Photosynthesis\n\nConverts light to energy.',
+              'utf8'
+            ),
+            fileName: 'bio.md',
+          },
+        ],
+      });
+
+      await useCase.execute({
+        user: FREE_USER,
+        content: 'What did it say about energy?',
+        conversationHistory: [
+          { role: 'user', content: 'Make cards from this' },
+          { role: 'assistant', content: 'answer' },
+        ],
+        conversationId: first.conversationId,
+      });
+
+      const text = historyText(anthropic.messages.stream, 1);
+      expect(text).toContain('<file name="bio.md">');
+      expect(text).toContain('Converts light to energy.');
+    });
+
+    it('persists the extracted text separately, keeping the stored message content raw', async () => {
+      const { messagesRepo, useCase } = buildUseCase('answer');
+
+      const first = await useCase.execute({
+        user: FREE_USER,
+        content: 'Summarize this',
+        conversationHistory: [],
+        attachments: [
+          {
+            mimeType: MARKDOWN_MIME,
+            data: Buffer.from('Krebs cycle produces ATP.', 'utf8'),
+            fileName: 'notes.md',
+          },
+        ],
+      });
+
+      const persisted = await messagesRepo.listForConversation({
+        userId: FREE_USER.owner,
+        conversationId: first.conversationId,
+      });
+      const userMsg = persisted.find((m) => m.role === 'user');
+      expect(userMsg?.content).toBe('Summarize this');
+      expect(userMsg?.attachmentText).toContain('<file name="notes.md">');
+      expect(userMsg?.attachmentText).toContain('Krebs cycle produces ATP.');
+    });
+
+    it('caps very large extracted text carried into later turns', async () => {
+      const { anthropic, useCase } = buildUseCase('answer');
+      const big = `${'A'.repeat(25_000)}ENDMARKER_XYZ`;
+
+      const first = await useCase.execute({
+        user: FREE_USER,
+        content: 'Make cards',
+        conversationHistory: [],
+        attachments: [
+          {
+            mimeType: MARKDOWN_MIME,
+            data: Buffer.from(big, 'utf8'),
+            fileName: 'big.md',
+          },
+        ],
+      });
+
+      await useCase.execute({
+        user: FREE_USER,
+        content: 'More please',
+        conversationHistory: [],
+        conversationId: first.conversationId,
+      });
+
+      const text = historyText(anthropic.messages.stream, 1);
+      expect(text).toContain('<file name="big.md">');
+      expect(text).toContain('[…truncated]');
+      expect(text).not.toContain('ENDMARKER_XYZ');
+      expect(text.length).toBeLessThan(21_000);
+    });
+  });
+
   describe('system prompt caching', () => {
     it('passes system as an array with a cache_control ephemeral block', async () => {
       const { anthropic, useCase } = buildUseCase('answer');

--- a/src/usecases/chat/ChatUseCase.ts
+++ b/src/usecases/chat/ChatUseCase.ts
@@ -83,6 +83,12 @@ const FREE_MONTHLY_LIMIT = 20;
 const FREE_MODEL = 'claude-haiku-4-5-20251001';
 const PATREON_MODEL = 'claude-sonnet-4-6';
 const MAX_HISTORY_TURNS = 10;
+// A follow-up turn replays the attachment text folded into its original user
+// message, so a large PDF would otherwise be re-sent on every subsequent turn.
+// The current turn still receives the full extracted text (up to
+// extractAttachmentText's 200 000-char budget); only the copy carried forward
+// as conversation memory is capped here.
+const MAX_ATTACHMENT_TEXT_IN_HISTORY = 20_000;
 const MAX_TOKENS = 4096;
 // MCQ is emitted as forced tool-use JSON (stem + 4 options + rationale per
 // card). At 4096 the structured output truncates on multi-card batches, the
@@ -186,6 +192,19 @@ function buildAutoTitle(firstMessage: string): string {
   if (trimmed.length === 0) return 'New conversation';
   if (trimmed.length <= AUTO_TITLE_MAX_LENGTH) return trimmed;
   return `${trimmed.slice(0, AUTO_TITLE_MAX_LENGTH).trimEnd()}…`;
+}
+
+function capAttachmentTextForHistory(block: string): string {
+  if (block.length <= MAX_ATTACHMENT_TEXT_IN_HISTORY) return block;
+  return `${block.slice(0, MAX_ATTACHMENT_TEXT_IN_HISTORY)}\n[…truncated]`;
+}
+
+function foldAttachmentIntoContent(
+  content: string,
+  attachmentText: string | null
+): string {
+  if (attachmentText == null || attachmentText.length === 0) return content;
+  return `${attachmentText}\n\n${content}`;
 }
 
 export class ChatRateLimitError extends Error {
@@ -477,7 +496,6 @@ export class ChatUseCase {
       });
     }
 
-    const recentHistory = conversationHistory.slice(-MAX_HISTORY_TURNS);
     const attachmentBlocks = buildAttachmentBlocks(attachments);
     const extractedText = await extractAttachmentText(attachments);
     const attachmentTextBlock = buildAttachmentTextBlock(extractedText);
@@ -490,24 +508,53 @@ export class ChatUseCase {
         ? [...attachmentBlocks, { type: 'text', text: promptText }]
         : promptText;
 
+    const historyMessages = await this.assembleHistory({
+      userId: user.owner,
+      conversationId,
+      isExistingConversation: input.conversationId != null,
+      clientHistory: conversationHistory,
+    });
+
     await this.messagesRepo.insert({
       userId: user.owner,
       conversationId,
       role: 'user',
       content,
+      attachmentText:
+        attachmentTextBlock.length > 0
+          ? capAttachmentTextForHistory(attachmentTextBlock)
+          : null,
     });
 
     return this.streamAssistantTurn({
       user,
       conversationId,
       templateSlug: input.templateSlug,
-      historyMessages: recentHistory.map((m) => ({
-        role: m.role,
-        content: m.content,
-      })),
+      historyMessages,
       userContent,
       onToken,
     });
+  }
+
+  private async assembleHistory(input: {
+    userId: number;
+    conversationId: number;
+    isExistingConversation: boolean;
+    clientHistory: ChatMessage[];
+  }): Promise<Array<{ role: 'user' | 'assistant'; content: string }>> {
+    if (input.isExistingConversation) {
+      const persisted = await this.messagesRepo.listForConversation({
+        userId: input.userId,
+        conversationId: input.conversationId,
+      });
+      return persisted.slice(-MAX_HISTORY_TURNS).map((m) => ({
+        role: m.role,
+        content: foldAttachmentIntoContent(m.content, m.attachmentText),
+      }));
+    }
+    return input.clientHistory
+      .slice(-MAX_HISTORY_TURNS)
+      .map((m) => ({ role: m.role, content: m.content }));
   }
 
   async regenerate(input: {

--- a/src/usecases/chat/TagCardsUseCase.test.ts
+++ b/src/usecases/chat/TagCardsUseCase.test.ts
@@ -91,6 +91,7 @@ describe('TagCardsUseCase', () => {
     const repo = {
       insert: jest.fn(),
       countThisMonth: jest.fn(),
+      listForConversation: jest.fn().mockResolvedValue([]),
       findLatestAssistantInConversation: jest
         .fn()
         .mockResolvedValue({ id: 42, content: stored }),
@@ -125,6 +126,7 @@ describe('TagCardsUseCase', () => {
     const repo = {
       insert: jest.fn(),
       countThisMonth: jest.fn(),
+      listForConversation: jest.fn().mockResolvedValue([]),
       findLatestAssistantInConversation: jest.fn(),
       updateContent: jest.fn(),
       deleteById: jest.fn(),

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-17-chat-attachment-memory.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-17-chat-attachment-memory.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-17-chat-attachment-memory",
+  "date": "2026-07-17",
+  "type": "fix",
+  "title": "Chat now remembers an uploaded file across follow-up messages"
+}


### PR DESCRIPTION
## What
Chat kept an uploaded file's extracted text only for the turn it was attached to. On the next message the model no longer had the document and contradicted itself ("I don't see any attachment"). This persists each message's extracted attachment text and replays it on follow-up turns.

## Why
`ChatUseCase` ran `extractAttachmentText` on the current message only and never carried the result into `conversationHistory`. Follow-up turns rebuilt the model context from history that contained just the raw typed text, so the document was gone one message later.

## How
- New nullable column `chat_messages.attachment_text` (migration + kanel-regenerated `ChatMessages` in the same PR).
- `ChatMessagesRepository.insert` stores the extracted text; new `listForConversation` reads it back.
- For an existing conversation, `ChatUseCase` now rebuilds model history from the persisted messages (consistent with how `regenerate` already reads the DB) and folds each message's stored attachment text back into its original user turn. New conversations keep the existing client-history path.
- **Size cap:** the copy carried forward is truncated to 20 000 characters (`MAX_ATTACHMENT_TEXT_IN_HISTORY`) so a large PDF does not re-inflate the context window on every subsequent turn. The current turn still receives the full extracted text (up to the 200 000-char extraction budget); only the carried-forward memory is capped.
- Scope: does not touch the system prompt, refusal/safety behavior, or the `regenerate`/display path (which would widen the client-facing message shape). Only the follow-up-turn context loss is fixed.

## Measuring success
No new metric. The behavior is verifiable in the chat: attach a file, discuss it, then ask a follow-up — the model keeps the document. Server-side, a follow-up turn's outbound Anthropic `messages` now contains the `<file name="…">` block folded into the prior user turn.

## Testing
- Unit/integration (Jest, Anthropic client + docx conversion mocked at the module boundary):
  - follow-up turn in the same conversation retains the attachment's extracted text in the assembled history (fails on old code for the right reason — attachment absent from history)
  - stored message keeps `content` raw while `attachment_text` holds the extracted block (round-trip through the repo)
  - very large extracted text is truncated with a marker and bounded when carried into later turns
- Full server chat suites green; `tsc -p .` (compiles tests) green after updating the `IChatMessagesRepository` mock literals in `TagCardsUseCase.test.ts`.
- Web typecheck + full vitest (changelog uniqueness loader) green.

## Browser check
Browser check: not applicable — server-only change; the sole `web/src` file is the changelog JSON.

## Changelog
`Chat now remembers an uploaded file across follow-up messages`

## Risks
- Follow-up turns for an existing conversation now source history from the DB instead of the client-supplied `history`. Existing chat tests that reuse a conversation stay green; the DB is already the source of truth for `regenerate`.
- Rollback: revert the PR. The migration is additive (nullable column); the column can stay unused with no effect. `regenerate` and the conversation-display path are unchanged and still lose the attachment on their own paths — a known, deliberately-deferred gap noted here, not fixed in this PR.
- Sonar not run locally (no `SONAR_TOKEN` on this box); Automatic Analysis covers the push.

## Goal alignment
Retention/quality of the Chat surface — removes a self-contradiction that makes the assistant look broken mid-conversation, protecting trust for paid users who lean on file uploads. No direct funnel metric; internal correctness fix on an existing surface.
