### PR TITLE
fix: build the Windows CLI binary (npx ENOENT on win32)

### DIFF
--- a/scripts/build-cli-binary.mjs
+++ b/scripts/build-cli-binary.mjs
@@ -17,7 +17,11 @@ const outDir = join('dist', 'cli');
 const binary = join(outDir, isWindows ? '2anki.exe' : '2anki');
 
 function run(cmd, args) {
-  execFileSync(cmd, args, { stdio: 'inherit' });
+  // On Windows, npx is a .cmd shim that execFileSync can't spawn directly
+  // (ENOENT) — resolve it to npx.cmd. Other commands (node, codesign) are real
+  // executables and spawn fine.
+  const resolved = isWindows && cmd === 'npx' ? 'npx.cmd' : cmd;
+  execFileSync(resolved, args, { stdio: 'inherit' });
 }
 
 mkdirSync(outDir, { recursive: true });

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -6,6 +6,29 @@ Turn your notes into Anki decks, using a 2anki API key.
 > people who have been granted developer access. Request access from the
 > [Developers page](https://2anki.net/developers).
 
+## Install (binary)
+
+Download the binary for your platform from the
+[latest release](https://github.com/2anki/server/releases/latest).
+
+**macOS** — the binary is not yet notarized, so Gatekeeper blocks it on first
+run. Clear the quarantine flag once:
+
+```bash
+xattr -d com.apple.quarantine ./2anki-macos-arm64
+chmod +x ./2anki-macos-arm64
+./2anki-macos-arm64 help
+```
+
+**Linux:**
+
+```bash
+chmod +x ./2anki-linux-x64
+./2anki-linux-x64 help
+```
+
+Rename to `2anki` and put it on your `PATH` to run it as `2anki <command>`.
+
 ## Install (dev)
 
 From the repo root:
@@ -13,8 +36,6 @@ From the repo root:
 ```bash
 pnpm cli -- <command>        # runs src/cli/index.ts via tsx
 ```
-
-Once published, it runs as `2anki <command>`.
 
 ## Log in
 


### PR DESCRIPTION
The `cli-release` Windows job failed with `spawnSync npx ENOENT` — `execFileSync` can't spawn the `npx` `.cmd` shim by bare name on Windows, so `postject` never ran.

Resolve `npx` → `npx.cmd` on win32. macOS/Linux paths unchanged (they already produced binaries on `cli-v0.1.0`). After this merges, a new `cli-v*` tag produces all three platforms.

no changelog entry — CI/release tooling only, no user-visible product change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)