### PR TITLE
fix: CLI convert saves the returned .apkg (not a fake job poll)

### DIFF
--- a/src/cli/apiClient.test.ts
+++ b/src/cli/apiClient.test.ts
@@ -5,7 +5,22 @@ function jsonResponse(status: number, body: unknown): Response {
     ok: status >= 200 && status < 300,
     status,
     statusText: 'x',
+    headers: new Headers({ 'content-type': 'application/json' }),
     text: async () => JSON.stringify(body),
+    json: async () => body,
+  } as Response;
+}
+
+function apkgResponse(
+  bytes: number[],
+  headers: Record<string, string>
+): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: new Headers({ 'content-type': 'application/apkg', ...headers }),
+    arrayBuffer: async () => new Uint8Array(bytes).buffer,
   } as Response;
 }
 
@@ -45,18 +60,17 @@ describe('ApiClient', () => {
     await expect(client.listJobs()).rejects.toBeInstanceOf(ApiError);
   });
 
-  it('uploads a file as multipart with the bearer token', async () => {
+  it('posts the file under the `pakker` field with the bearer token', async () => {
     const fetchImpl = jest.fn(async () =>
-      jsonResponse(200, { key: 'deck123' })
+      apkgResponse([1, 2, 3], { 'file-name': 'Deck.apkg', 'x-card-count': '5' })
     );
     const client = new ApiClient(
       { apiKey: 'sk_live_abc', apiBase: 'http://localhost:2020' },
       fetchImpl as unknown as typeof fetch
     );
 
-    const job = await client.uploadFile('notes.md', new Uint8Array([1, 2, 3]));
+    await client.convert('notes.md', new Uint8Array([1, 2, 3]));
 
-    expect(job.key).toBe('deck123');
     const [url, init] = fetchImpl.mock.calls[0] as unknown as [
       string,
       RequestInit,
@@ -66,11 +80,71 @@ describe('ApiClient', () => {
     expect((init.headers as Record<string, string>).Authorization).toBe(
       'Bearer sk_live_abc'
     );
-    expect(init.body).toBeInstanceOf(FormData);
-    // The server multer field is `pakker`, not `file` — sending the wrong name
-    // yields an empty req.files and a 400 "Please select a file to upload."
+    // The server multer field is `pakker`, not `file` — the wrong name yields an
+    // empty req.files and a 400 "Please select a file to upload."
     const form = init.body as FormData;
     expect(form.get('pakker')).not.toBeNull();
     expect(form.get('file')).toBeNull();
+  });
+
+  it('returns a single deck as raw apkg bytes with its name and card count', async () => {
+    const fetchImpl = jest.fn(async () =>
+      apkgResponse([9, 9, 9], {
+        'file-name': encodeURIComponent('My Deck.apkg'),
+        'x-card-count': '42',
+      })
+    );
+    const client = new ApiClient(
+      { apiKey: 'sk_live_abc' },
+      fetchImpl as unknown as typeof fetch
+    );
+
+    const result = await client.convert('notes.md', new Uint8Array([1]));
+
+    expect(result).toEqual({
+      kind: 'single',
+      bytes: new Uint8Array([9, 9, 9]),
+      deckName: 'My Deck.apkg',
+      cardCount: 42,
+    });
+  });
+
+  it('returns batch decks when the server responds with JSON', async () => {
+    const fetchImpl = jest.fn(async () =>
+      jsonResponse(200, {
+        kind: 'batch',
+        decks: [
+          { name: 'A', filename: 'A.apkg', downloadUrl: '/download/w/A.apkg' },
+        ],
+      })
+    );
+    const client = new ApiClient(
+      { apiKey: 'sk_live_abc' },
+      fetchImpl as unknown as typeof fetch
+    );
+
+    const result = await client.convert('notes.zip', new Uint8Array([1]));
+
+    expect(result.kind).toBe('batch');
+    if (result.kind === 'batch') {
+      expect(result.decks[0].downloadUrl).toBe('/download/w/A.apkg');
+    }
+  });
+
+  it('surfaces the server error message on a failed convert', async () => {
+    const fetchImpl = jest.fn(async () =>
+      jsonResponse(400, { message: 'Please select a file to upload.' })
+    );
+    const client = new ApiClient(
+      { apiKey: 'sk_live_abc' },
+      fetchImpl as unknown as typeof fetch
+    );
+
+    await expect(
+      client.convert('notes.md', new Uint8Array([1]))
+    ).rejects.toMatchObject({
+      status: 400,
+      message: 'Please select a file to upload.',
+    });
   });
 });

--- a/src/cli/apiClient.ts
+++ b/src/cli/apiClient.ts
@@ -17,6 +17,16 @@ export interface UploadJob {
   [k: string]: unknown;
 }
 
+export interface BatchDeck {
+  name: string;
+  filename: string;
+  downloadUrl: string;
+}
+
+export type ConvertResult =
+  | { kind: 'single'; bytes: Uint8Array; deckName: string; cardCount: number }
+  | { kind: 'batch'; decks: BatchDeck[] };
+
 export class ApiClient {
   private readonly base: string;
 
@@ -58,7 +68,12 @@ export class ApiClient {
     return Array.isArray(body) ? (body as UploadJob[]) : [];
   }
 
-  async uploadFile(filename: string, bytes: Uint8Array): Promise<UploadJob> {
+  /**
+   * Convert a file. `/api/upload/file` responds synchronously: a single deck
+   * comes back as raw `application/apkg` bytes (with File-Name / X-Card-Count
+   * headers); multiple decks come back as JSON with per-deck download URLs.
+   */
+  async convert(filename: string, bytes: Uint8Array): Promise<ConvertResult> {
     const form = new FormData();
     // Uint8Array is a valid BlobPart at runtime; the DOM lib's ArrayBuffer vs
     // ArrayBufferLike distinction is a type-only mismatch under Node.
@@ -69,7 +84,42 @@ export class ApiClient {
       headers: this.authHeader(),
       body: form,
     });
-    return (await this.parse(res)) as UploadJob;
+    if (!res.ok) {
+      const text = await res.text();
+      let message = `${res.status} ${res.statusText}`;
+      try {
+        const body = JSON.parse(text) as { message?: string };
+        if (body.message != null) message = body.message;
+      } catch {
+        if (text.trim().length > 0) message = text.trim();
+      }
+      throw new ApiError(message, res.status);
+    }
+    const contentType = res.headers.get('content-type') ?? '';
+    if (contentType.includes('application/json')) {
+      const body = (await res.json()) as { decks?: BatchDeck[] };
+      return { kind: 'batch', decks: body.decks ?? [] };
+    }
+    const out = new Uint8Array(await res.arrayBuffer());
+    const nameHeader = res.headers.get('file-name');
+    const deckName =
+      nameHeader != null && nameHeader.length > 0
+        ? decodeURIComponent(nameHeader)
+        : `${filename.replace(/\.[^.]+$/, '')}.apkg`;
+    const cardCount = Number(res.headers.get('x-card-count') ?? 0);
+    return { kind: 'single', bytes: out, deckName, cardCount };
+  }
+
+  /** Download a batch deck. The /download/:id/:file route is public (UUID). */
+  async downloadDeck(downloadUrl: string): Promise<Uint8Array> {
+    const res = await this.fetchImpl(`${this.base}${downloadUrl}`);
+    if (!res.ok) {
+      throw new ApiError(
+        `Download failed: ${res.status} ${res.statusText}`,
+        res.status
+      );
+    }
+    return new Uint8Array(await res.arrayBuffer());
   }
 }
 

--- a/src/cli/commands/convert.ts
+++ b/src/cli/commands/convert.ts
@@ -1,45 +1,15 @@
 import fs from 'fs';
 import path from 'path';
-import { readConfig, resolveApiBase } from '../config';
-import { ApiClient, ApiError, UploadJob } from '../apiClient';
+import { readConfig } from '../config';
+import { ApiClient, ApiError } from '../apiClient';
 import { info, success, error, warn, ui } from '../ui';
 
-const POLL_INTERVAL_MS = 2000;
-const MAX_POLLS = 60;
-
-function isDone(status: string | undefined): boolean {
-  return status === 'completed' || status === 'done' || status === 'success';
+function ensureApkg(name: string): string {
+  const base = path.basename(name);
+  return base.endsWith('.apkg') ? base : `${base}.apkg`;
 }
 
-function isFailed(status: string | undefined): boolean {
-  return status === 'failed' || status === 'error';
-}
-
-async function pollForJob(
-  client: ApiClient,
-  key: string | undefined,
-  sleep: (ms: number) => Promise<void>
-): Promise<UploadJob | null> {
-  for (let i = 0; i < MAX_POLLS; i += 1) {
-    const jobs = await client.listJobs();
-    const match =
-      key != null ? jobs.find((j) => j.key === key) : (jobs[0] ?? null);
-    if (match != null && (isDone(match.status) || isFailed(match.status))) {
-      return match;
-    }
-    await sleep(POLL_INTERVAL_MS);
-  }
-  return null;
-}
-
-export interface ConvertDeps {
-  sleep?: (ms: number) => Promise<void>;
-}
-
-export async function convert(
-  filePath: string | undefined,
-  deps: ConvertDeps = {}
-): Promise<number> {
+export async function convert(filePath: string | undefined): Promise<number> {
   if (filePath == null) {
     error('Usage: 2anki convert <file>');
     return 1;
@@ -60,35 +30,36 @@ export async function convert(
 
   const filename = path.basename(filePath);
   const client = new ApiClient(config);
-  const sleep =
-    deps.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
 
-  info(`Uploading ${ui.bold(filename)}…`);
-  let job: UploadJob;
+  info(`Converting ${ui.bold(filename)}…`);
   try {
-    job = await client.uploadFile(filename, bytes);
-  } catch (e) {
-    error(e instanceof ApiError ? e.message : 'Upload failed.');
-    return 1;
-  }
+    const result = await client.convert(filename, bytes);
 
-  info('Converting…');
-  const finished = await pollForJob(client, job.key, sleep);
-  if (finished == null) {
-    warn(
-      'Still converting after the wait window. Check back with `2anki whoami` or the web app.'
+    if (result.kind === 'single') {
+      const out = ensureApkg(result.deckName);
+      fs.writeFileSync(out, Buffer.from(result.bytes));
+      success(
+        `Deck ready: ${out}${result.cardCount > 0 ? ` (${result.cardCount} cards)` : ''}`
+      );
+      return 0;
+    }
+
+    if (result.decks.length === 0) {
+      warn('No decks were produced from this file.');
+      return 1;
+    }
+    for (const deck of result.decks) {
+      const deckBytes = await client.downloadDeck(deck.downloadUrl);
+      fs.writeFileSync(ensureApkg(deck.filename), Buffer.from(deckBytes));
+    }
+    success(
+      `${result.decks.length} decks ready: ${result.decks
+        .map((deck) => ensureApkg(deck.filename))
+        .join(', ')}`
     );
     return 0;
-  }
-  if (isFailed(finished.status)) {
-    error(
-      `Conversion failed${finished.title != null ? ` for ${finished.title}` : ''}.`
-    );
+  } catch (e) {
+    error(e instanceof ApiError ? e.message : 'Conversion failed.');
     return 1;
   }
-
-  const base = resolveApiBase(config).replace(/\/$/, '');
-  success(`Deck ready${finished.title != null ? `: ${finished.title}` : ''}.`);
-  info(ui.dim(`Download it from ${base}/uploads`));
-  return 0;
 }

--- a/src/cli/parseArgs.test.ts
+++ b/src/cli/parseArgs.test.ts
@@ -11,6 +11,12 @@ describe('parseArgs', () => {
     expect(parsed.positionals).toEqual(['notes.md']);
   });
 
+  it('strips a leading -- forwarded by pnpm/npx', () => {
+    const parsed = parseArgs(['--', 'convert', 'notes.md']);
+    expect(parsed.command).toBe('convert');
+    expect(parsed.positionals).toEqual(['notes.md']);
+  });
+
   it('reads a flag with a value', () => {
     const parsed = parseArgs(['login', '--key', 'sk_live_abc']);
     expect(parsed.command).toBe('login');

--- a/src/cli/parseArgs.ts
+++ b/src/cli/parseArgs.ts
@@ -9,7 +9,10 @@ export interface ParsedArgs {
  * Dependency-free on purpose — the CLI ships no third-party arg library.
  */
 export function parseArgs(argv: string[]): ParsedArgs {
-  const [command = 'help', ...rest] = argv;
+  // `pnpm cli -- convert x` / `npx pkg -- convert x` forward a literal `--` as
+  // the first token; drop it so the command is read correctly.
+  const normalized = argv[0] === '--' ? argv.slice(1) : argv;
+  const [command = 'help', ...rest] = normalized;
   const positionals: string[] = [];
   const flags: Record<string, string | boolean> = {};
 


### PR DESCRIPTION
This is the real fix for `2anki convert` — built against the actual endpoint this time, read from source.

### What was wrong
The convert command assumed `/api/upload/file` returns a JSON job to poll. It does not. Reading `UploadService.handleUpload`:
- **Single deck** → `200` with raw `application/apkg` **bytes**, plus `File-Name` and `X-Card-Count` headers.
- **Multiple decks** → `200` with JSON `{ kind:"batch", decks:[{ filename, downloadUrl:"/download/:id/:file" }] }` (that download route is public — unguessable UUID).

So every successful convert returned a body the CLI blindly `JSON.parse`d as if binary → threw → `Upload failed.`

### Fix
`client.convert` now branches on `content-type`:
- single → save the bytes to `<deck name>.apkg` (from the `File-Name` header), report the card count;
- batch → download each deck from its `downloadUrl` and save it.

Tests cover the single-binary path, the batch-JSON path, the `pakker` field name, and the error path.

no changelog entry — invite-only under-development CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)