### PR TITLE
feat: 2anki CLI with downloadable standalone binaries

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,0 +1,54 @@
+name: 2anki CLI release
+
+# Builds standalone `2anki` binaries for macOS, Linux, and Windows and attaches
+# them to a GitHub Release. Trigger by pushing a tag like `cli-v1.0.0`, or run
+# manually from the Actions tab.
+on:
+  push:
+    tags:
+      - 'cli-v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            asset: 2anki-linux-x64
+            binary: dist/cli/2anki
+          - os: macos-latest
+            asset: 2anki-macos-arm64
+            binary: dist/cli/2anki
+          - os: windows-latest
+            asset: 2anki-windows-x64.exe
+            binary: dist/cli/2anki.exe
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.20.0'
+      - name: Bundle the CLI
+        run: npm run cli:bundle
+      - name: Build the standalone binary
+        run: node scripts/build-cli-binary.mjs
+      - name: Rename for the platform
+        shell: bash
+        run: |
+          mkdir -p out
+          cp "${{ matrix.binary }}" "out/${{ matrix.asset }}"
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: out/${{ matrix.asset }}
+      - name: Attach to the release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: out/${{ matrix.asset }}

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ test/artifacts/*.zip
 test/artifacts/*.apkg
 
 dist/*.js
+dist/cli/
 
 # Electron builder
 

--- a/package.json
+++ b/package.json
@@ -17,8 +17,13 @@
     ]
   },
   "main": "main.js",
+  "bin": {
+    "2anki": "./dist/cli/2anki.cjs"
+  },
   "packageManager": "pnpm@10.18.2",
   "scripts": {
+    "cli": "tsx src/cli/bin.ts",
+    "cli:bundle": "npx --yes esbuild@0.25.10 src/cli/bin.ts --bundle --platform=node --target=node22 --format=cjs --outfile=dist/cli/2anki.cjs",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",

--- a/scripts/build-cli-binary.mjs
+++ b/scripts/build-cli-binary.mjs
@@ -1,0 +1,60 @@
+// Builds a standalone `2anki` executable for the current platform using Node's
+// built-in Single Executable Application support. No third-party packager.
+//
+//   pnpm cli:bundle            # bundle src/cli -> dist/cli/2anki.cjs
+//   node scripts/build-cli-binary.mjs
+//
+// Output: dist/cli/2anki (or 2anki.exe on Windows). The release workflow runs
+// this on macOS, Linux, and Windows runners and uploads each artifact.
+import { execFileSync } from 'node:child_process';
+import { copyFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const FUSE = 'NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2';
+const isWindows = process.platform === 'win32';
+const isMac = process.platform === 'darwin';
+const outDir = join('dist', 'cli');
+const binary = join(outDir, isWindows ? '2anki.exe' : '2anki');
+
+function run(cmd, args) {
+  execFileSync(cmd, args, { stdio: 'inherit' });
+}
+
+mkdirSync(outDir, { recursive: true });
+
+// 1. Generate the SEA blob from the bundled entry.
+run(process.execPath, ['--experimental-sea-config', 'sea-config.json']);
+
+// 2. Copy the running node binary as the target executable.
+copyFileSync(process.execPath, binary);
+
+// 3. On macOS the signature must be removed before injecting, then re-applied.
+if (isMac) {
+  try {
+    run('codesign', ['--remove-signature', binary]);
+  } catch {
+    // unsigned already
+  }
+}
+
+// 4. Inject the blob into the copied binary.
+const postjectArgs = [
+  '--yes',
+  'postject',
+  binary,
+  'NODE_SEA_BLOB',
+  join(outDir, 'sea-prep.blob'),
+  '--sentinel-fuse',
+  FUSE,
+];
+if (isMac) {
+  postjectArgs.push('--macho-segment-name', 'NODE_SEA');
+}
+run('npx', postjectArgs);
+
+// 5. Re-sign ad-hoc on macOS so Gatekeeper will run it.
+if (isMac) {
+  run('codesign', ['--sign', '-', binary]);
+}
+
+process.stdout.write(`Built ${binary}\n`);

--- a/sea-config.json
+++ b/sea-config.json
@@ -1,0 +1,5 @@
+{
+  "main": "dist/cli/2anki.cjs",
+  "output": "dist/cli/sea-prep.blob",
+  "disableExperimentalSEAWarning": true
+}

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -2,6 +2,10 @@
 
 Turn your notes into Anki decks, using a 2anki API key.
 
+> **Under development · invite-only.** Access is limited to lifetime accounts and
+> people who have been granted developer access. Request access from the
+> [Developers page](https://2anki.net/developers).
+
 ## Install (dev)
 
 From the repo root:

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -1,0 +1,56 @@
+# 2anki CLI
+
+Turn your notes into Anki decks, using a 2anki API key.
+
+## Install (dev)
+
+From the repo root:
+
+```bash
+pnpm cli -- <command>        # runs src/cli/index.ts via tsx
+```
+
+Once published, it runs as `2anki <command>`.
+
+## Log in
+
+```bash
+2anki login
+```
+
+Opens the [Developers page](https://2anki.net/developers), where you create an
+API key (shown once). Paste it back into the prompt. The key is stored in
+`~/.2anki/config.json` with owner-only permissions. To skip the browser:
+
+```bash
+2anki login --key sk_live_…
+```
+
+Access to the Developers page is limited to lifetime accounts. Free and
+subscriber accounts can request access from that page.
+
+## Commands
+
+| Command                | What it does                                           |
+| ---------------------- | ------------------------------------------------------ |
+| `2anki login`          | Connect an API key                                     |
+| `2anki whoami`         | Show the account and keys this machine is connected to |
+| `2anki convert <file>` | Convert a file into an Anki deck                       |
+| `2anki logout`         | Remove the stored key from this machine                |
+| `2anki help`           | Show help                                              |
+
+## Configuration
+
+| Env var              | Purpose                                                                 |
+| -------------------- | ----------------------------------------------------------------------- |
+| `TWOANKI_API_BASE`   | Point the CLI at a different API host (defaults to `https://2anki.net`) |
+| `TWOANKI_CONFIG_DIR` | Override where the key is stored (defaults to `~/.2anki`)               |
+| `NO_COLOR`           | Disable colored output                                                  |
+
+## Notes
+
+- The CLI authenticates with the same quota and plan as your account — an API
+  key acts as you.
+- `convert` uploads the file and waits for conversion. Headless `.apkg`
+  download lands with the deck-download route once it accepts key auth; today
+  the CLI points you at the web downloads page.

--- a/src/cli/apiClient.test.ts
+++ b/src/cli/apiClient.test.ts
@@ -1,0 +1,73 @@
+import { ApiClient, ApiError } from './apiClient';
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'x',
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+describe('ApiClient', () => {
+  it('sends the API key as a bearer token', async () => {
+    const fetchImpl = jest.fn(async () => jsonResponse(200, { keys: [] }));
+    const client = new ApiClient(
+      { apiKey: 'sk_live_abc', apiBase: 'http://localhost:2020' },
+      fetchImpl as unknown as typeof fetch
+    );
+
+    await client.listKeys();
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://localhost:2020/api/developer/keys',
+      { headers: { Authorization: 'Bearer sk_live_abc' } }
+    );
+  });
+
+  it('throws a typed ApiError with the server message on a non-2xx', async () => {
+    const fetchImpl = jest.fn(async () =>
+      jsonResponse(403, {
+        message: 'Developer access is not enabled for this account.',
+      })
+    );
+    const client = new ApiClient(
+      { apiKey: 'sk_live_abc' },
+      fetchImpl as unknown as typeof fetch
+    );
+
+    await expect(client.listKeys()).rejects.toMatchObject({
+      status: 403,
+      message: 'Developer access is not enabled for this account.',
+    });
+  });
+
+  it('refuses to call the API when no key is stored', async () => {
+    const client = new ApiClient({});
+    await expect(client.listKeys()).rejects.toBeInstanceOf(ApiError);
+  });
+
+  it('uploads a file as multipart with the bearer token', async () => {
+    const fetchImpl = jest.fn(async () =>
+      jsonResponse(200, { key: 'deck123' })
+    );
+    const client = new ApiClient(
+      { apiKey: 'sk_live_abc', apiBase: 'http://localhost:2020' },
+      fetchImpl as unknown as typeof fetch
+    );
+
+    const job = await client.uploadFile('notes.md', new Uint8Array([1, 2, 3]));
+
+    expect(job.key).toBe('deck123');
+    const [url, init] = fetchImpl.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe('http://localhost:2020/api/upload/file');
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      'Bearer sk_live_abc'
+    );
+    expect(init.body).toBeInstanceOf(FormData);
+  });
+});

--- a/src/cli/apiClient.ts
+++ b/src/cli/apiClient.ts
@@ -1,0 +1,85 @@
+import { CliConfig, resolveApiBase } from './config';
+
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+export interface UploadJob {
+  key?: string;
+  status?: string;
+  title?: string;
+  [k: string]: unknown;
+}
+
+export class ApiClient {
+  private readonly base: string;
+
+  constructor(
+    private readonly config: CliConfig,
+    private readonly fetchImpl: typeof fetch = fetch
+  ) {
+    this.base = resolveApiBase(config).replace(/\/$/, '');
+  }
+
+  private authHeader(): Record<string, string> {
+    if (this.config.apiKey == null) {
+      throw new ApiError('Not logged in. Run `2anki login` first.', 401);
+    }
+    return { Authorization: `Bearer ${this.config.apiKey}` };
+  }
+
+  private async parse(res: Response): Promise<unknown> {
+    const text = await res.text();
+    if (!res.ok) {
+      let message = `${res.status} ${res.statusText}`;
+      try {
+        const body = JSON.parse(text) as { message?: string };
+        if (body.message != null) message = body.message;
+      } catch {
+        // non-JSON error body
+      }
+      throw new ApiError(message, res.status);
+    }
+    return text.length > 0 ? JSON.parse(text) : {};
+  }
+
+  /** Lists the caller's API keys — also serves as a cheap auth/whoami probe. */
+  async listKeys(): Promise<Array<{ name: string; prefix: string }>> {
+    const res = await this.fetchImpl(`${this.base}/api/developer/keys`, {
+      headers: this.authHeader(),
+    });
+    const body = (await this.parse(res)) as {
+      keys?: Array<{ name: string; prefix: string }>;
+    };
+    return body.keys ?? [];
+  }
+
+  async listJobs(): Promise<UploadJob[]> {
+    const res = await this.fetchImpl(`${this.base}/api/upload/jobs`, {
+      headers: this.authHeader(),
+    });
+    const body = await this.parse(res);
+    return Array.isArray(body) ? (body as UploadJob[]) : [];
+  }
+
+  async uploadFile(filename: string, bytes: Uint8Array): Promise<UploadJob> {
+    const form = new FormData();
+    // Uint8Array is a valid BlobPart at runtime; the DOM lib's ArrayBuffer vs
+    // ArrayBufferLike distinction is a type-only mismatch under Node.
+    form.append('file', new Blob([bytes as unknown as BlobPart]), filename);
+    const res = await this.fetchImpl(`${this.base}/api/upload/file`, {
+      method: 'POST',
+      headers: this.authHeader(),
+      body: form,
+    });
+    return (await this.parse(res)) as UploadJob;
+  }
+}
+
+export default ApiClient;

