### PR TITLE
fix: CLI convert 400 (upload field) + Developers card spacing

### DIFF
--- a/src/cli/apiClient.test.ts
+++ b/src/cli/apiClient.test.ts
@@ -67,5 +67,10 @@ describe('ApiClient', () => {
       'Bearer sk_live_abc'
     );
     expect(init.body).toBeInstanceOf(FormData);
+    // The server multer field is `pakker`, not `file` — sending the wrong name
+    // yields an empty req.files and a 400 "Please select a file to upload."
+    const form = init.body as FormData;
+    expect(form.get('pakker')).not.toBeNull();
+    expect(form.get('file')).toBeNull();
   });
 });

--- a/src/cli/apiClient.ts
+++ b/src/cli/apiClient.ts
@@ -62,7 +62,8 @@ export class ApiClient {
     const form = new FormData();
     // Uint8Array is a valid BlobPart at runtime; the DOM lib's ArrayBuffer vs
     // ArrayBufferLike distinction is a type-only mismatch under Node.
-    form.append('file', new Blob([bytes as unknown as BlobPart]), filename);
+    // The server's multer parses the upload field named `pakker` (.array).
+    form.append('pakker', new Blob([bytes as unknown as BlobPart]), filename);
     const res = await this.fetchImpl(`${this.base}/api/upload/file`, {
       method: 'POST',
       headers: this.authHeader(),

--- a/web/src/pages/DevelopersPage/DevelopersPage.module.css
+++ b/web/src/pages/DevelopersPage/DevelopersPage.module.css
@@ -1,3 +1,11 @@
+/* The shared .page has no vertical gap, so stacked section cards touch. */
+.page {
+  composes: page from '../../styles/shared.module.css';
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
 .title {
   font-size: var(--text-2xl);
   font-weight: var(--font-semibold);
@@ -20,8 +28,8 @@
 
 .createRow {
   display: flex;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
   flex-wrap: wrap;
 }
 
@@ -44,7 +52,7 @@
 .keyList {
   list-style: none;
   padding: 0;
-  margin: 0;
+  margin: 0.5rem 0 0;
 }
 
 .keyRow {
@@ -52,7 +60,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  padding: 0.6rem 0;
+  padding: 0.75rem 0;
   border-bottom: 1px solid var(--color-border-light);
 }
 

--- a/web/src/pages/DevelopersPage/DevelopersPage.tsx
+++ b/web/src/pages/DevelopersPage/DevelopersPage.tsx
@@ -276,7 +276,7 @@ export default function DevelopersPage() {
     data?.locals?.patreon === true || data?.locals?.developer_access === true;
 
   return (
-    <div className={sharedStyles.page}>
+    <div className={styles.page}>
       <Helmet>
         <title>Developers — 2anki</title>
       </Helmet>


### PR DESCRIPTION
Two fixes for the developer surface — ready to review in the morning.

### CLI `convert` returned 400 on every upload
The CLI sent the file as multipart field `file`, but the server multer parses **`pakker`** (`.array('pakker')` in `GetUploadHandler.ts` — that is why the web works). Wrong field → empty `req.files` → `400 "Please select a file to upload."` (the 31-byte body seen in prod logs). Now sends `pakker`; a regression test asserts the field name.

Verified via prod logs: the key auth worked (`POST /api/upload/file` reached the handler), only the field name was wrong.

### Developers page card spacing
The page used the shared `.page` (no vertical gap), so the two section cards stacked flush, and the key list sat tight under the create row. Added a local gapped `.page` and loosened the create-row / key-list spacing.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: golden-path green; DevelopersPage + CLI apiClient tests green.

no changelog entry — fixes on the same-week invite-only developer surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)