### PR TITLE
feat: API guide, docs link, and CLI download on the Developers page

### DIFF
--- a/web/src/pages/DevelopersPage/DevelopersPage.module.css
+++ b/web/src/pages/DevelopersPage/DevelopersPage.module.css
@@ -136,3 +136,44 @@
   flex: 1;
   color: var(--color-text-primary);
 }
+
+.endpointList {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1rem;
+}
+
+.endpointRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem 1rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.endpointRow:last-child {
+  border-bottom: none;
+}
+
+.endpoint {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+}
+
+.method {
+  font-weight: var(--font-semibold);
+  color: var(--color-text-secondary);
+}
+
+.endpointLabel {
+  color: var(--color-text-tertiary);
+  font-size: var(--text-sm);
+}
+
+.linkRow {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}

--- a/web/src/pages/DevelopersPage/DevelopersPage.test.tsx
+++ b/web/src/pages/DevelopersPage/DevelopersPage.test.tsx
@@ -44,6 +44,12 @@ describe('DevelopersPage', () => {
       expect(screen.getByText('API keys')).toBeInTheDocument()
     );
     expect(screen.getByText('Create key')).toBeInTheDocument();
+    expect(screen.getByText('Full API docs')).toHaveAttribute(
+      'href',
+      '/api/docs'
+    );
+    expect(screen.getByText('Download the CLI')).toBeInTheDocument();
+    expect(screen.getByText('Convert a file into a deck')).toBeInTheDocument();
   });
 
   test('shows the key manager for a granted developer_access account', async () => {

--- a/web/src/pages/DevelopersPage/DevelopersPage.tsx
+++ b/web/src/pages/DevelopersPage/DevelopersPage.tsx
@@ -216,6 +216,60 @@ function KeyManager() {
   );
 }
 
+const RELEVANT_ENDPOINTS = [
+  {
+    method: 'POST',
+    path: '/api/upload/file',
+    label: 'Convert a file into a deck',
+  },
+  { method: 'GET', path: '/api/upload/jobs', label: 'Check conversion status' },
+  {
+    method: 'GET',
+    path: '/api/apkg/:key/meta',
+    label: 'Deck preview — counts and decks',
+  },
+  { method: 'GET', path: '/api/apkg/:key/cards', label: 'Rendered cards' },
+];
+
+const CLI_RELEASES_URL = 'https://github.com/2anki/server/releases/latest';
+
+function ApiGuide() {
+  return (
+    <section className={sharedStyles.sectionCard}>
+      <h2 className={styles.cardTitle}>Using the API</h2>
+      <p className={styles.body}>
+        Send your key as a bearer token:{' '}
+        <code>Authorization: Bearer sk_live_…</code>. These are the endpoints a
+        converter client needs.
+      </p>
+      <ul className={styles.endpointList}>
+        {RELEVANT_ENDPOINTS.map((endpoint) => (
+          <li key={endpoint.path} className={styles.endpointRow}>
+            <code className={styles.endpoint}>
+              <span className={styles.method}>{endpoint.method}</span>{' '}
+              {endpoint.path}
+            </code>
+            <span className={styles.endpointLabel}>{endpoint.label}</span>
+          </li>
+        ))}
+      </ul>
+      <div className={styles.linkRow}>
+        <a className={sharedStyles.btnSecondary} href="/api/docs">
+          Full API docs
+        </a>
+        <a
+          className={sharedStyles.btnSecondary}
+          href={CLI_RELEASES_URL}
+          target="_blank"
+          rel="noreferrer"
+        >
+          Download the CLI
+        </a>
+      </div>
+    </section>
+  );
+}
+
 export default function DevelopersPage() {
   const { data, isLoading } = useUserLocals();
   const hasAccess =
@@ -235,7 +289,10 @@ export default function DevelopersPage() {
       {isLoading ? (
         <p className={styles.body}>Loading</p>
       ) : hasAccess ? (
-        <KeyManager />
+        <>
+          <KeyManager />
+          <ApiGuide />
+        </>
       ) : (
         <LockedState />
       )}


### PR DESCRIPTION
Addresses three requests for the `/developers` page: a curated endpoint list, a link to full API docs, and a CLI download.

- **Using the API** section lists only the relevant endpoints — `POST /api/upload/file`, `GET /api/upload/jobs`, `GET /api/apkg/:key/meta`, `GET /api/apkg/:key/cards` — instead of pointing developers at all ~34 documented routers.
- **Full API docs** button → `/api/docs` (Swagger UI).
- **Download the CLI** button → the GitHub releases page (binaries are published by the `cli-release` workflow on a `cli-v*` tag).

Shown to accounts with developer access, below the key manager.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: golden-path green; DevelopersPage vitest green (asserts the docs link + download + endpoints render).

no changelog entry — increment to the same-day invite-only Developers page; the page already has its feature entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)