### PR TITLE
fix: Developers page fails to load API keys (e.text is not a function)

### DIFF
--- a/web/src/lib/backend/developerKeys.test.ts
+++ b/web/src/lib/backend/developerKeys.test.ts
@@ -1,0 +1,67 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  listApiKeys,
+  createApiKey,
+  revokeApiKey,
+  requestDeveloperAccess,
+} from './developerKeys';
+
+function textResponse(status: number, body: string): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'x',
+    text: async () => body,
+  } as Response;
+}
+
+describe('developerKeys client', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test('listApiKeys parses the keys array (regression: response is read via text())', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      textResponse(200, JSON.stringify({ keys: [{ id: 1, name: 'CLI' }] }))
+    );
+    const keys = await listApiKeys();
+    expect(keys).toEqual([{ id: 1, name: 'CLI' }]);
+    const [, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
+      .calls[0] as [string, RequestInit];
+    expect(init.credentials).toBe('include');
+  });
+
+  test('createApiKey returns the created key with its secret', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      textResponse(
+        201,
+        JSON.stringify({ id: 2, name: 'k', secret: 'sk_live_x' })
+      )
+    );
+    const created = await createApiKey('k');
+    expect(created.secret).toBe('sk_live_x');
+  });
+
+  test('revokeApiKey tolerates an empty 204 body', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      textResponse(204, '')
+    );
+    await expect(revokeApiKey(2)).resolves.toBeUndefined();
+  });
+
+  test('surfaces the server message and status on an error', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      textResponse(403, JSON.stringify({ message: 'not enabled' }))
+    );
+    await expect(requestDeveloperAccess()).rejects.toMatchObject({
+      message: 'not enabled',
+      status: 403,
+    });
+  });
+});

--- a/web/src/lib/backend/developerKeys.ts
+++ b/web/src/lib/backend/developerKeys.ts
@@ -1,4 +1,3 @@
-import { post, del, get } from './api';
 import { get2ankiApi } from './get2ankiApi';
 
 export interface ApiKeySummary {
@@ -17,10 +16,15 @@ function base(): string {
   return `${get2ankiApi().baseURL}developer`;
 }
 
-async function unwrap(response: Response | null): Promise<unknown> {
-  if (response == null) {
-    throw new Error('Request was redirected');
-  }
+async function request(path: string, init: RequestInit = {}): Promise<unknown> {
+  const response = await fetch(`${base()}${path}`, {
+    credentials: 'include',
+    headers:
+      init.body != null
+        ? { 'Content-Type': 'application/json', Accept: 'application/json' }
+        : { Accept: 'application/json' },
+    ...init,
+  });
   const text = await response.text();
   if (!response.ok) {
     let message = `${response.status} ${response.statusText}`;
@@ -28,7 +32,7 @@ async function unwrap(response: Response | null): Promise<unknown> {
       const body = JSON.parse(text) as { message?: string };
       if (body.message != null) message = body.message;
     } catch {
-      // non-JSON error
+      // non-JSON error body
     }
     const error = new Error(message) as Error & { status?: number };
     error.status = response.status;
@@ -38,22 +42,24 @@ async function unwrap(response: Response | null): Promise<unknown> {
 }
 
 export async function listApiKeys(): Promise<ApiKeySummary[]> {
-  const body = (await unwrap(await get(`${base()}/keys`))) as {
-    keys?: ApiKeySummary[];
-  };
+  const body = (await request('/keys')) as { keys?: ApiKeySummary[] };
   return body.keys ?? [];
 }
 
 export async function createApiKey(name: string): Promise<CreatedApiKey> {
-  return (await unwrap(
-    await post(`${base()}/keys`, { name })
-  )) as CreatedApiKey;
+  return (await request('/keys', {
+    method: 'POST',
+    body: JSON.stringify({ name }),
+  })) as CreatedApiKey;
 }
 
 export async function revokeApiKey(id: number): Promise<void> {
-  await unwrap(await del(`${base()}/keys/${id}`));
+  await request(`/keys/${id}`, { method: 'DELETE' });
 }
 
 export async function requestDeveloperAccess(): Promise<void> {
-  await unwrap(await post(`${base()}/request-access`, {}));
+  await request('/request-access', {
+    method: 'POST',
+    body: JSON.stringify({}),
+  });
 }


### PR DESCRIPTION
The Developers page threw `e.text is not a function` on load. The `developerKeys` client wrapped the shared api helpers, but `get()` returns already-parsed JSON while `post()`/`del()` return a raw `Response` — so the shared `unwrap()` called `.text()` on a plain object.

Fix: use `fetch` directly and read every response the same way (matching the CLI client). Adds a regression test that drives the real client — the page test mocked the whole module, so it never exercised this path.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: golden-path green; developerKeys + DevelopersPage vitest green.

Changelog: not applicable — fixes a same-day regression on the brand-new invite-only Developers page; no user saw a shipped-and-broken state worth a note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


no changelog entry — fixes a same-day regression on the brand-new invite-only Developers page; no user saw a shipped-and-broken state worth a note.
