### PR TITLE
style: format i18n files to satisfy oxfmt tree-check

### DIFF
--- a/web/src/components/FeatureDoor/FeatureDoor.tsx
+++ b/web/src/components/FeatureDoor/FeatureDoor.tsx
@@ -20,11 +20,7 @@ interface FeatureDoorProps {
   question?: string;
 }
 
-export function FeatureDoor({
-  featureKey,
-  title,
-  question,
-}: FeatureDoorProps) {
+export function FeatureDoor({ featureKey, title, question }: FeatureDoorProps) {
   const { t } = useTranslation('marketing');
   const questionText = question ?? t('featureDoor.defaultQuestion');
   const [stage, setStage] = useState<Stage>({ kind: 'prompt' });

--- a/web/src/components/FeedbackWidget/FeedbackWidget.i18n.test.tsx
+++ b/web/src/components/FeedbackWidget/FeedbackWidget.i18n.test.tsx
@@ -21,8 +21,6 @@ describe('FeedbackWidget in German', () => {
   it('translates the prompt and rating labels', () => {
     render(<FeedbackWidget page="about" />);
     expect(screen.getByText('Wie ist deine Erfahrung?')).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: 'Wütend' })
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Wütend' })).toBeInTheDocument();
   });
 });

--- a/web/src/lib/i18n/locales/es/es.test.ts
+++ b/web/src/lib/i18n/locales/es/es.test.ts
@@ -62,18 +62,21 @@ describe('Spanish locale', () => {
     expect(flatKeys(es).sort()).toEqual(flatKeys(en).sort());
   });
 