--- a/src/cli/bin.ts
+++ b/src/cli/bin.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import { run } from './index';
+
+run(process.argv.slice(2))
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((err) => {
+    process.stderr.write(
+      `${err instanceof Error ? err.message : String(err)}\n`
+    );
+    process.exitCode = 1;
+  });

--- a/src/cli/commands/convert.ts
+++ b/src/cli/commands/convert.ts
@@ -1,0 +1,94 @@
+import fs from 'fs';
+import path from 'path';
+import { readConfig, resolveApiBase } from '../config';
+import { ApiClient, ApiError, UploadJob } from '../apiClient';
+import { info, success, error, warn, ui } from '../ui';
+
+const POLL_INTERVAL_MS = 2000;
+const MAX_POLLS = 60;
+
+function isDone(status: string | undefined): boolean {
+  return status === 'completed' || status === 'done' || status === 'success';
+}
+
+function isFailed(status: string | undefined): boolean {
+  return status === 'failed' || status === 'error';
+}
+
+async function pollForJob(
+  client: ApiClient,
+  key: string | undefined,
+  sleep: (ms: number) => Promise<void>
+): Promise<UploadJob | null> {
+  for (let i = 0; i < MAX_POLLS; i += 1) {
+    const jobs = await client.listJobs();
+    const match =
+      key != null ? jobs.find((j) => j.key === key) : (jobs[0] ?? null);
+    if (match != null && (isDone(match.status) || isFailed(match.status))) {
+      return match;
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+  return null;
+}
+
+export interface ConvertDeps {
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export async function convert(
+  filePath: string | undefined,
+  deps: ConvertDeps = {}
+): Promise<number> {
+  if (filePath == null) {
+    error('Usage: 2anki convert <file>');
+    return 1;
+  }
+  const config = readConfig();
+  if (config.apiKey == null) {
+    warn('Not logged in. Run `2anki login` first.');
+    return 1;
+  }
+
+  let bytes: Buffer;
+  try {
+    bytes = fs.readFileSync(filePath);
+  } catch {
+    error(`Could not read ${filePath}.`);
+    return 1;
+  }
+
+  const filename = path.basename(filePath);
+  const client = new ApiClient(config);
+  const sleep =
+    deps.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+
+  info(`Uploading ${ui.bold(filename)}…`);
+  let job: UploadJob;
+  try {
+    job = await client.uploadFile(filename, bytes);
+  } catch (e) {
+    error(e instanceof ApiError ? e.message : 'Upload failed.');
+    return 1;
+  }
+
+  info('Converting…');
+  const finished = await pollForJob(client, job.key, sleep);
+  if (finished == null) {
+    warn(
+      'Still converting after the wait window. Check back with `2anki whoami` or the web app.'
+    );
+    return 0;
+  }
+  if (isFailed(finished.status)) {
+    error(
+      `Conversion failed${finished.title != null ? ` for ${finished.title}` : ''}.`
+    );
+    return 1;
+  }
+
+  const base = resolveApiBase(config).replace(/\/$/, '');
+  success(`Deck ready${finished.title != null ? `: ${finished.title}` : ''}.`);
+  info(ui.dim(`Download it from ${base}/uploads`));
+  return 0;
+}

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -1,0 +1,56 @@
+import { readConfig, writeConfig, resolveApiBase } from '../config';
+import { ApiClient, ApiError } from '../apiClient';
+import { prompt, openBrowser } from '../prompt';
+import { info, success, error, ui } from '../ui';
+
+const API_KEY_PREFIX = 'sk_live_';
+
+function looksLikeApiKey(value: string): boolean {
+  return (
+    value.startsWith(API_KEY_PREFIX) && value.length > API_KEY_PREFIX.length
+  );
+}
+
+export interface LoginOptions {
+  key?: string;
+}
+
+export async function login(options: LoginOptions = {}): Promise<number> {
+  const config = readConfig();
+  const base = resolveApiBase(config);
+  const keysUrl = `${base.replace(/\/$/, '')}/developers`;
+
+  let key = options.key;
+  if (key == null) {
+    info(`Opening ${ui.cyan(keysUrl)} to create an API key.`);
+    info(
+      ui.dim(
+        'On the Developers page, create a key and copy it. It is shown only once.'
+      )
+    );
+    openBrowser(keysUrl);
+    key = await prompt('Paste your API key: ');
+  }
+
+  if (!looksLikeApiKey(key)) {
+    error('That does not look like a 2anki API key (expected sk_live_…).');
+    return 1;
+  }
+
+  const next = { ...config, apiKey: key };
+  const client = new ApiClient(next);
+  try {
+    await client.listKeys();
+  } catch (e) {
+    if (e instanceof ApiError) {
+      error(`Could not verify the key: ${e.message}`);
+      return 1;
+    }
+    error('Could not reach 2anki. Check your connection and try again.');
+    return 1;
+  }
+
+  writeConfig(next);
+  success('Logged in. Your key is stored in ~/.2anki/config.json.');
+  return 0;
+}

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -43,6 +43,13 @@ export async function login(options: LoginOptions = {}): Promise<number> {
     await client.listKeys();
   } catch (e) {
     if (e instanceof ApiError) {
+      if (e.status === 403) {
+        error(
+          'The CLI is invite-only while under development. Request access at ' +
+            `${base.replace(/\/$/, '')}/developers`
+        );
+        return 1;
+      }
       error(`Could not verify the key: ${e.message}`);
       return 1;
     }

--- a/src/cli/commands/logout.ts
+++ b/src/cli/commands/logout.ts
@@ -1,0 +1,14 @@
+import { readConfig, writeConfig } from '../config';
+import { success, info } from '../ui';
+
+export function logout(): number {
+  const config = readConfig();
+  if (config.apiKey == null) {
+    info('You are not logged in.');
+    return 0;
+  }
+  const { apiKey: _removed, ...rest } = config;
+  writeConfig(rest);
+  success('Logged out. The stored key was removed from this machine.');
+  return 0;
+}

--- a/src/cli/commands/whoami.ts
+++ b/src/cli/commands/whoami.ts
@@ -1,0 +1,31 @@
+import { readConfig, resolveApiBase } from '../config';
+import { ApiClient, ApiError } from '../apiClient';
+import { info, error, warn, ui } from '../ui';
+
+export async function whoami(): Promise<number> {
+  const config = readConfig();
+  if (config.apiKey == null) {
+    warn('Not logged in. Run `2anki login` to connect an API key.');
+    return 1;
+  }
+
+  const client = new ApiClient(config);
+  try {
+    const keys = await client.listKeys();
+    info(`${ui.bold('Connected to')} ${resolveApiBase(config)}`);
+    info(
+      `${keys.length} API key${keys.length === 1 ? '' : 's'} on this account.`
+    );
+    for (const key of keys) {
+      info(`  ${ui.dim(key.prefix + '…')}  ${key.name}`);
+    }
+    return 0;
+  } catch (e) {
+    if (e instanceof ApiError) {
+      error(e.message);
+      return 1;
+    }
+    error('Could not reach 2anki. Check your connection and try again.');
+    return 1;
+  }
+}

--- a/src/cli/config.test.ts
+++ b/src/cli/config.test.ts
@@ -1,0 +1,61 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  readConfig,
+  writeConfig,
+  clearConfig,
+  resolveApiBase,
+  DEFAULT_API_BASE,
+} from './config';
+
+describe('cli config', () => {
+  let dir: string;
+  const origEnv = process.env.TWOANKI_CONFIG_DIR;
+  const origBase = process.env.TWOANKI_API_BASE;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), '2anki-cli-'));
+    process.env.TWOANKI_CONFIG_DIR = dir;
+    delete process.env.TWOANKI_API_BASE;
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    if (origEnv == null) delete process.env.TWOANKI_CONFIG_DIR;
+    else process.env.TWOANKI_CONFIG_DIR = origEnv;
+    if (origBase == null) delete process.env.TWOANKI_API_BASE;
+    else process.env.TWOANKI_API_BASE = origBase;
+  });
+
+  it('returns an empty config when nothing is stored', () => {
+    expect(readConfig()).toEqual({});
+  });
+
+  it('round-trips a written config', () => {
+    writeConfig({ apiKey: 'sk_live_abc', apiBase: 'http://localhost:2020' });
+    expect(readConfig()).toEqual({
+      apiKey: 'sk_live_abc',
+      apiBase: 'http://localhost:2020',
+    });
+  });
+
+  it('writes the config file with owner-only permissions', () => {
+    writeConfig({ apiKey: 'sk_live_secret' });
+    const mode = fs.statSync(path.join(dir, 'config.json')).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it('clears the stored config', () => {
+    writeConfig({ apiKey: 'sk_live_abc' });
+    clearConfig();
+    expect(readConfig()).toEqual({});
+  });
+
+  it('resolves the API base from config, env, then default', () => {
+    expect(resolveApiBase({})).toBe(DEFAULT_API_BASE);
+    expect(resolveApiBase({ apiBase: 'http://a' })).toBe('http://a');
+    process.env.TWOANKI_API_BASE = 'http://env';
+    expect(resolveApiBase({ apiBase: 'http://a' })).toBe('http://env');
+  });
+});

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -1,0 +1,58 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+export const DEFAULT_API_BASE = 'https://2anki.net';
+
+export interface CliConfig {
+  apiKey?: string;
+  apiBase?: string;
+}
+
+export function configDir(): string {
+  return process.env.TWOANKI_CONFIG_DIR ?? path.join(os.homedir(), '.2anki');
+}
+
+export function configPath(): string {
+  return path.join(configDir(), 'config.json');
+}
+
+export function readConfig(): CliConfig {
+  try {
+    const raw = fs.readFileSync(configPath(), 'utf8');
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed == null || typeof parsed !== 'object') {
+      return {};
+    }
+    return parsed as CliConfig;
+  } catch {
+    return {};
+  }
+}
+
+export function writeConfig(config: CliConfig): void {
+  const dir = configDir();
+  fs.mkdirSync(dir, { recursive: true });
+  const file = configPath();
+  fs.writeFileSync(file, `${JSON.stringify(config, null, 2)}\n`, {
+    mode: 0o600,
+  });
+  // Tighten perms even if the file already existed with looser bits.
+  try {
+    fs.chmodSync(file, 0o600);
+  } catch {
+    // best-effort on platforms without POSIX perms
+  }
+}
+
+export function clearConfig(): void {
+  try {
+    fs.rmSync(configPath());
+  } catch {
+    // already gone
+  }
+}
+
+export function resolveApiBase(config: CliConfig): string {
+  return process.env.TWOANKI_API_BASE ?? config.apiBase ?? DEFAULT_API_BASE;
+}

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -1,0 +1,19 @@
+import { run } from './index';
+
+describe('cli run dispatch', () => {
+  const write = jest
+    .spyOn(process.stdout, 'write')
+    .mockImplementation(() => true);
+
+  afterEach(() => write.mockClear());
+  afterAll(() => write.mockRestore());
+
+  it('prints help and exits 0 for help', async () => {
+    expect(await run(['help'])).toBe(0);
+    expect(write).toHaveBeenCalled();
+  });
+
+  it('exits 1 for an unknown command', async () => {
+    expect(await run(['definitely-not-a-command'])).toBe(1);
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,6 +6,7 @@ import { convert } from './commands/convert';
 import { info, ui } from './ui';
 
 const HELP = `${ui.bold('2anki')} — turn your notes into Anki decks
+${ui.dim('Under development · invite-only. Request access at https://2anki.net/developers')}
 
 ${ui.bold('Usage')}
   2anki <command> [options]

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,47 @@
+import { parseArgs } from './parseArgs';
+import { login } from './commands/login';
+import { logout } from './commands/logout';
+import { whoami } from './commands/whoami';
+import { convert } from './commands/convert';
+import { info, ui } from './ui';
+
+const HELP = `${ui.bold('2anki')} — turn your notes into Anki decks
+
+${ui.bold('Usage')}
+  2anki <command> [options]
+
+${ui.bold('Commands')}
+  login            Connect an API key (opens the Developers page)
+  logout           Remove the stored key from this machine
+  whoami           Show the account this machine is connected to
+  convert <file>   Convert a file into an Anki deck
+  help             Show this help
+
+${ui.bold('Options')}
+  2anki login --key sk_live_…   Log in without the browser prompt
+
+${ui.dim('Create keys at https://2anki.net/developers')}`;
+
+export async function run(argv: string[]): Promise<number> {
+  const { command, positionals, flags } = parseArgs(argv);
+  switch (command) {
+    case 'login':
+      return login({
+        key: typeof flags.key === 'string' ? flags.key : undefined,
+      });
+    case 'logout':
+      return logout();
+    case 'whoami':
+      return whoami();
+    case 'convert':
+      return convert(positionals[0]);
+    case 'help':
+    case '--help':
+    case '-h':
+      info(HELP);
+      return 0;
+    default:
+      info(HELP);
+      return command === 'help' ? 0 : 1;
+  }
+}

--- a/src/cli/parseArgs.test.ts
+++ b/src/cli/parseArgs.test.ts
@@ -1,0 +1,24 @@
+import { parseArgs } from './parseArgs';
+
+describe('parseArgs', () => {
+  it('defaults to help with no args', () => {
+    expect(parseArgs([]).command).toBe('help');
+  });
+
+  it('reads a command and positionals', () => {
+    const parsed = parseArgs(['convert', 'notes.md']);
+    expect(parsed.command).toBe('convert');
+    expect(parsed.positionals).toEqual(['notes.md']);
+  });
+
+  it('reads a flag with a value', () => {
+    const parsed = parseArgs(['login', '--key', 'sk_live_abc']);
+    expect(parsed.command).toBe('login');
+    expect(parsed.flags.key).toBe('sk_live_abc');
+  });
+
+  it('treats a trailing flag without a value as a boolean', () => {
+    const parsed = parseArgs(['whoami', '--json']);
+    expect(parsed.flags.json).toBe(true);
+  });
+});

--- a/src/cli/parseArgs.ts
+++ b/src/cli/parseArgs.ts
@@ -1,0 +1,33 @@
+export interface ParsedArgs {
+  command: string;
+  positionals: string[];
+  flags: Record<string, string | boolean>;
+}
+
+/**
+ * Minimal argv parser: `2anki <command> [positionals] [--flag value | --flag]`.
+ * Dependency-free on purpose — the CLI ships no third-party arg library.
+ */
+export function parseArgs(argv: string[]): ParsedArgs {
+  const [command = 'help', ...rest] = argv;
+  const positionals: string[] = [];
+  const flags: Record<string, string | boolean> = {};
+
+  for (let i = 0; i < rest.length; i += 1) {
+    const token = rest[i];
+    if (token.startsWith('--')) {
+      const name = token.slice(2);
+      const next = rest[i + 1];
+      if (next != null && !next.startsWith('--')) {
+        flags[name] = next;
+        i += 1;
+      } else {
+        flags[name] = true;
+      }
+    } else {
+      positionals.push(token);
+    }
+  }
+
+  return { command, positionals, flags };
+}

--- a/src/cli/prompt.ts
+++ b/src/cli/prompt.ts
@@ -1,0 +1,33 @@
+import readline from 'readline';
+import { spawn } from 'child_process';
+
+export function prompt(question: string): Promise<string> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+/** Best-effort open a URL in the user's browser; never throws. */
+export function openBrowser(url: string): void {
+  const command =
+    process.platform === 'darwin'
+      ? 'open'
+      : process.platform === 'win32'
+        ? 'cmd'
+        : 'xdg-open';
+  const args = process.platform === 'win32' ? ['/c', 'start', '', url] : [url];
+  try {
+    const child = spawn(command, args, { stdio: 'ignore', detached: true });
+    child.on('error', () => undefined);
+    child.unref();
+  } catch {
+    // headless environment — the caller already printed the URL
+  }
+}

--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -1,0 +1,30 @@
+const useColor = process.stdout.isTTY && process.env.NO_COLOR == null;
+
+function paint(code: string, text: string): string {
+  return useColor ? `[${code}m${text}[0m` : text;
+}
+
+export const ui = {
+  bold: (t: string) => paint('1', t),
+  dim: (t: string) => paint('2', t),
+  green: (t: string) => paint('32', t),
+  red: (t: string) => paint('31', t),
+  yellow: (t: string) => paint('33', t),
+  cyan: (t: string) => paint('36', t),
+};
+
+export function info(message: string): void {
+  process.stdout.write(`${message}\n`);
+}
+
+export function success(message: string): void {
+  process.stdout.write(`${ui.green('✓')} ${message}\n`);
+}
+
+export function warn(message: string): void {
+  process.stdout.write(`${ui.yellow('!')} ${message}\n`);
+}
+
+export function error(message: string): void {
+  process.stderr.write(`${ui.red('✗')} ${message}\n`);
+}


### PR DESCRIPTION
**DRAFT.** The `2anki` CLI, built on the developer API-key substrate in #3697. Ship after that merges — the CLI calls `/api/developer/keys` and the bearer-auth `/api/upload/file` this substrate adds. Part of #3687 / the plan in #3696.

## What
A dependency-free CLI under `src/cli` (native `fetch`/`readline`/ANSI — no third-party runtime deps).

- `2anki login` — opens the Developers page, you create a key (shown once), paste it back. Stored in `~/.2anki/config.json` with `0600` perms. `--key sk_live_…` skips the browser.
- `2anki whoami` — the account + keys this machine is connected to.
- `2anki convert <file>` — uploads and waits for the deck.
- `2anki logout` — removes the stored key.

## Downloadable binaries
`.github/workflows/cli-release.yml` builds **standalone executables** for macOS, Linux, and Windows using Node's built-in **Single Executable Application** support (no third-party packager) and attaches them to a GitHub Release on a `cli-v*` tag. People download a binary instead of installing Node. Verified locally: the built macOS arm64 binary runs `2anki help` / `whoami` as a real Mach-O executable.

## Decisions made overnight (please review)
- **Login = paste-a-key, not device-flow OAuth.** The spec deferred OAuth device-flow; the paste-key flow (gh/stripe style) is smooth and needs no new server surface. If you want a true `gh auth login` device flow, that is a follow-up on the substrate.
- **`convert` points at the web downloads page for the `.apkg`**, because the binary deck-download route isn't in the substrate's key-auth set yet. Add that route to `acceptKeyOr` and the CLI can stream the deck headlessly — flagged as the next substrate step.
- **No new dependency** — bundling uses `npx --yes esbuild@0.25.10` (pinned, build-time only), so `package.json`/lockfile gain only a `bin` entry and two scripts.
- **`quota`/`upgrade` commands deferred** — they need a `GET /api/developer/me` endpoint the substrate doesn't have yet.

## Tests
`parseArgs`, `config` (round-trip + `0600` perms + env resolution), `apiClient` (bearer header, typed errors, multipart upload, no-key guard), and the `run` dispatcher. Server `tsc -p .` and the CLI suite are green.

## Browser check
Browser check: not applicable — no `web/src` changes (CLI + workflow + build script only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs4pvvQ4BKVpvEtGA9GXTn



## Changelog
no changelog entry — the CLI is invite-only and under development, and is not usable until the Developers page ships a way to create keys. It gets a What's New entry when it is generally usable.
