### PR TITLE
fix: stream zip image entries to disk so big decks don't exhaust heap

### DIFF
--- a/src/lib/parser/DeckParser.batchImageMedia.test.ts
+++ b/src/lib/parser/DeckParser.batchImageMedia.test.ts
@@ -1,10 +1,13 @@
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
+import { zipSync } from 'fflate';
 
 import { setupTests } from '../../test/configure-jest';
 import CardOption from './Settings/CardOption';
 import { DeckParser } from './DeckParser';
 import Workspace from './WorkSpace';
+import { ZipHandler } from '../zip/zip';
 
 beforeEach(() => setupTests());
 
@@ -47,4 +50,52 @@ test('batch build keeps the embedded markdown image in card media and the export
   expect(fs.existsSync(path.join(batchWorkspace.location, embeddedSrc!))).toBe(
     true
   );
+});
+
+test('embeds a disk-backed (spilled) image with its real bytes into the deck media', async () => {
+  process.env.SKIP_CREATE_DECK = 'true';
+
+  const constructorWorkspace = new Workspace(true, 'fs');
+  const batchWorkspace = Workspace.subdir(constructorWorkspace.location);
+
+  // Spill the image to disk exactly as the upload path now does, then feed the
+  // lazily-read entry into the parser instead of an in-memory Buffer.
+  const spill = fs.mkdtempSync(path.join(os.tmpdir(), 'deck-spill-'));
+  const imageBytes = Buffer.from('distinct-spilled-png-bytes-0123456789');
+  const zip = zipSync(
+    { 'image.png': new Uint8Array(imageBytes) },
+    { level: 0 }
+  );
+  const handler = new ZipHandler(10);
+  await handler.build(zip, true, new CardOption({}), spill);
+  const spilledImage = handler.files.find((f) => f.name === 'image.png');
+
+  const markdown = [
+    '- What is shown here?',
+    '    ![image.png](image.png)',
+    '',
+  ].join('\n');
+  const parser = new DeckParser({
+    name: 'notes.md',
+    settings: new CardOption({ 'markdown-nested-bullet-points': 'true' }),
+    files: [
+      { name: 'notes.md', contents: markdown },
+      spilledImage,
+    ] as unknown as DeckParser['files'],
+    noLimits: true,
+    workspace: constructorWorkspace,
+  });
+
+  await parser.writeDeckInfo(batchWorkspace);
+
+  const card = parser.payload[0].cards[0];
+  const embeddedSrc = /<img[^>]+src="([^"]+)"/.exec(card.back)?.[1];
+  expect(embeddedSrc).toBeDefined();
+  expect(card.media).toContain(embeddedSrc);
+
+  const mediaPath = path.join(batchWorkspace.location, embeddedSrc!);
+  expect(fs.existsSync(mediaPath)).toBe(true);
+  // The bytes packed into the deck media must equal the spilled image's real
+  // bytes — proving the lazy disk read flows through embedFile → addMedia.
+  expect(fs.readFileSync(mediaPath)).toEqual(imageBytes);
 });

--- a/src/lib/parser/exporters/embedFile.test.ts
+++ b/src/lib/parser/exporters/embedFile.test.ts
@@ -1,7 +1,13 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { zipSync } from 'fflate';
 import { setupTests } from '../../../test/configure-jest';
 import { embedFile } from './embedFile';
 import CustomExporter from './CustomExporter';
 import Workspace from '../WorkSpace';
+import { ZipHandler } from '../../zip/zip';
+import CardOption from '../Settings';
 
 beforeEach(() => setupTests());
 
