### PR TITLE
fix: land new email signups straight on the upload page

### DIFF
--- a/web/src/components/forms/RegisterForm.test.tsx
+++ b/web/src/components/forms/RegisterForm.test.tsx
@@ -71,6 +71,46 @@ describe('RegisterForm', () => {
     ).toHaveLength(1);
   });
 
+  describe('post-signup destination', () => {
+    let hrefValue: string;
+
+    beforeEach(() => {
+      hrefValue = 'http://localhost/register';
+      vi.stubGlobal('location', {
+        origin: 'http://localhost',
+        search: '',
+        get href() {
+          return hrefValue;
+        },
+        set href(value: string) {
+          hrefValue = value;
+        },
+      });
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('lands a new signup with no redirect on the upload page', async () => {
+      registerMock.mockResolvedValue({ status: 200 });
+
+      renderForm();
+      fillAndSubmit();
+
+      await waitFor(() => expect(hrefValue).toBe('/upload'));
+    });
+
+    it('honors an explicit redirect over the upload default', async () => {
+      registerMock.mockResolvedValue({ status: 200 });
+
+      renderForm('/pricing');
+      fillAndSubmit();
+
+      await waitFor(() => expect(hrefValue).toBe('/pricing'));
+    });
+  });
+
   it('fires signup_started once with method email on mount', () => {
     registerMock.mockResolvedValue({ status: 200 });
 

--- a/web/src/components/forms/RegisterForm.tsx
+++ b/web/src/components/forms/RegisterForm.tsx
@@ -88,7 +88,7 @@ function RegisterForm({ setErrorMessage, redirect }: Props) {
         );
         globalThis.location.href = redirect
           ? `/${redirect.replace(/^\//, '')}`
-          : '/';
+          : '/upload';
       } else {
         track('signup_failed', { method: 'email' });
         const body = await res.json().catch(() => null);

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-17-signup-lands-on-upload.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-17-signup-lands-on-upload.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-17-signup-lands-on-upload",
+  "date": "2026-07-17",
+  "type": "fix",
+  "title": "New accounts open straight to the upload page"
+}


### PR DESCRIPTION
Fixes #3578.

## What
The issue's own audit found the biggest signup→first-download drop is **Signup → first upload (−13.6%)** — accounts that create then never submit. Email signup fell back to `/` (home) after account creation, bouncing through the marketing hero (HomePage redirects logged-in users via `<Navigate to="/upload">`) before landing on upload. OAuth signups already go straight to `/upload` via `getRedirect`'s `DEFAULT_REDIRECT`.

This changes the no-redirect fallback in `RegisterForm` from `/` to `/upload`, so email signup matches OAuth: the new user lands directly on the upload surface — no marketing-hero flash, one fewer full-page load between account creation and the first upload. Explicit `?redirect=` (e.g. limit-wall signups carrying `redirect=/upload`, or `/register?redirect=/pricing`) is still honored — only the empty-redirect branch changes.

One line of source + two vitest assertions (no-redirect → `/upload`; explicit redirect preserved).

## Decisions made overnight (please review)
- **Scope: shipped the redirect only.** The trio (pm + designer + engineer) agreed the redirect is ~90% of the win and is the friction-removal shape that has historically moved 2anki acquisition. Assumption: the redirect is the durable fix. If you want more, see the two deferred items below.
- **Deferred — first-run welcome banner (designer's call).** Designer proposed a dismissible `role="status"` line on `/upload` gated on the existing `isFreshSignup` helper: **"Account created. Drop a file below to make your first deck."** I deferred it to keep this PR to the unambiguous, high-confidence change and avoid adding a string across 12 locales unattended. Say the word and I'll ship it as a follow-up.
- **Deferred — demoting the OnboardingTour auto-open (designer's call).** The 4-step `aria-modal` tour auto-opens for the fresh-signup cohort. Designer argued landing on `/upload` into that modal blunts the win and wants it demoted to an opt-in link. I did **not** touch it because **OAuth signups already land on `/upload` and already hit that tour today** — so this PR introduces no new modal-wall, and whether the tour helps or hurts activation is a separate, unmeasured product bet that deserves its own change. Flagging for your decision.

## Metric to move
Signup → `upload_started` (and `upload_page_viewed`) for the email-signup cohort, read at `/api/ops/upload-funnel` and the `/ops` Upload Funnel tab. Baseline: the −13.6% drop in the issue audit. Day-7 check: pull `?window=7d` and compare the signup→upload rate to the pre-ship baseline.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: `pnpm --filter 2anki-web test:golden-path` green; RegisterForm vitest (16) green; changelog loader green. Change is a post-signup navigation target, no new rendered UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs4pvvQ4BKVpvEtGA9GXTn
