### PR TITLE
fix: unbreak CLI release (npm@11 pin + Windows npx shell)

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -68,9 +68,10 @@ jobs:
         with:
           node-version: '22.20.0'
           registry-url: 'https://registry.npmjs.org'
-      # Trusted Publishing needs a recent npm CLI (>= 11.5.1).
+      # Trusted Publishing needs npm >= 11.5.1. Pin to 11.x — npm@latest (12+)
+      # requires a newer node than this workflow pins and fails with EBADENGINE.
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
       - name: Assemble the npm package
         run: node scripts/build-cli-npm.mjs "${{ github.ref_name }}"
       - name: Publish to npm

--- a/scripts/build-cli-binary.mjs
+++ b/scripts/build-cli-binary.mjs
@@ -18,15 +18,17 @@ const binary = join(outDir, isWindows ? '2anki.exe' : '2anki');
 
 function run(cmd, args) {
   // execFileSync can't resolve a bare `npx` from PATH (ENOENT), and on Windows
-  // it's a .cmd shim. npx sits next to the running node binary, so resolve it
-  // there. Other commands (node, codesign) are real executables and spawn fine.
-  let resolved = cmd;
+  // it's a .cmd shim that also needs a shell to run (EINVAL otherwise). npx sits
+  // next to the running node binary, so resolve it there and use a shell on
+  // Windows. Other commands (node, codesign) are real executables, spawn fine.
   if (cmd === 'npx') {
     const name = isWindows ? 'npx.cmd' : 'npx';
     const colocated = join(dirname(process.execPath), name);
-    resolved = existsSync(colocated) ? colocated : name;
+    const resolved = existsSync(colocated) ? colocated : name;
+    execFileSync(resolved, args, { stdio: 'inherit', shell: isWindows });
+    return;
   }
-  execFileSync(resolved, args, { stdio: 'inherit' });
+  execFileSync(cmd, args, { stdio: 'inherit' });
 }
 
 mkdirSync(outDir, { recursive: true });


### PR DESCRIPTION
`cli-v0.1.2` release failed two ways:

1. **npm publish** — `npm install -g npm@latest` pulled **npm@12**, which needs node ≥22.22.2; the workflow pins 22.20.0 → `EBADENGINE`. Pin **`npm@11`** (still has OIDC trusted publishing).
2. **Windows binary** — the postject step spawned `npx.cmd` via `execFileSync`, which Node rejects for a `.cmd` without a shell → `EINVAL`. Pass `shell:true` on the Windows npx call.

macOS + Linux binaries already succeeded on `cli-v0.1.2`; npm has `0.1.1`. After merge, tagging `cli-v0.1.3` gives a clean full release (all 3 binaries + npm 0.1.3 via OIDC).

no changelog entry — release/CI tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)