### PR TITLE
feat: Developers page and sidebar item for API key management

### DIFF
--- a/src/routes/knownRoutes.ts
+++ b/src/routes/knownRoutes.ts
@@ -22,6 +22,7 @@ const APP_ROUTES = new Set<string>([
   '/ankify',
   '/ankify/setup',
   '/ankify/history',
+  '/developers',
   '/settings',
   '/settings/card-options',
   '/card-options',

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -71,6 +71,10 @@ const AccountClaimPage = lazyWithRetry(
   () => import('./pages/AccountClaimPage/AccountClaimPage'),
   './pages/AccountClaimPage/AccountClaimPage'
 );
+const DevelopersPage = lazyWithRetry(
+  () => import('./pages/DevelopersPage/DevelopersPage'),
+  './pages/DevelopersPage/DevelopersPage'
+);
 const AccountPreviewPage = import.meta.env.DEV
   ? lazy(() => import('./pages/AccountPreviewPage/AccountPreviewPage'))
   : null;
@@ -510,6 +514,10 @@ function AppContent({
               element={requireAuth(<ImportPage setError={setErrorMessage} />)}
             />
             <Route path="/ankify" element={requireAuth(<AnkifyPage />)} />
+            <Route
+              path="/developers"
+              element={requireAuth(<DevelopersPage />)}
+            />
             <Route
               path="/ankify/setup"
               element={requireAuth(<AnkifySetupPage />)}

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -65,6 +65,7 @@ function CardUsageCounter({ used, limit }: Readonly<CardUsageCounterProps>) {
 
 export interface SidebarLocals {
   patreon?: boolean;
+  developer_access?: boolean;
   subscriber?: boolean;
   autoSyncActive?: boolean;
   passExpiresAt?: string | null;
@@ -224,6 +225,8 @@ export function Sidebar({
   const logoSrc = getLogoSrc(collapsed, theme);
   const showAnkify =
     locals?.patreon === true || locals?.autoSyncActive === true;
+  const showDevelopers =
+    locals?.patreon === true || locals?.developer_access === true;
   const showFavorites = email != null && email !== '';
   const isLoggedIn = locals != null;
   const paying = isPayingUser(locals);
@@ -354,6 +357,16 @@ export function Sidebar({
                 icon={SparklesIcon}
               >
                 {t('nav.autoSync')}
+              </SidebarRow>
+            )}
+            {showDevelopers && (
+              <SidebarRow
+                href="/developers"
+                pathname={pathname}
+                onClick={handleNavClick()}
+                icon={CommandLineIcon}
+              >
+                {t('nav.developers')}
               </SidebarRow>
             )}
           </div>

--- a/web/src/lib/backend/developerKeys.ts
+++ b/web/src/lib/backend/developerKeys.ts
@@ -1,0 +1,59 @@
+import { post, del, get } from './api';
+import { get2ankiApi } from './get2ankiApi';
+
+export interface ApiKeySummary {
+  id: number;
+  name: string;
+  prefix: string;
+  last_used_at: string | null;
+  created_at: string;
+}
+
+export interface CreatedApiKey extends ApiKeySummary {
+  secret: string;
+}
+
+function base(): string {
+  return `${get2ankiApi().baseURL}developer`;
+}
+
+async function unwrap(response: Response | null): Promise<unknown> {
+  if (response == null) {
+    throw new Error('Request was redirected');
+  }
+  const text = await response.text();
+  if (!response.ok) {
+    let message = `${response.status} ${response.statusText}`;
+    try {
+      const body = JSON.parse(text) as { message?: string };
+      if (body.message != null) message = body.message;
+    } catch {
+      // non-JSON error
+    }
+    const error = new Error(message) as Error & { status?: number };
+    error.status = response.status;
+    throw error;
+  }
+  return text.length > 0 ? JSON.parse(text) : {};
+}
+
+export async function listApiKeys(): Promise<ApiKeySummary[]> {
+  const body = (await unwrap(await get(`${base()}/keys`))) as {
+    keys?: ApiKeySummary[];
+  };
+  return body.keys ?? [];
+}
+
+export async function createApiKey(name: string): Promise<CreatedApiKey> {
+  return (await unwrap(
+    await post(`${base()}/keys`, { name })
+  )) as CreatedApiKey;
+}
+
+export async function revokeApiKey(id: number): Promise<void> {
+  await unwrap(await del(`${base()}/keys/${id}`));
+}
+
+export async function requestDeveloperAccess(): Promise<void> {
+  await unwrap(await post(`${base()}/request-access`, {}));
+}

--- a/web/src/lib/backend/getUserLocals.ts
+++ b/web/src/lib/backend/getUserLocals.ts
@@ -6,6 +6,7 @@ interface GetUserLocalsResponse {
   locals: {
     owner: number;
     patreon: boolean;
+    developer_access?: boolean;
     subscriber: boolean;
     subscriptionInfo: {
       active: boolean;

--- a/web/src/lib/i18n/locales/de/common.json
+++ b/web/src/lib/i18n/locales/de/common.json
@@ -10,6 +10,7 @@
     "photoToDeck": "Foto zu Stapel",
     "ankiToNotion": "Anki zu Notion",
     "autoSync": "Auto-Sync",
+    "developers": "Entwickler",
     "library": "Bibliothek",
     "myDecks": "Meine Stapel",
     "favorites": "Favoriten",

--- a/web/src/lib/i18n/locales/en/common.json
+++ b/web/src/lib/i18n/locales/en/common.json
@@ -10,6 +10,7 @@
     "photoToDeck": "Photo to deck",
     "ankiToNotion": "Anki to Notion",
     "autoSync": "Auto Sync",
+    "developers": "Developers",
     "library": "Library",
     "myDecks": "My Decks",
     "favorites": "Favorites",

--- a/web/src/lib/i18n/locales/es/common.json
+++ b/web/src/lib/i18n/locales/es/common.json
@@ -10,6 +10,7 @@
     "photoToDeck": "Foto a mazo",
     "ankiToNotion": "Anki a Notion",
     "autoSync": "Auto Sync",
+    "developers": "Desarrolladores",
     "library": "Biblioteca",
     "myDecks": "Mis mazos",
     "favorites": "Favoritos",

--- a/web/src/lib/i18n/locales/fr/common.json
+++ b/web/src/lib/i18n/locales/fr/common.json
@@ -10,6 +10,7 @@
     "photoToDeck": "Photo vers paquet",
     "ankiToNotion": "Anki vers Notion",
     "autoSync": "Auto Sync",
+    "developers": "Développeurs",
     "library": "Bibliothèque",
     "myDecks": "Mes paquets",
     "favorites": "Favoris",

--- a/web/src/lib/i18n/locales/it/common.json
+++ b/web/src/lib/i18n/locales/it/common.json
@@ -10,6 +10,7 @@
     "photoToDeck": "Da foto a mazzo",
     "ankiToNotion": "Da Anki a Notion",
     "autoSync": "Auto Sync",
+    "developers": "Sviluppatori",
     "library": "Libreria",
     "myDecks": "I miei mazzi",
     "favorites": "Preferiti",

--- a/web/src/lib/i18n/locales/ja/common.json
+++ b/web/src/lib/i18n/locales/ja/common.json
@@ -10,6 +10,7 @@
     "photoToDeck": "写真からデッキ",
     "ankiToNotion": "Anki から Notion へ",
     "autoSync": "Auto Sync",
+    "developers": "開発者",
     "library": "ライブラリ",
     "myDecks": "マイデッキ",
     "favorites": "お気に入り",

--- a/web/src/lib/i18n/locales/nl/common.json
+++ b/web/src/lib/i18n/locales/nl/common.json
@@ -10,6 +10,7 @@
     "photoToDeck": "Foto naar deck",
     "ankiToNotion": "Anki naar Notion",
     "autoSync": "Auto Sync",
+    "developers": "Ontwikkelaars",
     "library": "Bibliotheek",
     "myDecks": "Mijn decks",
     "favorites": "Favorieten",

--- a/web/src/lib/i18n/locales/pl/common.json
+++ b/web/src/lib/i18n/locales/pl/common.json
@@ -10,6 +10,7 @@
     "photoToDeck": "Zdjęcie na talię",
     "ankiToNotion": "Anki do Notion",
     "autoSync": "Auto Sync",
+    "developers": "Deweloperzy",
     "library": "Biblioteka",
     "myDecks": "Moje talie",
     "favorites": "Ulubione",

--- a/web/src/lib/i18n/locales/pt/common.json
+++ b/web/src/lib/i18n/locales/pt/common.json
@@ -10,6 +10,7 @@
     "photoToDeck": "Foto para baralho",
     "ankiToNotion": "Anki para Notion",
     "autoSync": "Auto Sync",
+    "developers": "Programadores",
     "library": "Biblioteca",
     "myDecks": "Meus baralhos",
     "favorites": "Favoritos",

--- a/web/src/lib/i18n/locales/ru/common.json
+++ b/web/src/lib/i18n/locales/ru/common.json
@@ -10,6 +10,7 @@
     "photoToDeck": "Фото в колоду",
     "ankiToNotion": "Anki в Notion",
     "autoSync": "Auto Sync",
+    "developers": "Разработчики",
     "library": "Библиотека",
     "myDecks": "Мои колоды",
     "favorites": "Избранное",

--- a/web/src/pages/DevelopersPage/DevelopersPage.module.css
+++ b/web/src/pages/DevelopersPage/DevelopersPage.module.css
@@ -1,0 +1,138 @@
+.title {
+  font-size: var(--text-2xl);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+}
+
+.cardTitle {
+  font-size: var(--text-lg);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  margin-bottom: 0.5rem;
+}
+
+.body {
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+  margin-bottom: 1rem;
+}
+
+.createRow {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.textInput {
+  flex: 1;
+  min-width: 12rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  font-size: var(--text-sm);
+}
+
+.textInput:focus {
+  outline: none;
+  border-color: var(--color-accent);
+}
+
+.keyList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.keyRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.6rem 0;
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.keyRow:last-child {
+  border-bottom: none;
+}
+
+.keyName {
+  display: block;
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+  font-size: var(--text-sm);
+}
+
+.keyMeta {
+  display: block;
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-tertiary);
+  font-size: var(--text-xs);
+}
+
+.revokeButton {
+  background: none;
+  border: none;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font-size: var(--text-sm);
+  padding: 0.25rem 0.5rem;
+}
+
+.revokeButton:hover {
+  color: var(--color-danger);
+}
+
+.noticeSuccess {
+  color: var(--color-success);
+  font-size: var(--text-sm);
+}
+
+.noticeDanger {
+  color: var(--color-danger);
+  font-size: var(--text-sm);
+  margin-top: 0.5rem;
+}
+
+.revealBackdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  z-index: 1000;
+}
+
+.revealCard {
+  background: var(--color-bg-primary);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  max-width: 32rem;
+  width: 100%;
+  box-shadow: var(--shadow-lg);
+}
+
+.keyReveal {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--color-bg-secondary);
+  border-radius: var(--radius-md);
+  padding: 0.75rem;
+  margin: 1rem 0;
+}
+
+.keyValue {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  word-break: break-all;
+  flex: 1;
+  color: var(--color-text-primary);
+}

--- a/web/src/pages/DevelopersPage/DevelopersPage.test.tsx
+++ b/web/src/pages/DevelopersPage/DevelopersPage.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { HelmetProvider } from 'react-helmet-async';
+import DevelopersPage from './DevelopersPage';
+
+const useUserLocals = vi.fn();
+vi.mock('../../lib/hooks/useUserLocals', () => ({
+  useUserLocals: () => useUserLocals(),
+}));
+
+const listApiKeys = vi.fn();
+const requestDeveloperAccess = vi.fn();
+vi.mock('../../lib/backend/developerKeys', () => ({
+  listApiKeys: () => listApiKeys(),
+  requestDeveloperAccess: () => requestDeveloperAccess(),
+  createApiKey: vi.fn(),
+  revokeApiKey: vi.fn(),
+}));
+
+function renderPage() {
+  render(
+    <HelmetProvider>
+      <DevelopersPage />
+    </HelmetProvider>
+  );
+}
+
+describe('DevelopersPage', () => {
+  beforeEach(() => {
+    useUserLocals.mockReset();
+    listApiKeys.mockReset();
+    requestDeveloperAccess.mockReset();
+    listApiKeys.mockResolvedValue([]);
+  });
+
+  test('shows the key manager for a lifetime account', async () => {
+    useUserLocals.mockReturnValue({
+      data: { locals: { patreon: true } },
+      isLoading: false,
+    });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText('API keys')).toBeInTheDocument()
+    );
+    expect(screen.getByText('Create key')).toBeInTheDocument();
+  });
+
+  test('shows the key manager for a granted developer_access account', async () => {
+    useUserLocals.mockReturnValue({
+      data: { locals: { patreon: false, developer_access: true } },
+      isLoading: false,
+    });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText('API keys')).toBeInTheDocument()
+    );
+  });
+
+  test('shows the locked request-access state for a non-access account', () => {
+    useUserLocals.mockReturnValue({
+      data: { locals: { patreon: false, developer_access: false } },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByText('Request access')).toBeInTheDocument();
+    expect(screen.queryByText('Create key')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/DevelopersPage/DevelopersPage.tsx
+++ b/web/src/pages/DevelopersPage/DevelopersPage.tsx
@@ -1,0 +1,244 @@
+import { useEffect, useState } from 'react';
+import { Helmet } from 'react-helmet-async';
+import { useUserLocals } from '../../lib/hooks/useUserLocals';
+import {
+  ApiKeySummary,
+  CreatedApiKey,
+  createApiKey,
+  listApiKeys,
+  revokeApiKey,
+  requestDeveloperAccess,
+} from '../../lib/backend/developerKeys';
+import sharedStyles from '../../styles/shared.module.css';
+import styles from './DevelopersPage.module.css';
+
+function formatLastUsed(value: string | null): string {
+  if (value == null) return 'Never used';
+  const date = new Date(value);
+  return `Used ${date.toLocaleDateString()}`;
+}
+
+function LockedState() {
+  const [status, setStatus] = useState<'idle' | 'sending' | 'sent' | 'error'>(
+    'idle'
+  );
+  const [message, setMessage] = useState('');
+
+  const request = async () => {
+    setStatus('sending');
+    try {
+      await requestDeveloperAccess();
+      setStatus('sent');
+    } catch (error) {
+      setStatus('error');
+      setMessage(error instanceof Error ? error.message : 'Something broke.');
+    }
+  };
+
+  return (
+    <section className={sharedStyles.sectionCard}>
+      <h2 className={styles.cardTitle}>Developer access</h2>
+      <p className={styles.body}>
+        The developer API and CLI are under development and invite-only. Use an
+        API key to convert from your own tools — a script, a cron job, or an MCP
+        client. Access is open to lifetime accounts; everyone else can request
+        it.
+      </p>
+      {status === 'sent' ? (
+        <p className={styles.noticeSuccess}>
+          Request sent. We&rsquo;ll be in touch by email.
+        </p>
+      ) : (
+        <button
+          type="button"
+          className={sharedStyles.btnPrimary}
+          onClick={request}
+          disabled={status === 'sending'}
+        >
+          {status === 'sending' ? 'Sending' : 'Request access'}
+        </button>
+      )}
+      {status === 'error' && <p className={styles.noticeDanger}>{message}</p>}
+    </section>
+  );
+}
+
+function RevealDialog({
+  created,
+  onDone,
+}: Readonly<{ created: CreatedApiKey; onDone: () => void }>) {
+  const [copied, setCopied] = useState(false);
+  const copy = () => {
+    void navigator.clipboard?.writeText(created.secret);
+    setCopied(true);
+  };
+  return (
+    <div className={styles.revealBackdrop}>
+      <div className={styles.revealCard} role="dialog" aria-modal="true">
+        <h3 className={styles.cardTitle}>Copy your API key</h3>
+        <p className={styles.noticeDanger}>
+          This is the only time you&rsquo;ll see this key. Copy it now and store
+          it somewhere safe — you won&rsquo;t be able to see it again.
+        </p>
+        <div className={styles.keyReveal} data-hj-suppress>
+          <code className={styles.keyValue}>{created.secret}</code>
+          <button
+            type="button"
+            className={sharedStyles.btnSecondary}
+            onClick={copy}
+          >
+            {copied ? 'Copied' : 'Copy'}
+          </button>
+        </div>
+        <button
+          type="button"
+          className={sharedStyles.btnPrimary}
+          onClick={onDone}
+        >
+          Done
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function KeyManager() {
+  const [keys, setKeys] = useState<ApiKeySummary[] | null>(null);
+  const [error, setError] = useState('');
+  const [name, setName] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [reveal, setReveal] = useState<CreatedApiKey | null>(null);
+
+  const refresh = () => {
+    listApiKeys()
+      .then(setKeys)
+      .catch((e) =>
+        setError(e instanceof Error ? e.message : 'Could not load your keys.')
+      );
+  };
+
+  useEffect(refresh, []);
+
+  const create = async () => {
+    if (name.trim().length === 0) return;
+    setCreating(true);
+    setError('');
+    try {
+      const created = await createApiKey(name.trim());
+      setReveal(created);
+      setName('');
+      refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not create the key.');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const revoke = async (id: number, keyName: string) => {
+    if (
+      !globalThis.confirm(
+        `Revoke ${keyName}? Anything using it stops working right away. This can't be undone.`
+      )
+    ) {
+      return;
+    }
+    try {
+      await revokeApiKey(id);
+      refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not revoke the key.');
+    }
+  };
+
+  return (
+    <section className={sharedStyles.sectionCard}>
+      <h2 className={styles.cardTitle}>API keys</h2>
+      <p className={styles.body}>
+        Use an API key to convert from your own tools — a script, a cron job, or
+        an MCP client. Keep it secret; anyone with the key can convert on your
+        account.
+      </p>
+
+      <div className={styles.createRow}>
+        <input
+          type="text"
+          aria-label="Key name"
+          placeholder="CLI on my laptop"
+          className={styles.textInput}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <button
+          type="button"
+          className={sharedStyles.btnPrimary}
+          onClick={create}
+          disabled={creating || name.trim().length === 0}
+        >
+          {creating ? 'Creating' : 'Create key'}
+        </button>
+      </div>
+
+      {error !== '' && <p className={styles.noticeDanger}>{error}</p>}
+
+      {keys != null && keys.length === 0 && (
+        <p className={styles.body}>
+          No API keys yet. Create one to convert from your own tools.
+        </p>
+      )}
+
+      {keys != null && keys.length > 0 && (
+        <ul className={styles.keyList}>
+          {keys.map((key) => (
+            <li key={key.id} className={styles.keyRow}>
+              <div>
+                <span className={styles.keyName}>{key.name}</span>
+                <span className={styles.keyMeta} data-hj-suppress>
+                  {key.prefix}… · {formatLastUsed(key.last_used_at)}
+                </span>
+              </div>
+              <button
+                type="button"
+                className={styles.revokeButton}
+                onClick={() => revoke(key.id, key.name)}
+              >
+                Revoke
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {reveal != null && (
+        <RevealDialog created={reveal} onDone={() => setReveal(null)} />
+      )}
+    </section>
+  );
+}
+
+export default function DevelopersPage() {
+  const { data, isLoading } = useUserLocals();
+  const hasAccess =
+    data?.locals?.patreon === true || data?.locals?.developer_access === true;
+
+  return (
+    <div className={sharedStyles.page}>
+      <Helmet>
+        <title>Developers — 2anki</title>
+      </Helmet>
+      <header className={sharedStyles.pageHeader}>
+        <h1 className={styles.title}>Developers</h1>
+        <p className={styles.body}>
+          Convert with the 2anki API from your own tools. Under development.
+        </p>
+      </header>
+      {isLoading ? (
+        <p className={styles.body}>Loading</p>
+      ) : hasAccess ? (
+        <KeyManager />
+      ) : (
+        <LockedState />
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-18-developers-api-keys.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-18-developers-api-keys.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-18-developers-api-keys",
+  "date": "2026-07-18",
+  "type": "feature",
+  "title": "Developers page — create API keys to convert from your own tools"
+}


### PR DESCRIPTION
The user-facing half of the developer API substrate (#3687) — the **Developers** sidebar item and page. Builds on the merged substrate (#3697) and completes the surface the CLI (#3698) points people at.

## What
- A **Developers** item (terminal icon) in the sidebar, shown to **lifetime** accounts and accounts granted **`developer_access`**.
- The `/developers` page:
  - **Access:** create API keys — the full `sk_live_…` is shown **once** with copy-to-clipboard, then only the prefix + last-used are listed; revoke with a confirm.
  - **No access:** a locked state with a **Request access** button that emails support@2anki.net (via the substrate's request-access endpoint) so you can grant it from `/ops` → Commands.
- `developer_access` now flows to the client via `getUserLocals`; the `/developers` route is registered in `App.tsx` + `knownRoutes.ts` (direct load doesn't 404); the nav label is localized across all 10 locales.

## Decisions made overnight (please review)
- **Copy is inline English, not a new i18n namespace.** Only the sidebar label (`nav.developers`) went through i18n (parity across all locales). The page body copy is English inline — it's an under-development developer surface; a full localized namespace can follow. Change if you'd rather localize the page now.
- **Revoke uses a native `confirm()`**, matching the lightweight ops-tool pattern, rather than a bespoke modal. Swap for a styled dialog if you want it to match the account-page revoke UX.
- **Gating is client-side for display + server-side for enforcement.** The page shows locked/unlocked from `locals`, but the real gate is the substrate's `RequireDeveloperAccess` on the API — a non-access user who forces the UI still gets 403 from the endpoints.

## Tests
DevelopersPage (key-manager for lifetime + granted; locked/request state for others), i18n parity across all locales, changelog loader, AppShell/Sidebar — all green. Server `tsc`, web typecheck, golden-path, and format/lint clean.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: `pnpm --filter 2anki-web test:golden-path` green; DevelopersPage + Sidebar vitest green. New authed page; sidebar item renders only for lifetime/granted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs4pvvQ4BKVpvEtGA9GXTn