-  it.each(namespaces)('%s preserves interpolation placeholders', (_name, en, es) => {
-    const enLeaves = new Map(leafPairs(en));
-    for (const [key, esValue] of leafPairs(es)) {
-      const enValue = enLeaves.get(key);
-      if (enValue == null) {
-        continue;
+  it.each(namespaces)(
+    '%s preserves interpolation placeholders',
+    (_name, en, es) => {
+      const enLeaves = new Map(leafPairs(en));
+      for (const [key, esValue] of leafPairs(es)) {
+        const enValue = enLeaves.get(key);
+        if (enValue == null) {
+          continue;
+        }
+        const enTokens = (enValue.match(/{{\s*[\w]+\s*}}/g) ?? []).sort();
+        const esTokens = (esValue.match(/{{\s*[\w]+\s*}}/g) ?? []).sort();
+        expect(esTokens, `placeholders differ at ${key}`).toEqual(enTokens);
       }
-      const enTokens = (enValue.match(/{{\s*[\w]+\s*}}/g) ?? []).sort();
-      const esTokens = (esValue.match(/{{\s*[\w]+\s*}}/g) ?? []).sort();
-      expect(esTokens, `placeholders differ at ${key}`).toEqual(enTokens);
     }
-  });
+  );
 
   it.each(namespaces)('%s actually translates most values', (_name, en, es) => {
     const enLeaves = new Map(leafPairs(en));

--- a/web/src/lib/i18n/locales/nl/nl.test.ts
+++ b/web/src/lib/i18n/locales/nl/nl.test.ts
@@ -34,7 +34,11 @@ const PAIRS: Array<[string, Namespace, Namespace]> = [
   ['tools', enTools, nlTools],
 ];
 
-function flatten(value: JsonValue, prefix = '', out: Record<string, string> = {}): Record<string, string> {
+function flatten(
+  value: JsonValue,
+  prefix = '',
+  out: Record<string, string> = {}
+): Record<string, string> {
   if (typeof value === 'string') {
     out[prefix] = value;
     return out;
@@ -52,16 +56,21 @@ function placeholders(text: string): string[] {
 
 describe('Dutch (nl) locale parity', () => {
   it.each(PAIRS)('%s has exactly the same keys as English', (_name, en, nl) => {
-    expect(Object.keys(flatten(nl)).sort()).toEqual(Object.keys(flatten(en)).sort());
+    expect(Object.keys(flatten(nl)).sort()).toEqual(
+      Object.keys(flatten(en)).sort()
+    );
   });
 
-  it.each(PAIRS)('%s keeps every interpolation placeholder intact', (_name, en, nl) => {
-    const flatEn = flatten(en);
-    const flatNl = flatten(nl);
-    for (const key of Object.keys(flatEn)) {
-      expect(placeholders(flatNl[key])).toEqual(placeholders(flatEn[key]));
+  it.each(PAIRS)(
+    '%s keeps every interpolation placeholder intact',
+    (_name, en, nl) => {
+      const flatEn = flatten(en);
+      const flatNl = flatten(nl);
+      for (const key of Object.keys(flatEn)) {
+        expect(placeholders(flatNl[key])).toEqual(placeholders(flatEn[key]));
+      }
     }
-  });
+  );
 
   it('translates the overwhelming majority of values away from English', () => {
     let total = 0;

--- a/web/src/lib/i18n/locales/pl/pl.test.ts
+++ b/web/src/lib/i18n/locales/pl/pl.test.ts
@@ -55,7 +55,11 @@ function baseKeys(value: Json): Set<string> {
   return bases;
 }
 
-function collectLeafEntries(value: unknown, prefix: string, out: Map<string, string>) {
+function collectLeafEntries(
+  value: unknown,
+  prefix: string,
+  out: Map<string, string>
+) {
   if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
     for (const [key, child] of Object.entries(value as Json)) {
       collectLeafEntries(child, prefix ? `${prefix}.${key}` : key, out);
@@ -73,7 +77,9 @@ describe('Polish locale', () => {
     (name) => {
       const { en, pl } = namespaces[name];
       const plBases = baseKeys(pl);
-      const missing = Array.from(baseKeys(en)).filter((key) => !plBases.has(key));
+      const missing = Array.from(baseKeys(en)).filter(
+        (key) => !plBases.has(key)
+      );
       expect(missing).toEqual([]);
     }
   );

--- a/web/src/lib/i18n/locales/pt/pt.test.ts
+++ b/web/src/lib/i18n/locales/pt/pt.test.ts
@@ -54,11 +54,14 @@ function placeholders(value: string): string[] {
 }
 
 describe('Portuguese (pt) locale', () => {
-  it.each(namespaces)('%s has the exact same keys as English', (_name, en, pt) => {
-    const enKeys = Object.keys(flatten(en)).sort();
-    const ptKeys = Object.keys(flatten(pt)).sort();
-    expect(ptKeys).toEqual(enKeys);
-  });
+  it.each(namespaces)(
+    '%s has the exact same keys as English',
+    (_name, en, pt) => {
+      const enKeys = Object.keys(flatten(en)).sort();
+      const ptKeys = Object.keys(flatten(pt)).sort();
+      expect(ptKeys).toEqual(enKeys);
+    }
+  );
 
   it.each(namespaces)(
     '%s preserves every interpolation placeholder',

--- a/web/src/pages/AboutPage/AboutPage.i18n.test.tsx
+++ b/web/src/pages/AboutPage/AboutPage.i18n.test.tsx
@@ -30,9 +30,7 @@ describe('AboutPage in German', () => {
 
   it('keeps the SuperMemo link inside the translated philosophy', () => {
     render(<AboutPage />);
-    expect(
-      screen.getByRole('link', { name: 'SuperMemo' })
-    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'SuperMemo' })).toBeInTheDocument();
     expect(
       screen.getByText(/Wir bauen keinen Anki-Ersatz/i)
     ).toBeInTheDocument();

--- a/web/src/pages/DocsPage/content/de/help/limits.md
+++ b/web/src/pages/DocsPage/content/de/help/limits.md
@@ -7,11 +7,11 @@ description: Was auf jedem Plan erlaubt ist und wie lange deine Decks bleiben.
 
 ## Karten pro Monat
 
-| Plan                    | Karten pro Monat        |
-| ----------------------- | ----------------------- |
-| Anonym (kein Konto)     | 21 pro Konvertierung    |
-| Kostenloses Konto       | 100 pro Monat           |
-| Subscription / Lifetime | Unbegrenzt              |
+| Plan                    | Karten pro Monat     |
+| ----------------------- | -------------------- |
+| Anonym (kein Konto)     | 21 pro Konvertierung |
+| Kostenloses Konto       | 100 pro Monat        |
+| Subscription / Lifetime | Unbegrenzt           |
 
 Das kostenlose Monatslimit zählt Karten über **jeden** Konvertierungsweg — Datei-Uploads, `.zip`, Notion, alle davon — nicht nur Notion. Der Zähler setzt sich zu Beginn jedes Kalendermonats zurück.
 
@@ -19,10 +19,10 @@ Ohne Konto ist jede Konvertierung auf 21 Karten begrenzt. Registriere ein kosten
 
 ## Dateigröße
 
-| Plan                    | Max. Upload-Größe    |
-| ----------------------- | -------------------- |
-| Free                    | 100 MB pro Anfrage   |
-| Subscription / Lifetime | ~10 GB pro Anfrage   |
+| Plan                    | Max. Upload-Größe  |
+| ----------------------- | ------------------ |
+| Free                    | 100 MB pro Anfrage |
+| Subscription / Lifetime | ~10 GB pro Anfrage |
 
 Free umfasst anonyme und angemeldete Nutzer ohne kostenpflichtigen Plan.
 
@@ -43,11 +43,11 @@ Die Kartenoption **Use Claude AI** ist eine Subscription-/Lifetime-Funktion. Kos
 
 Der Chat-Lernassistent ist für alle angemeldeten Nutzer verfügbar.
 
-|                       | Free             | Subscription       | Lifetime           |
-| --------------------- | ---------------- | ------------------ | ------------------ |
-| Nachrichten pro Monat | 20               | Unbegrenzt         | Unbegrenzt         |
-| Nachrichtenlänge      | 4 000 Zeichen    | 100 000 Zeichen    | 100 000 Zeichen    |
-| Modell                | Claude Haiku     | Claude Sonnet      | Claude Sonnet      |
+|                       | Free          | Subscription    | Lifetime        |
+| --------------------- | ------------- | --------------- | --------------- |
+| Nachrichten pro Monat | 20            | Unbegrenzt      | Unbegrenzt      |
+| Nachrichtenlänge      | 4 000 Zeichen | 100 000 Zeichen | 100 000 Zeichen |
+| Modell                | Claude Haiku  | Claude Sonnet   | Claude Sonnet   |
 
 Kostenlose Nutzer, die 20 Nachrichten erreichen, sehen das genaue Reset-Datum (der Erste des Folgemonats). Der Nachrichtenzähler setzt sich monatlich zurück.
 
@@ -65,11 +65,11 @@ Deine Datei liegt nur so lange auf der Festplatte, wie es dauert, das Deck zu ba
 
 Diese Wege bauen dein Deck im Hintergrund und speichern die `.apkg` in unserem Bucket, damit du es unter **My Decks** erneut herunterladen kannst und damit [Sync](/documentation/sync/how-it-works) etwas zum Aktualisieren hat.
 
-| Plan               | Wie lange deine Decks im Bucket bleiben                    |
-| ------------------ | --------------------------------------------------------- |
+| Plan               | Wie lange deine Decks im Bucket bleiben                             |
+| ------------------ | ------------------------------------------------------------------- |
 | Kostenloses Konto  | In der nächsten täglichen Bereinigung entfernt (binnen 24 Stunden). |
-| Subscription       | Behalten, solange dein Abo aktiv ist.                     |
-| Lifetime (Patreon) | Unbegrenzt behalten.                                      |
+| Subscription       | Behalten, solange dein Abo aktiv ist.                               |
+| Lifetime (Patreon) | Unbegrenzt behalten.                                                |
 
 Wenn dein Abo ausläuft, werden deine gespeicherten Decks in der nächsten täglichen Bereinigung entfernt — konvertiere erneut, und sie kommen zurück. Du kannst ein Deck auch jederzeit selbst unter **My Decks** löschen.
 
@@ -77,15 +77,15 @@ Wenn dein Abo ausläuft, werden deine gespeicherten Decks in der nächsten tägl
 
 Free deckt die Konvertierungswege ab, die die meisten Leute brauchen: eine Datei hineinziehen, ein Deck zurückbekommen. Die kostenpflichtigen Pläne fügen KI-generierte Karteikarten, größere Uploads, längere Speicherung und Notion-Sync hinzu.
 
-| Fähigkeit                                          | Free               | Subscription  | Lifetime   |
-| -------------------------------------------------- | ------------------ | ------------- | ---------- |
-| Karten pro Monat                                   | 100 (21 anonym)    | Unbegrenzt    | Unbegrenzt |
-| Anonymer Datei-Upload                              | ✓                  | ✓             | ✓          |
-| Kontofunktionen (Verlauf, Favoriten, Vorlagen)     | Anmeldung nötig    | ✓             | ✓          |
-| KI-generierte Karteikarten (Claude)                | —                  | ✓             | ✓          |
-| Chat (Lernassistent)                               | 20 Nachr. / Monat  | Unbegrenzt    | Unbegrenzt |
-| Langzeit-Deckspeicherung                           | 24 h               | aktives Abo   | unbegrenzt |
-| Auto Sync (Notion → Anki)                          | —                  | 30 $/Mo. Add-on | ✓        |
+| Fähigkeit                                      | Free              | Subscription    | Lifetime   |
+| ---------------------------------------------- | ----------------- | --------------- | ---------- |
+| Karten pro Monat                               | 100 (21 anonym)   | Unbegrenzt      | Unbegrenzt |
+| Anonymer Datei-Upload                          | ✓                 | ✓               | ✓          |
+| Kontofunktionen (Verlauf, Favoriten, Vorlagen) | Anmeldung nötig   | ✓               | ✓          |
+| KI-generierte Karteikarten (Claude)            | —                 | ✓               | ✓          |
+| Chat (Lernassistent)                           | 20 Nachr. / Monat | Unbegrenzt      | Unbegrenzt |
+| Langzeit-Deckspeicherung                       | 24 h              | aktives Abo     | unbegrenzt |
+| Auto Sync (Notion → Anki)                      | —                 | 30 $/Mo. Add-on | ✓          |
 
 Siehe die [Preisseite](/pricing) für die aktuelle Planliste. Datenschutzdetails — was wir lesen, was nicht — findest du in der [Datenschutzerklärung](/documentation/reference/privacy).
 

--- a/web/src/pages/ImageOcclusionPage/ImageOcclusionPage.tsx
+++ b/web/src/pages/ImageOcclusionPage/ImageOcclusionPage.tsx
@@ -142,7 +142,9 @@ export function ImageOcclusionPage() {
   const [hydrated, setHydrated] = useState(false);
   const [entries, setEntries] = useState<ImageEntry[]>([]);
   const [activeIndex, setActiveIndex] = useState(0);
-  const [deckName, setDeckName] = useState(() => t('occlusion.deckNamePlaceholder'));
+  const [deckName, setDeckName] = useState(() =>
+    t('occlusion.deckNamePlaceholder')
+  );
   const [mode, setMode] = useState<Mode>('hide_all');
   const [draftId, setDraftId] = useState<string | null>(null);
   const [isDownloading, setIsDownloading] = useState(false);
@@ -331,81 +333,84 @@ export function ImageOcclusionPage() {
     });
   }, []);
 
-  const handleAddFromNotion = useCallback(async (blockIds: string[]) => {
-    const placeholders: ImageEntry[] = blockIds.map(
-      (id) =>
-        ({
-          id: crypto.randomUUID(),
-          file: null,
-          imageName: `notion-${id.slice(0, 8)}`,
-          header: '',
-          rects: [],
-          previewUrl: '',
-          s3Key: null,
-          uploading: true,
-          _notionBlockId: id,
-        }) as ImageEntry & { _notionBlockId: string }
-    );
+  const handleAddFromNotion = useCallback(
+    async (blockIds: string[]) => {
+      const placeholders: ImageEntry[] = blockIds.map(
+        (id) =>
+          ({
+            id: crypto.randomUUID(),
+            file: null,
+            imageName: `notion-${id.slice(0, 8)}`,
+            header: '',
+            rects: [],
+            previewUrl: '',
+            s3Key: null,
+            uploading: true,
+            _notionBlockId: id,
+          }) as ImageEntry & { _notionBlockId: string }
+      );
 
-    setEntries((prev) => {
-      const next = [...prev, ...placeholders];
-      setActiveIndex(next.length - 1);
-      return next;
-    });
-
-    try {
-      const res = await fetch('/api/image-occlusion/draft/notion-image', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ blockIds }),
+      setEntries((prev) => {
+        const next = [...prev, ...placeholders];
+        setActiveIndex(next.length - 1);
+        return next;
       });
 
-      if (res.status === 401) {
-        setEntries((prev) =>
-          prev.filter((e) => !placeholders.some((p) => p.id === e.id))
-        );
-        setError(t('occlusion.notionRefresh'));
-        return;
-      }
-      if (!res.ok) {
+      try {
+        const res = await fetch('/api/image-occlusion/draft/notion-image', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ blockIds }),
+        });
+
+        if (res.status === 401) {
+          setEntries((prev) =>
+            prev.filter((e) => !placeholders.some((p) => p.id === e.id))
+          );
+          setError(t('occlusion.notionRefresh'));
+          return;
+        }
+        if (!res.ok) {
+          setEntries((prev) =>
+            prev.filter((e) => !placeholders.some((p) => p.id === e.id))
+          );
+          setError(t('occlusion.notionUnreachable'));
+          return;
+        }
+
+        const imported = (await res.json()) as Array<{
+          s3Key: string;
+          presignedUrl: string;
+        }>;
+
+        setEntries((prev) => {
+          const withoutPlaceholders = prev.filter(
+            (e) => !placeholders.some((p) => p.id === e.id)
+          );
+          const resolved: ImageEntry[] = imported.map((item, i) => ({
+            id: crypto.randomUUID(),
+            file: null,
+            imageName: placeholders[i]?.imageName ?? `notion-image-${i + 1}`,
+            header: '',
+            rects: [],
+            previewUrl: item.presignedUrl,
+            s3Key: item.s3Key,
+            uploading: false,
+          }));
+          const next = [...withoutPlaceholders, ...resolved];
+          if (resolved.length > 0) setActiveIndex(next.length - 1);
+          return next;
+        });
+      } catch {
         setEntries((prev) =>
           prev.filter((e) => !placeholders.some((p) => p.id === e.id))
         );
         setError(t('occlusion.notionUnreachable'));
-        return;
       }
-
-      const imported = (await res.json()) as Array<{
-        s3Key: string;
-        presignedUrl: string;
-      }>;
-
-      setEntries((prev) => {
-        const withoutPlaceholders = prev.filter(
-          (e) => !placeholders.some((p) => p.id === e.id)
-        );
-        const resolved: ImageEntry[] = imported.map((item, i) => ({
-          id: crypto.randomUUID(),
-          file: null,
-          imageName: placeholders[i]?.imageName ?? `notion-image-${i + 1}`,
-          header: '',
-          rects: [],
-          previewUrl: item.presignedUrl,
-          s3Key: item.s3Key,
-          uploading: false,
-        }));
-        const next = [...withoutPlaceholders, ...resolved];
-        if (resolved.length > 0) setActiveIndex(next.length - 1);
-        return next;
-      });
-    } catch {
-      setEntries((prev) =>
-        prev.filter((e) => !placeholders.some((p) => p.id === e.id))
-      );
-      setError(t('occlusion.notionUnreachable'));
-    }
-  }, [t]);
+    },
+    [t]
+  );
 
   const handleDownload = async () => {
     if (entries.length === 0) {

--- a/web/src/pages/ImageOcclusionPage/components/CanvasToolbar.tsx
+++ b/web/src/pages/ImageOcclusionPage/components/CanvasToolbar.tsx
@@ -99,7 +99,9 @@ export function CanvasToolbar({
       <button
         type="button"
         className={`${styles.btn} ${masksHidden ? styles.btnActive : ''}`}
-        title={masksHidden ? t('occlusion.showMasks') : t('occlusion.hideMasks')}
+        title={
+          masksHidden ? t('occlusion.showMasks') : t('occlusion.hideMasks')
+        }
         aria-label={
           masksHidden ? t('occlusion.showMasks') : t('occlusion.hideMasks')
         }

--- a/web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx
+++ b/web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx
@@ -226,7 +226,8 @@ export function NotionImportDrawer({
               ...prev,
               {
                 id,
-                title: title.trim().length > 0 ? title : t('occlusion.untitledPage'),
+                title:
+                  title.trim().length > 0 ? title : t('occlusion.untitledPage'),
                 icon,
                 images: uniqueImages,
                 loading: false,
@@ -484,7 +485,9 @@ export function NotionImportDrawer({
                             >
                               <img
                                 src={item.imageUrl}
-                                alt={item.caption || t('occlusion.notionImageAlt')}
+                                alt={
+                                  item.caption || t('occlusion.notionImageAlt')
+                                }
                                 className={styles.galleryTileImg}
                                 loading="lazy"
                                 decoding="async"

--- a/web/src/pages/ImportPage/ImportPage.tsx
+++ b/web/src/pages/ImportPage/ImportPage.tsx
@@ -119,9 +119,7 @@ export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
       <div className={sharedStyles.page}>
         <div className={sharedStyles.pageHeader}>
           <h1 className={sharedStyles.title}>{t('import.title')}</h1>
-          <p className={sharedStyles.subtitle}>
-            {t('import.connectSubtitle')}
-          </p>
+          <p className={sharedStyles.subtitle}>{t('import.connectSubtitle')}</p>
         </div>
         <div className={styles.connectCta}>
           <a href="/notion" className={sharedStyles.btnPrimary}>

--- a/web/src/pages/MindmapsPage/MindmapEditor.tsx
+++ b/web/src/pages/MindmapsPage/MindmapEditor.tsx
@@ -968,7 +968,7 @@ export function MindmapEditor() {
       onBlur={(e) => {
         const text = e.currentTarget.innerText;
         if (text.trim().length === 0) {
-          e.currentTarget.innerText = (map?.title ?? t('mindmaps.untitled'));
+          e.currentTarget.innerText = map?.title ?? t('mindmaps.untitled');
           return;
         }
         commitTitle(text);
@@ -979,7 +979,7 @@ export function MindmapEditor() {
           e.currentTarget.blur();
         } else if (e.key === 'Escape') {
           e.preventDefault();
-          e.currentTarget.innerText = (map?.title ?? t('mindmaps.untitled'));
+          e.currentTarget.innerText = map?.title ?? t('mindmaps.untitled');
           e.currentTarget.blur();
         }
         e.stopPropagation();
@@ -990,7 +990,7 @@ export function MindmapEditor() {
           : styles.sidebarTitle
       }
     >
-      {(map?.title ?? t('mindmaps.untitled'))}
+      {map?.title ?? t('mindmaps.untitled')}
     </h2>
   );
 

--- a/web/src/pages/PreviewApkgPage/PreviewApkgPage.tsx
+++ b/web/src/pages/PreviewApkgPage/PreviewApkgPage.tsx
@@ -192,7 +192,10 @@ export default function PreviewApkgPage({
                 : ''}
               {totalAll === 0
                 ? t('apkg.loadingDeck')
-                : t('apkg.cardsLoaded', { loaded: loadedCount, total: totalAll })}
+                : t('apkg.cardsLoaded', {
+                    loaded: loadedCount,
+                    total: totalAll,
+                  })}
             </>
           )}
         </p>

--- a/web/src/pages/PrintPage/components/PrintForm.tsx
+++ b/web/src/pages/PrintPage/components/PrintForm.tsx
@@ -260,7 +260,9 @@ export default function PrintForm() {
       {state === 'done' && (
         <p className={sharedStyles.notificationSuccess}>
           {t('print.doneMessage')}
-          {cardCount == null ? '' : ` — ${t('print.doneCards', { count: cardCount })}`}
+          {cardCount == null
+            ? ''
+            : ` — ${t('print.doneCards', { count: cardCount })}`}
         </p>
       )}
 

--- a/web/src/pages/StatusPage/StatusPage.tsx
+++ b/web/src/pages/StatusPage/StatusPage.tsx
@@ -90,9 +90,7 @@ export default function StatusPage() {
               />
               <span className={pageStyles.label}>{t('status.api')}</span>
               <span>
-                {status.api.ok
-                  ? t('status.operational')
-                  : t('status.degraded')}
+                {status.api.ok ? t('status.operational') : t('status.degraded')}
               </span>
             </div>
             <div className={pageStyles.signalRow}>

--- a/web/src/pages/TemplatesPage/EditorPage.tsx
+++ b/web/src/pages/TemplatesPage/EditorPage.tsx
@@ -193,7 +193,9 @@ function AIGenerateSection({ onGenerated }: Readonly<AIGenerateSectionProps>) {
       onGenerated(result.starter);
     } catch (err: unknown) {
       setError(
-        err instanceof Error ? err.message : t('templates.couldNotGenerateShort')
+        err instanceof Error
+          ? err.message
+          : t('templates.couldNotGenerateShort')
       );
       if (err instanceof AiQuotaExceededError) {
         setQuotaUpgradeUrl(err.upgradeUrl);
@@ -435,9 +437,7 @@ function EditorBody({ initialStarter, shouldFork }: Readonly<EditorBodyProps>) {
       URL.revokeObjectURL(url);
     } catch (error: unknown) {
       setSaveError(
-        error instanceof Error
-          ? error.message
-          : t('templates.couldNotGenerate')
+        error instanceof Error ? error.message : t('templates.couldNotGenerate')
       );
     }
   };
@@ -564,7 +564,9 @@ function EditorBody({ initialStarter, shouldFork }: Readonly<EditorBodyProps>) {
                   setDraft((current) => removeFieldOp(current, index))
                 }
                 disabled={draft.noteType.flds.length <= 1}
-                aria-label={t('templates.removeFieldAria', { name: field.name })}
+                aria-label={t('templates.removeFieldAria', {
+                  name: field.name,
+                })}
               >
                 {t('templates.remove')}
               </button>

--- a/web/src/pages/TemplatesPage/TemplatesPage.tsx
+++ b/web/src/pages/TemplatesPage/TemplatesPage.tsx
@@ -119,7 +119,9 @@ function NoteTypeCard({
                   ? t('templates.editAria', { name: starter.name })
                   : t('templates.customizeAria', { name: starter.name })
               }
-              title={ownedByUser ? t('templates.edit') : t('templates.customize')}
+              title={
+                ownedByUser ? t('templates.edit') : t('templates.customize')
+              }
             >
               <PencilIcon width={16} height={16} />
             </Link>
@@ -301,9 +303,7 @@ export function TemplatesPage() {
         });
       } catch (error: unknown) {
         setDownloadError(
-          error instanceof Error
-            ? error.message
-            : t('templates.couldNotDelete')
+          error instanceof Error ? error.message : t('templates.couldNotDelete')
         );
       }
     },


### PR DESCRIPTION
Several i18n PRs merged with files that passed the agents local per-file format run but failed CI tree-wide oxfmt (.oxfmtrc.json), leaving main static job red and failing every new PR format check. Ran oxfmt --write across src web/src to bring the 18 drifted files back into spec. Formatting only — no logic change.

Browser check: not applicable — formatting only, no rendered-output change.

No changelog entry — formatting only. Sonar not run locally; Automatic Analysis covers the push.