@@ -114,5 +120,48 @@ describe('embedFile — filename-only fallback', () => {
 
     expect(result).toBeNull();
     expect(exporter.addMedia).not.toHaveBeenCalled();
+  });
+});
+
+describe('embedFile — disk-backed (spilled) zip entries', () => {
+  it('resolves a spilled image lazily from disk and embeds its real bytes', async () => {
+    const spill = fs.mkdtempSync(path.join(os.tmpdir(), 'embed-spill-'));
+    const imageBytes = Buffer.alloc(64, 7);
+    const zip = zipSync(
+      { 'chapter1/image.png': new Uint8Array(imageBytes) },
+      { level: 0 }
+    );
+
+    const handler = new ZipHandler(10);
+    await handler.build(zip, true, new CardOption({}), spill);
+
+    // The bytes are on disk; the in-memory entry reads them lazily.
+    expect(fs.existsSync(path.join(spill, 'chapter1/image.png'))).toBe(true);
+
+    const captured: Buffer[] = [];
+    const exporter = {
+      firstDeckName: 'deck',
+      workspace: '/tmp',
+      media: [],
+      addMedia: jest.fn((_name: string, contents: Buffer) => {
+        captured.push(Buffer.from(contents));
+        return '/tmp/x.png';
+      }),
+    } as unknown as CustomExporter;
+
+    const result = embedFile({
+      exporter,
+      files: handler.files,
+      filePath: 'chapter1/image.png',
+      // A location that does not exist so getFile falls through to the
+      // in-memory (now disk-backed) entry, exercising the lazy read.
+      workspace: {
+        location: '/nonexistent-workspace-xyzzy',
+      } as unknown as Workspace,
+    });
+
+    expect(result).not.toBeNull();
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).toEqual(imageBytes);
   });
 });

--- a/src/lib/zip/zip.test.tsx
+++ b/src/lib/zip/zip.test.tsx
@@ -1,7 +1,14 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { strToU8, zipSync } from 'fflate';
 
 import { ZipHandler } from './zip';
 import CardOption from '../parser/Settings';
+
+function makeSpillDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'ziphandler-spill-'));
+}
 
 function buildZip(files: Record<string, string>): Uint8Array {
   const entries: Record<string, Uint8Array> = {};
@@ -80,14 +87,10 @@ describe('ZipHandler entry-name safety', () => {
   });
 });
 
