### PR TITLE
fix: 2anki login rejects a valid API key (Authentication required)

### DIFF
--- a/src/cli/apiClient.test.ts
+++ b/src/cli/apiClient.test.ts
@@ -10,41 +10,39 @@ function jsonResponse(status: number, body: unknown): Response {
 }
 
 describe('ApiClient', () => {
-  it('sends the API key as a bearer token', async () => {
-    const fetchImpl = jest.fn(async () => jsonResponse(200, { keys: [] }));
+  it('verifies the key against the key-authed jobs endpoint with a bearer token', async () => {
+    const fetchImpl = jest.fn(async () => jsonResponse(200, []));
     const client = new ApiClient(
       { apiKey: 'sk_live_abc', apiBase: 'http://localhost:2020' },
       fetchImpl as unknown as typeof fetch
     );
 
-    await client.listKeys();
+    await client.listJobs();
 
     expect(fetchImpl).toHaveBeenCalledWith(
-      'http://localhost:2020/api/developer/keys',
+      'http://localhost:2020/api/upload/jobs',
       { headers: { Authorization: 'Bearer sk_live_abc' } }
     );
   });
 
   it('throws a typed ApiError with the server message on a non-2xx', async () => {
     const fetchImpl = jest.fn(async () =>
-      jsonResponse(403, {
-        message: 'Developer access is not enabled for this account.',
-      })
+      jsonResponse(401, { message: 'Authentication required' })
     );
     const client = new ApiClient(
       { apiKey: 'sk_live_abc' },
       fetchImpl as unknown as typeof fetch
     );
 
-    await expect(client.listKeys()).rejects.toMatchObject({
-      status: 403,
-      message: 'Developer access is not enabled for this account.',
+    await expect(client.listJobs()).rejects.toMatchObject({
+      status: 401,
+      message: 'Authentication required',
     });
   });
 
   it('refuses to call the API when no key is stored', async () => {
     const client = new ApiClient({});
-    await expect(client.listKeys()).rejects.toBeInstanceOf(ApiError);
+    await expect(client.listJobs()).rejects.toBeInstanceOf(ApiError);
   });
 
   it('uploads a file as multipart with the bearer token', async () => {

--- a/src/cli/apiClient.ts
+++ b/src/cli/apiClient.ts
@@ -49,17 +49,7 @@ export class ApiClient {
     return text.length > 0 ? JSON.parse(text) : {};
   }
 
-  /** Lists the caller's API keys — also serves as a cheap auth/whoami probe. */
-  async listKeys(): Promise<Array<{ name: string; prefix: string }>> {
-    const res = await this.fetchImpl(`${this.base}/api/developer/keys`, {
-      headers: this.authHeader(),
-    });
-    const body = (await this.parse(res)) as {
-      keys?: Array<{ name: string; prefix: string }>;
-    };
-    return body.keys ?? [];
-  }
-
+  /** Key-authed read used to verify a key on login/whoami. */
   async listJobs(): Promise<UploadJob[]> {
     const res = await this.fetchImpl(`${this.base}/api/upload/jobs`, {
       headers: this.authHeader(),

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -40,7 +40,9 @@ export async function login(options: LoginOptions = {}): Promise<number> {
   const next = { ...config, apiKey: key };
   const client = new ApiClient(next);
   try {
-    await client.listKeys();
+    // Verify against a key-authed endpoint. Key management (/developer/keys) is
+    // session-only; the conversion endpoints are what an API key unlocks.
+    await client.listJobs();
   } catch (e) {
     if (e instanceof ApiError) {
       if (e.status === 403) {

--- a/src/cli/commands/whoami.ts
+++ b/src/cli/commands/whoami.ts
@@ -11,17 +11,17 @@ export async function whoami(): Promise<number> {
 
   const client = new ApiClient(config);
   try {
-    const keys = await client.listKeys();
+    // Probe a key-authed endpoint to confirm the stored key still works.
+    const jobs = await client.listJobs();
     info(`${ui.bold('Connected to')} ${resolveApiBase(config)}`);
-    info(
-      `${keys.length} API key${keys.length === 1 ? '' : 's'} on this account.`
-    );
-    for (const key of keys) {
-      info(`  ${ui.dim(key.prefix + '…')}  ${key.name}`);
-    }
+    info(`${jobs.length} recent job${jobs.length === 1 ? '' : 's'}.`);
     return 0;
   } catch (e) {
     if (e instanceof ApiError) {
+      if (e.status === 401) {
+        error('Your API key is no longer valid. Run `2anki login` again.');
+        return 1;
+      }
       error(e.message);
       return 1;
     }


### PR DESCRIPTION
`2anki login` pasted a valid key and got `✗ Could not verify the key: Authentication required`.

Cause: `login`/`whoami` verified the key by calling `GET /api/developer/keys`, but key management is **session-cookie only** (`RequireAuthentication`) — an API key gets 401 there. An API key only unlocks the conversion endpoints.

Fix: verify against the key-authed `GET /api/upload/jobs` instead. `whoami` now reports the connection + recent job count; the dead `listKeys` client method is removed.

no changelog entry — CLI is invite-only/under-development, not yet in the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)