### PR TITLE
fix: guard oversized uploads from OOM-crashing the conversion server

### DIFF
--- a/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
+++ b/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
@@ -30,6 +30,12 @@ import { writeWorkspaceFile } from './writeWorkspaceFile';
 
 const HTML_GENERATION_CONCURRENCY = 3;
 
+// Bound how many files convert at once. An unbounded Promise.all over a
+// large image/PDF deck holds every converter's working memory (base64 copies,
+// pdf→image buffers) resident simultaneously, which is a heap-OOM path on a big
+// upload (#3709). Order is preserved by mapWithConcurrency's indexed writes.
+const FILE_CONVERSION_CONCURRENCY = 4;
+
 async function mapWithConcurrency<T, R>(
   items: T[],
   concurrency: number,
@@ -366,8 +372,10 @@ export async function PrepareDeck(
   });
 
   const tConvert = Date.now();
-  const results = await Promise.all(
-    files.map((file) => convertFile(file, input))
+  const results = await mapWithConcurrency(
+    files,
+    FILE_CONVERSION_CONCURRENCY,
+    (file) => convertFile(file, input)
   );
   const convertedFiles = results.flatMap((r) => (r ? [r] : []));
   console.log('[PrepareDeck] file conversions done', {
@@ -543,8 +551,10 @@ export async function prepareDeckInfoOnly(
   outputWorkspace: Workspace
 ): Promise<DeckInfoOnlyResult> {
   const files = dedupeFilesByName(input.files);
-  const results = await Promise.all(
-    files.map((file) => convertFile(file, input))
+  const results = await mapWithConcurrency(
+    files,
+    FILE_CONVERSION_CONCURRENCY,
+    (file) => convertFile(file, input)
   );
   const convertedFiles = results.flatMap((r) => (r ? [r] : []));
   const allFiles = [...files, ...convertedFiles];

--- a/src/lib/zip/zip.test.tsx
+++ b/src/lib/zip/zip.test.tsx
@@ -11,6 +11,16 @@ function buildZip(files: Record<string, string>): Uint8Array {
   return zipSync(entries);
 }
 
+function buildBinaryZip(files: Record<string, number>): Uint8Array {
+  const entries: Record<string, Uint8Array> = {};
+  for (const [name, size] of Object.entries(files)) {
+    // Incompressible-ish payload so fflate keeps it near `size` decompressed;
+    // the guard measures decompressed length, which is what we assert on.
+    entries[name] = new Uint8Array(size).fill(1);
+  }
+  return zipSync(entries, { level: 0 });
+}
+
 describe('ZipHandler entry-name safety', () => {
   it('drops absolute-path entries while keeping safe entries', async () => {
     const zip = buildZip({
@@ -67,5 +77,43 @@ describe('ZipHandler entry-name safety', () => {
     const names = handler.getFileNames();
     expect(names).toContain('Private & Shared/SLE/page.html');
     expect(names).toContain('Private & Shared/SLE/notes.md');
+  });
+});
+
+describe('ZipHandler decompressed-size guard', () => {
+  it('rejects a zip whose decompressed contents exceed the cap', async () => {
+    // Three 1 KB image entries decompress to ~3 KB; cap at 2 KB.
+    const zip = buildBinaryZip({
+      'a.png': 1024,
+      'b.png': 1024,
+      'c.png': 1024,
+    });
+
+    const handler = new ZipHandler(10, 2 * 1024);
+
+    await expect(handler.build(zip, true, new CardOption({}))).rejects.toThrow(
+      /too large to process/
+    );
+  });
+
+  it('accepts a zip that stays under the cap', async () => {
+    const zip = buildBinaryZip({ 'a.png': 1024, 'b.png': 1024 });
+
+    const handler = new ZipHandler(10, 8 * 1024);
+    await handler.build(zip, true, new CardOption({}));
+
+    expect(handler.getFileNames()).toEqual(
+      expect.arrayContaining(['a.png', 'b.png'])
+    );
+  });
+
+  it('accumulates across nested zips', async () => {
+    const inner = buildBinaryZip({ 'big.png': 4 * 1024 });
+    const outer = zipSync({ 'nested.zip': inner }, { level: 0 });
+
+    const handler = new ZipHandler(10, 2 * 1024);
+    await expect(
+      handler.build(outer, true, new CardOption({}))
+    ).rejects.toThrow(/too large to process/);
   });
 });

--- a/src/lib/zip/zip.tsx
+++ b/src/lib/zip/zip.tsx
@@ -19,17 +19,49 @@ interface File {
   contents?: Buffer | Uint8Array | string;
 }
 
+// A zip passes the compressed-size check (`limits.fileSize`) yet can still
+// decompress to many gigabytes of image bytes that all sit resident in memory
+// at once — the whole archive is inflated up front and every entry is held in
+// `this.files`. A single such upload OOM-crashed the shared server (#3709),
+// which kills every *other* user's in-flight conversion on the process too.
+// Cap the cumulative decompressed size (across nested zips) and fail closed
+// with a clear, actionable error instead. The 16 GB heap on prod amplifies to
+// ~3× during processing, so 4 GB decompressed leaves headroom.
+const MAX_DECOMPRESSED_BYTES = 4 * 1024 * 1024 * 1024;
+
+function formatGigabytes(bytes: number): string {
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
 class ZipHandler {
   files: File[];
   zipFileCount: number;
   maxZipFiles: number;
   combinedHTML: string;
+  decompressedBytes: number;
+  maxDecompressedBytes: number;
 
-  constructor(maxNestedZipFiles: number) {
+  constructor(
+    maxNestedZipFiles: number,
+    maxDecompressedBytes: number = MAX_DECOMPRESSED_BYTES
+  ) {
     this.files = [];
     this.zipFileCount = 0;
     this.maxZipFiles = maxNestedZipFiles;
     this.combinedHTML = '';
+    this.decompressedBytes = 0;
+    this.maxDecompressedBytes = maxDecompressedBytes;
+  }
+
+  private trackDecompressedBytes(byteLength: number) {
+    this.decompressedBytes += byteLength;
+    if (this.decompressedBytes > this.maxDecompressedBytes) {
+      throw new Error(
+        `This upload is too large to process — it decompresses to over ${formatGigabytes(
+          this.maxDecompressedBytes
+        )}. Split it into smaller uploads and try again.`
+      );
+    }
   }
 
   async build(zipData: Uint8Array, paying: boolean, settings: CardOption) {
@@ -105,7 +137,15 @@ class ZipHandler {
     if (name.endsWith('.zip')) {
       this.zipFileCount++;
       await this.processZip(file, paying, settings);
-    } else if (isHTMLFile(name) || isMarkdownFile(name)) {
+      return;
+    }
+
+    // Every non-zip entry below is retained in memory (as a Buffer, Uint8Array,
+    // or decoded string). Count it toward the resident-payload ceiling before
+    // holding onto it, so an oversized deck fails closed instead of OOMing.
+    this.trackDecompressedBytes(file.length);
+
+    if (isHTMLFile(name) || isMarkdownFile(name)) {
       this.files.push({ name, contents: strFromU8(file) });
     } else if (paying && settings.imageQuizHtmlToAnki && isImageFile(name)) {
       await this.convertAndAddImageToHTML(name, file);

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-18-large-upload-guard.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-18-large-upload-guard.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-18-large-upload-guard",
+  "date": "2026-07-18",
+  "type": "fix",
+  "title": "Very large uploads show a clear size message instead of failing mid-conversion"
+}


### PR DESCRIPTION
Fixes #3709.

## What crashed

Prod `server-green` OOM-crashed twice this morning during a large image-heavy conversion (thousands of PNG screenshots). The process runs a **16 GB** heap (`--max-old-space-size=16384`) and still ran out — the killer is that the entire zip is inflated into memory up front and every entry is held resident in `ZipHandler.files`, with further copies downstream. Because the conversion process is **shared**, one oversized upload takes down every other user's in-flight conversion as collateral.

## This PR (interim stability fix)

1. **Decompressed-size guard in `ZipHandler`.** A zip passes the compressed `fileSize` check yet can decompress to many GB. Track cumulative decompressed bytes (across nested zips) and fail closed at 4 GB with a clear, VOICE-compliant message ("This upload is too large to process — it decompresses to over 4.0 GB. Split it into smaller uploads and try again.") instead of crashing the shared server. Cap is injectable via the constructor so it's unit-testable without building a 4 GB fixture. 4 GB × the ~3× processing amplification stays under the 16 GB heap.

2. **Bounded conversion fan-out in `PrepareDeck`.** Replaced the two unbounded `Promise.all(files.map(convertFile))` sites with the existing order-preserving `mapWithConcurrency` (concurrency 4), so a large PDF/PPT/docx deck no longer holds every converter's working memory (base64 copies, pdf→image buffers) resident simultaneously.

## What this does NOT do (tracked follow-up on #3709)

It does **not** yet let one user convert an arbitrarily huge image deck — the proper fix is streaming zip entries to disk and resolving media from disk instead of holding all bytes in memory (`unzipSync` → streaming, `ZipHandler.files` → disk-backed). That's a large blast radius across `ZipHandler → getPackagesFromZip → DeckParser → CustomExporter/embedFile` and needs full-pipeline (python packaging) testing in the main checkout, so it's a separate PR. This PR's job is to stop one deck from crashing everyone else's conversions.

## Decisions made
- **Reject vs convert the giant deck:** chose reject-with-clear-message for now. Rationale: a server-wide crash that kills all concurrent paying users' conversions is strictly worse than one clear error for the one oversized upload. The convert-anything path is the streaming follow-up. If you'd rather raise/lower the 4 GB ceiling, it's one constant (`MAX_DECOMPRESSED_BYTES` in `src/lib/zip/zip.tsx`).
- **Concurrency = 4** for file conversion — conservative; bump if throughput on big multi-PDF decks regresses.

## Tests
- `src/lib/zip/zip.test.tsx`: rejects over-cap zip, accepts under-cap, accumulates across nested zips.
- Existing `PrepareDeck` (107) + zip (now 7) suites green; `tsc -p .` clean; tree-wide `oxfmt --check` clean.

## Notes
- No Sonar locally (no `SONAR_TOKEN` on this box) — Automatic Analysis covers the push.

Browser check: not applicable — the only `web/src/` change is a changelog JSON, no runtime-visible UI change.


Streaming rewrite (the convert-anything path) tracked in #3711.