-describe('ZipHandler decompressed-size guard', () => {
-  it('rejects a zip whose decompressed contents exceed the cap', async () => {
-    // Three 1 KB image entries decompress to ~3 KB; cap at 2 KB.
-    const zip = buildBinaryZip({
-      'a.png': 1024,
-      'b.png': 1024,
-      'c.png': 1024,
-    });
+describe('ZipHandler in-memory text guard', () => {
+  it('rejects a zip that holds more decoded text than the cap', async () => {
+    const big = 'x'.repeat(3 * 1024);
+    const zip = buildZip({ 'a.html': big });
 
     const handler = new ZipHandler(10, 2 * 1024);
 
@@ -96,24 +99,66 @@ describe('ZipHandler decompressed-size guard', () => {
     );
   });
 
-  it('accepts a zip that stays under the cap', async () => {
-    const zip = buildBinaryZip({ 'a.png': 1024, 'b.png': 1024 });
+  it('accepts a zip whose text stays under the cap', async () => {
+    const zip = buildZip({ 'a.html': 'x'.repeat(1024) });
 
     const handler = new ZipHandler(10, 8 * 1024);
     await handler.build(zip, true, new CardOption({}));
 
-    expect(handler.getFileNames()).toEqual(
-      expect.arrayContaining(['a.png', 'b.png'])
-    );
+    expect(handler.getFileNames()).toEqual(['a.html']);
   });
 
-  it('accumulates across nested zips', async () => {
-    const inner = buildBinaryZip({ 'big.png': 4 * 1024 });
+  it('accumulates text across nested zips', async () => {
+    const inner = buildZip({ 'big.html': 'x'.repeat(4 * 1024) });
     const outer = zipSync({ 'nested.zip': inner }, { level: 0 });
 
     const handler = new ZipHandler(10, 2 * 1024);
     await expect(
       handler.build(outer, true, new CardOption({}))
     ).rejects.toThrow(/too large to process/);
+  });
+});
+
+describe('ZipHandler disk spill', () => {
+  it('spills binary entries to the workspace and reads them back lazily', async () => {
+    const spill = makeSpillDir();
+    const zip = buildBinaryZip({ 'img.png': 2048 });
+
+    const handler = new ZipHandler(10);
+    await handler.build(zip, true, new CardOption({}), spill);
+
+    // The bytes live on disk, not in the in-memory entry's own storage.
+    expect(fs.existsSync(path.join(spill, 'img.png'))).toBe(true);
+    const entry = handler.files.find((f) => f.name === 'img.png');
+    expect(entry).toBeDefined();
+    expect(Buffer.from(entry!.contents as Buffer)).toEqual(
+      Buffer.alloc(2048, 1)
+    );
+  });
+
+  it('does not count spilled binary bytes toward the in-memory cap', async () => {
+    const spill = makeSpillDir();
+    // 8 KB of images with a tiny 1 KB in-memory cap: must NOT throw, because
+    // the images go to disk instead of memory.
+    const zip = buildBinaryZip({ 'a.png': 4096, 'b.png': 4096 });
+
+    const handler = new ZipHandler(10, 1024);
+    await handler.build(zip, true, new CardOption({}), spill);
+
+    expect(handler.getFileNames()).toEqual(
+      expect.arrayContaining(['a.png', 'b.png'])
+    );
+  });
+
+  it('keeps html in memory as a decoded string, not a disk path', async () => {
+    const spill = makeSpillDir();
+    const zip = buildZip({ 'page.html': '<p>real deck</p>' });
+
+    const handler = new ZipHandler(10);
+    await handler.build(zip, true, new CardOption({}), spill);
+
+    const entry = handler.files.find((f) => f.name === 'page.html');
+    expect(entry?.contents).toBe('<p>real deck</p>');
+    expect(fs.existsSync(path.join(spill, 'page.html'))).toBe(false);
   });
 });

--- a/src/lib/zip/zip.tsx
+++ b/src/lib/zip/zip.tsx
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import path from 'path';
 import { strFromU8, unzipSync } from 'fflate';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { getUploadLimits } from '../misc/getUploadLimits';
@@ -19,18 +21,33 @@ interface File {
   contents?: Buffer | Uint8Array | string;
 }
 
-// A zip passes the compressed-size check (`limits.fileSize`) yet can still
-// decompress to many gigabytes of image bytes that all sit resident in memory
-// at once — the whole archive is inflated up front and every entry is held in
-// `this.files`. A single such upload OOM-crashed the shared server (#3709),
-// which kills every *other* user's in-flight conversion on the process too.
-// Cap the cumulative decompressed size (across nested zips) and fail closed
-// with a clear, actionable error instead. The 16 GB heap on prod amplifies to
-// ~3× during processing, so 4 GB decompressed leaves headroom.
-const MAX_DECOMPRESSED_BYTES = 4 * 1024 * 1024 * 1024;
+// Binary entries (images, audio, misc media) are spilled to the workspace on
+// disk during extraction and backed by a lazy read, so they no longer sit
+// resident in memory — a deck of thousands of screenshots used to inflate the
+// whole archive into RAM at once and OOM-crash the shared server (#3709/#3711).
+// Only entries we KEEP in memory (decoded HTML/markdown text, the OCR html) are
+// counted toward this heap ceiling; disk-backed media is bounded instead by the
+// compressed-upload cap (`getUploadLimits().fileSize`). 4 GB of in-memory text
+// leaves headroom under the 16 GB prod heap.
+const MAX_IN_MEMORY_BYTES = 4 * 1024 * 1024 * 1024;
 
 function formatGigabytes(bytes: number): string {
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
+// Back a spilled entry with a lazy disk read so every consumer that reads
+// `.contents` (embedFile, PrepareDeck converters, writeWorkspaceFile) still gets
+// real bytes, but only one entry's bytes are resident at a time instead of all.
+function makeDiskBackedFile(name: string, diskPath: string): File {
+  const file: File = { name };
+  Object.defineProperty(file, 'contents', {
+    enumerable: true,
+    configurable: true,
+    get() {
+      return fs.readFileSync(diskPath);
+    },
+  });
+  return file;
 }
 
 class ZipHandler {
@@ -38,33 +55,55 @@ class ZipHandler {
   zipFileCount: number;
   maxZipFiles: number;
   combinedHTML: string;
-  decompressedBytes: number;
-  maxDecompressedBytes: number;
+  inMemoryBytes: number;
+  maxInMemoryBytes: number;
+  spillLocation?: string;
 
   constructor(
     maxNestedZipFiles: number,
-    maxDecompressedBytes: number = MAX_DECOMPRESSED_BYTES
+    maxInMemoryBytes: number = MAX_IN_MEMORY_BYTES
   ) {
     this.files = [];
     this.zipFileCount = 0;
     this.maxZipFiles = maxNestedZipFiles;
     this.combinedHTML = '';
-    this.decompressedBytes = 0;
-    this.maxDecompressedBytes = maxDecompressedBytes;
+    this.inMemoryBytes = 0;
+    this.maxInMemoryBytes = maxInMemoryBytes;
   }
 
-  private trackDecompressedBytes(byteLength: number) {
-    this.decompressedBytes += byteLength;
-    if (this.decompressedBytes > this.maxDecompressedBytes) {
+  private trackInMemoryBytes(byteLength: number) {
+    this.inMemoryBytes += byteLength;
+    if (this.inMemoryBytes > this.maxInMemoryBytes) {
       throw new Error(
-        `This upload is too large to process — it decompresses to over ${formatGigabytes(
-          this.maxDecompressedBytes
-        )}. Split it into smaller uploads and try again.`
+        `This upload is too large to process — it holds over ${formatGigabytes(
+          this.maxInMemoryBytes
+        )} of text in memory. Split it into smaller uploads and try again.`
       );
     }
   }
 
-  async build(zipData: Uint8Array, paying: boolean, settings: CardOption) {
+  // Write a binary entry to the workspace on disk and return a lazily-read File.
+  // Returns undefined when there is no spill location (in-memory callers/tests).
+  private spillToDisk(name: string, file: Uint8Array): File | undefined {
+    if (this.spillLocation == null) return undefined;
+    const base = path.resolve(this.spillLocation);
+    const abs = path.resolve(base, name);
+    if (abs !== base && !abs.startsWith(base + path.sep)) {
+      console.warn('Skipped zip entry that escaped the spill directory');
+      return undefined;
+    }
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, file);
+    return makeDiskBackedFile(name, abs);
+  }
+
+  async build(
+    zipData: Uint8Array,
+    paying: boolean,
+    settings: CardOption,
+    spillLocation?: string
+  ) {
+    this.spillLocation = spillLocation;
     const size = Buffer.byteLength(zipData);
     const limits = getUploadLimits(paying);
 
@@ -140,20 +179,23 @@ class ZipHandler {
       return;
     }
 
-    // Every non-zip entry below is retained in memory (as a Buffer, Uint8Array,
-    // or decoded string). Count it toward the resident-payload ceiling before
-    // holding onto it, so an oversized deck fails closed instead of OOMing.
-    this.trackDecompressedBytes(file.length);
-
     if (isHTMLFile(name) || isMarkdownFile(name)) {
+      this.trackInMemoryBytes(file.length);
       this.files.push({ name, contents: strFromU8(file) });
     } else if (paying && settings.imageQuizHtmlToAnki && isImageFile(name)) {
+      this.trackInMemoryBytes(file.length);
       await this.convertAndAddImageToHTML(name, file);
     } else if (isPDFFile(name) && settings.processPDFs === false) {
       // Skip PDF processing when processPDFs is false
       return;
     } else {
-      this.files.push({ name, contents: file });
+      const spilled = this.spillToDisk(name, file);
+      if (spilled) {
+        this.files.push(spilled);
+      } else {
+        this.trackInMemoryBytes(file.length);
+        this.files.push({ name, contents: file });
+      }
     }
   }
 

--- a/src/usecases/uploads/getPackagesFromZip.ts
+++ b/src/usecases/uploads/getPackagesFromZip.ts
@@ -300,7 +300,12 @@ export const getPackagesFromZip = async (
   }
 
   const zipHandler = new ZipHandler(getMaxUploadCount(paying));
-  await zipHandler.build(fileContents as Uint8Array, paying, settings);
+  await zipHandler.build(
+    fileContents as Uint8Array,
+    paying,
+    settings,
+    workspace.location
+  );
 
   const ankiAppResult = await convertAnkiAppDecksFromZip(
     zipHandler.files,

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-18-large-image-decks.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-18-large-image-decks.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-18-large-image-decks",
+  "date": "2026-07-18",
+  "type": "fix",
+  "title": "Uploads with thousands of images convert instead of stalling the server"
+}


### PR DESCRIPTION
Fixes #3711 (follow-up to #3709 / PR #3710).

## The problem

`ZipHandler` inflated the entire uploaded archive into memory (`unzipSync`) and held every entry's bytes in `ZipHandler.files`. A deck of thousands of screenshots kept gigabytes of image data resident at once and OOM-crashed the shared server — which runs a 16 GB heap and still ran out. #3710 added a guard that *rejected* such decks; this PR makes them *convert*.

## The change

Binary entries (images, audio, misc media) now spill to the workspace on disk during extraction, and the in-memory `File` is backed by a lazy read instead of an eager `Uint8Array`. Peak memory becomes one entry's bytes at a time, not the whole archive.

Why this is low-risk:
- **Resolution is unchanged.** `embedFile`/`getFile` already resolve media by `name`, disk-first; only where the bytes *live* changed. Every consumer that reads `.contents` (`embedFile`, the `PrepareDeck` converters, `writeWorkspaceFile`, the AnkiApp path) still gets real bytes via the getter. No workspace-threading change.
- **HTML/markdown stay in memory** (small text). Only binary entries spill.
- **The heap guard now counts only in-memory-retained text.** Disk-backed media is bounded by the existing compressed-upload cap (`getUploadLimits().fileSize`) instead of the heap. The `#3710` reject only fires now for a pathological volume of *text*, not images.

## Verification

Genanki (`create_deck`) isn't installable on this box, so the final `.apkg` zip step can't run locally — but it's byte-source-agnostic (it tars whatever `addMedia` wrote to the workspace), and this diff doesn't touch it. Everything up to it is covered:

- **Real end-to-end (minus genanki):** a spilled, disk-backed image referenced by markdown embeds its **exact bytes** into the deck media through the real `DeckParser -> embedFile -> addMedia` path (`DeckParser.batchImageMedia.test.ts`).
- **Seam test:** a spilled image resolves lazily from disk and passes correct bytes to `addMedia` (`embedFile.test.ts`).
- **Unit:** `ZipHandler` spills binaries to disk, reads them back lazily, keeps HTML in memory, and does **not** count spilled bytes toward the in-memory cap (`zip.test.tsx`).
- Full `src/lib/zip`, `src/usecases/uploads`, `src/lib/parser/exporters` suites green (132 tests); `tsc -p .` clean; tree-wide `oxfmt --check` clean.
- The 56 `DeckParser` python-packaging failures are pre-existing and environmental (no `create_deck` on this box) — identical on the unchanged baseline, zero added by this diff.

## Decisions made
- **Kept the 4 GB ceiling, repurposed to in-memory text only** (renamed `MAX_IN_MEMORY_BYTES`). Rationale: with media on disk, heap is bounded by text, and disk is bounded by the upload cap — so no need to guess a disk ceiling. If a huge *text* zip should also convert, that's a separate tune.
- **Only binary entries spill; convertibles (xlsx/docx/pdf/ppt) also ride the same disk-backed path** since they fall through the same branch — they're few per deck, so it's a bonus, not the target.

## Notes
- No Sonar locally (no `SONAR_TOKEN` on this box) — Automatic Analysis covers the push.

Browser check: not applicable — the only `web/src/` change is a changelog JSON, no rendered UI change.
