### PR TITLE
fix: npm publish E422 — add repository.url for provenance

### DIFF
--- a/scripts/build-cli-npm.mjs
+++ b/scripts/build-cli-npm.mjs
@@ -56,6 +56,12 @@ const pkg = {
   bin: { '2anki': '2anki.cjs' },
   files: ['2anki.cjs', 'README.md'],
   type: 'commonjs',
+  // Trusted-publishing provenance requires repository.url to match the source
+  // repo, or npm publish rejects with E422.
+  repository: {
+    type: 'git',
+    url: 'git+https://github.com/Laer-Smart/2anki.net.git',
+  },
   engines: { node: '>=18' },
   keywords: ['anki', '2anki', 'flashcards', 'cli'],
   homepage: 'https://2anki.net/developers',


### PR DESCRIPTION
The `cli-v0.1.3` publish got through OIDC + signing, then failed:
```
E422 — Error verifying sigstore provenance bundle: package.json "repository.url" is "", expected https://github.com/Laer-Smart/2anki.net
```

Trusted publishing auto-adds **provenance**, which requires the published `package.json` `repository.url` to match the source repo. The generated package.json had none. Adds `repository` pointing at `Laer-Smart/2anki.net`.

Everything else worked (npm@11, build, OIDC auth, signing). After merge, tag `cli-v0.1.4` for the clean publish + binaries.

no changelog entry — release tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)