### PR TITLE
feat: instrument subscription cancel funnel

### DIFF
--- a/src/controllers/OpsController.test.ts
+++ b/src/controllers/OpsController.test.ts
@@ -8,6 +8,7 @@ import { DeleteInactiveUsersUseCase } from '../usecases/ops/DeleteInactiveUsersU
 import { GetLandingPageYieldUseCase } from '../usecases/ops/GetLandingPageYieldUseCase';
 import { GetCustomerSignalsUseCase } from '../usecases/ops/GetCustomerSignalsUseCase';
 import { GetPassUnlockMonitorUseCase } from '../usecases/ops/GetPassUnlockMonitorUseCase';
+import { GetCancelFunnelUseCase } from '../usecases/ops/GetCancelFunnelUseCase';
 
 const buildRes = () => {
   const json = jest.fn();
@@ -504,5 +505,91 @@ describe('OpsController.deleteInactiveUsers', () => {
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({ message: expect.any(String) })
     );
+  });
+});
+
+describe('OpsController.getCancelFunnel', () => {
+  const buildController = (useCase?: GetCancelFunnelUseCase) =>
+    new OpsController(
+      {} as unknown as GetOpsMetricsUseCase,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      useCase
+    );
+
+  it('passes the window down and returns the funnel payload', async () => {
+    const payload = {
+      stages: {
+        cancel_started: 100,
+        pause_offered: 40,
+        paused: 12,
+        cancelled: 70,
+        pause_offer_declined: 25,
+      },
+      save_rate_pct: 30,
+      offer_reach_pct: 40,
+      since: '2026-06-01T00:00:00.000Z',
+      as_of: '2026-07-01T00:00:00.000Z',
+    };
+    const useCase = {
+      execute: jest.fn().mockResolvedValue(payload),
+    } as unknown as GetCancelFunnelUseCase;
+    const controller = buildController(useCase);
+    const req = { query: { window: '14d' } } as unknown as express.Request;
+    const res = buildRes();
+
+    await controller.getCancelFunnel(req, res);
+
+    expect(useCase.execute as jest.Mock).toHaveBeenCalledWith('14d');
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(payload);
+  });
+
+  it('responds 500 when the use case is not configured', async () => {
+    const controller = buildController(undefined);
+    const req = { query: {} } as unknown as express.Request;
+    const res = buildRes();
+
+    await controller.getCancelFunnel(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.any(String) })
+    );
+  });
+
+  it('responds 500 when the use case throws', async () => {
+    const useCase = {
+      execute: jest.fn().mockRejectedValue(new Error('db down')),
+    } as unknown as GetCancelFunnelUseCase;
+    const controller = buildController(useCase);
+    const req = { query: {} } as unknown as express.Request;
+    const res = buildRes();
+    const errSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    await controller.getCancelFunnel(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    errSpy.mockRestore();
   });
 });

--- a/src/controllers/OpsController.ts
+++ b/src/controllers/OpsController.ts
@@ -18,6 +18,7 @@ import {
   SetFeatureFlagUseCase,
 } from '../usecases/ops/SetFeatureFlagUseCase';
 import { GetUploadFunnelUseCase } from '../usecases/ops/GetUploadFunnelUseCase';
+import { GetCancelFunnelUseCase } from '../usecases/ops/GetCancelFunnelUseCase';
 import { GetOrphanedSubscriptionsUseCase } from '../usecases/ops/GetOrphanedSubscriptionsUseCase';
 import { ReconcileOrphanedSubscriptionsUseCase } from '../usecases/ops/ReconcileOrphanedSubscriptionsUseCase';
 import { GetLandingPageYieldUseCase } from '../usecases/ops/GetLandingPageYieldUseCase';
@@ -49,7 +50,8 @@ class OpsController {
     private readonly getCustomerSignalsUseCase?: GetCustomerSignalsUseCase,
     private readonly getPassUnlockMonitorUseCase?: GetPassUnlockMonitorUseCase,
     private readonly sendPassWinbackUseCase?: SendPassWinbackUseCase,
-    private readonly grantDeveloperAccessUseCase?: GrantDeveloperAccessUseCase
+    private readonly grantDeveloperAccessUseCase?: GrantDeveloperAccessUseCase,
+    private readonly getCancelFunnelUseCase?: GetCancelFunnelUseCase
   ) {}
 
   async grantDeveloperAccess(req: express.Request, res: express.Response) {
@@ -367,6 +369,22 @@ class OpsController {
     } catch (error) {
       console.error('[ops] getUploadFunnel failed', error);
       res.status(500).json({ message: 'Failed to load upload funnel' });
+    }
+  }
+
+  async getCancelFunnel(req: express.Request, res: express.Response) {
+    if (this.getCancelFunnelUseCase == null) {
+      res.status(500).json({ message: 'Cancel funnel not configured' });
+      return;
+    }
+    try {
+      const window =
+        typeof req.query.window === 'string' ? req.query.window : undefined;
+      const result = await this.getCancelFunnelUseCase.execute(window);
+      res.status(200).json(result);
+    } catch (error) {
+      console.error('[ops] getCancelFunnel failed', error);
+      res.status(500).json({ message: 'Failed to load cancel funnel' });
     }
   }
 

--- a/src/controllers/UsersControllers.test.ts
+++ b/src/controllers/UsersControllers.test.ts
@@ -2867,6 +2867,7 @@ describe('UsersController.cancelSubscription', () => {
 
   beforeEach(() => {
     (SubscriptionService.cancelUserSubscriptions as jest.Mock).mockReset();
+    trackMock.mockClear();
   });
 
   it('returns 422 with a recovery hint when no subscription matches the account', async () => {
@@ -2926,6 +2927,72 @@ describe('UsersController.cancelSubscription', () => {
 
     expect(res.status).toHaveBeenCalledWith(401);
     expect(SubscriptionService.cancelUserSubscriptions).not.toHaveBeenCalled();
+  });
+
+  it('fires subscription_cancelled once with reason and period_end cancel_type', async () => {
+    (
+      SubscriptionService.cancelUserSubscriptions as jest.Mock
+    ).mockResolvedValue(1);
+    const { controller } = buildCancelController();
+    const req = {
+      body: { mode: 'period_end', reason: "I don't use it enough" },
+    } as express.Request;
+    const res = buildResWithLocals();
+
+    await controller.cancelSubscription(req, res);
+
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    expect(trackMock).toHaveBeenCalledWith('subscription_cancelled', {
+      userId: 1,
+      props: { reason: "I don't use it enough", cancel_type: 'period_end' },
+    });
+  });
+
+  it('records cancel_type immediate when the mode is immediate', async () => {
+    (
+      SubscriptionService.cancelUserSubscriptions as jest.Mock
+    ).mockResolvedValue(2);
+    const { controller } = buildCancelController();
+    const req = {
+      body: { mode: 'immediate', reason: 'Too expensive' },
+    } as express.Request;
+    const res = buildResWithLocals();
+
+    await controller.cancelSubscription(req, res);
+
+    expect(trackMock).toHaveBeenCalledWith('subscription_cancelled', {
+      userId: 1,
+      props: { reason: 'Too expensive', cancel_type: 'immediate' },
+    });
+  });
+
+  it('sends reason null when the body omits a reason', async () => {
+    (
+      SubscriptionService.cancelUserSubscriptions as jest.Mock
+    ).mockResolvedValue(1);
+    const { controller } = buildCancelController();
+    const req = { body: { mode: 'period_end' } } as express.Request;
+    const res = buildResWithLocals();
+
+    await controller.cancelSubscription(req, res);
+
+    expect(trackMock).toHaveBeenCalledWith('subscription_cancelled', {
+      userId: 1,
+      props: { reason: null, cancel_type: 'period_end' },
+    });
+  });
+
+  it('does not fire subscription_cancelled when no subscription matches', async () => {
+    (
+      SubscriptionService.cancelUserSubscriptions as jest.Mock
+    ).mockResolvedValue(0);
+    const { controller } = buildCancelController();
+    const req = { body: { mode: 'period_end' } } as express.Request;
+    const res = buildResWithLocals();
+
+    await controller.cancelSubscription(req, res);
+
+    expect(trackMock).not.toHaveBeenCalled();
   });
 });
 
@@ -3112,6 +3179,7 @@ describe('UsersController.cancelSubscriptionById', () => {
 
   beforeEach(() => {
     (SubscriptionService.cancelSubscriptionById as jest.Mock).mockReset();
+    trackMock.mockClear();
   });
 
   it('returns 401 when there is no authenticated owner', async () => {
@@ -3126,6 +3194,7 @@ describe('UsersController.cancelSubscriptionById', () => {
 
     expect(res.status).toHaveBeenCalledWith(401);
     expect(SubscriptionService.cancelSubscriptionById).not.toHaveBeenCalled();
+    expect(trackMock).not.toHaveBeenCalled();
   });
 
   it('returns 404 when the user is not found', async () => {
@@ -3192,6 +3261,42 @@ describe('UsersController.cancelSubscriptionById', () => {
       'immediate'
     );
     expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('fires subscription_cancelled with reason and cancel_type from the request', async () => {
+    (SubscriptionService.cancelSubscriptionById as jest.Mock).mockResolvedValue(
+      undefined
+    );
+    const { controller } = buildByIdController();
+    const req = {
+      params: { id: 'sub_owned' },
+      body: { mode: 'period_end', reason: 'I finished what I needed' },
+    } as unknown as express.Request;
+    const res = buildResWithLocals();
+
+    await controller.cancelSubscriptionById(req, res);
+
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    expect(trackMock).toHaveBeenCalledWith('subscription_cancelled', {
+      userId: 1,
+      props: { reason: 'I finished what I needed', cancel_type: 'period_end' },
+    });
+  });
+
+  it('does not fire subscription_cancelled when the subscription is not owned', async () => {
+    (SubscriptionService.cancelSubscriptionById as jest.Mock).mockRejectedValue(
+      new SubscriptionNotOwnedError()
+    );
+    const { controller } = buildByIdController();
+    const req = {
+      params: { id: 'sub_other' },
+      body: { mode: 'immediate' },
+    } as unknown as express.Request;
+    const res = buildResWithLocals();
+
+    await controller.cancelSubscriptionById(req, res);
+
+    expect(trackMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -538,6 +538,15 @@ class UsersController {
         });
       }
 
+      const reason =
+        typeof req.body?.reason === 'string' && req.body.reason.length > 0
+          ? req.body.reason
+          : null;
+      track('subscription_cancelled', {
+        userId: owner,
+        props: { reason, cancel_type: requestedMode },
+      });
+
       const message =
         requestedMode === 'immediate'
           ? 'Your subscription has been cancelled. A confirmation email is on its way.'
@@ -576,6 +585,15 @@ class UsersController {
         id,
         requestedMode
       );
+
+      const reason =
+        typeof req.body?.reason === 'string' && req.body.reason.length > 0
+          ? req.body.reason
+          : null;
+      track('subscription_cancelled', {
+        userId: owner,
+        props: { reason, cancel_type: requestedMode },
+      });
 
       return res.status(200).json({ message: 'This plan has been cancelled.' });
     } catch (error) {

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -50,6 +50,8 @@ import { EventsMetricsRepository } from '../data_layer/EventsMetricsRepository';
 import { SyncStripeSubscriptionsUseCase } from '../usecases/ops/SyncStripeSubscriptionsUseCase';
 import { GetUploadFunnelUseCase } from '../usecases/ops/GetUploadFunnelUseCase';
 import { UploadFunnelService } from '../services/ops/UploadFunnelService';
+import { GetCancelFunnelUseCase } from '../usecases/ops/GetCancelFunnelUseCase';
+import { CancelFunnelService } from '../services/ops/CancelFunnelService';
 import { GetLandingPageYieldUseCase } from '../usecases/ops/GetLandingPageYieldUseCase';
 import { LandingPageYieldService } from '../services/ops/LandingPageYieldService';
 import { LandingPageYieldRepository } from '../data_layer/LandingPageYieldRepository';
@@ -186,7 +188,10 @@ const OpsRouter = () => {
         ),
       getEventsSink()
     ),
-    new GrantDeveloperAccessUseCase(new UsersRepository(database))
+    new GrantDeveloperAccessUseCase(new UsersRepository(database)),
+    new GetCancelFunnelUseCase(
+      new CancelFunnelService({ eventsRepo: new EventsRepository(database) })
+    )
   );
 
   /**
@@ -574,6 +579,37 @@ const OpsRouter = () => {
    */
   router.get('/api/ops/upload-funnel', RequireOpsAccess, (req, res) =>
     controller.getUploadFunnel(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ops/cancel-funnel:
+   *   get:
+   *     summary: Cancel-flow funnel by stage with pause save-rate
+   *     description: |
+   *       Returns event counts for each cancel-flow stage
+   *       (subscription_cancel_started, subscription_pause_offered,
+   *       subscription_paused, subscription_cancelled,
+   *       subscription_pause_offer_declined), plus the pause save-rate
+   *       (paused ÷ pause_offered) and offer-reach (pause_offered ÷ cancel_started).
+   *       Defaults to the last 30 days; pass ?window=7d|14d|30d|60d|90d.
+   *       Internal endpoint locked to the ops owner — returns 404 for everyone else.
+   *     tags: [Ops]
+   *     parameters:
+   *       - in: query
+   *         name: window
+   *         schema:
+   *           type: string
+   *           enum: ['7d', '14d', '30d', '60d', '90d']
+   *         description: Lookback window. Defaults to 30d.
+   *     responses:
+   *       200:
+   *         description: Cancel funnel payload
+   *       404:
+   *         description: Not the ops owner
+   */
+  router.get('/api/ops/cancel-funnel', RequireOpsAccess, (req, res) =>
+    controller.getCancelFunnel(req, res)
   );
 
   /**

--- a/src/services/ops/CancelFunnelService.test.ts
+++ b/src/services/ops/CancelFunnelService.test.ts
@@ -1,0 +1,119 @@
+import { IEventsRepository } from '../../data_layer/EventsRepository';
+import { CancelFunnelService } from './CancelFunnelService';
+
+const buildRepo = (counts: Record<string, number>): IEventsRepository => {
+  const countByName = jest.fn((name: string) =>
+    Promise.resolve(counts[name] ?? 0)
+  );
+  return { countByName } as unknown as IEventsRepository;
+};
+
+const SINCE = new Date('2026-07-01T00:00:00.000Z');
+
+describe('CancelFunnelService', () => {
+  it('maps each event name to its stage count', async () => {
+    const repo = buildRepo({
+      subscription_cancel_started: 100,
+      subscription_pause_offered: 40,
+      subscription_paused: 12,
+      subscription_cancelled: 70,
+      subscription_pause_offer_declined: 25,
+    });
+    const service = new CancelFunnelService({ eventsRepo: repo });
+
+    const result = await service.getMetrics(SINCE);
+
+    expect(result.stages).toEqual({
+      cancel_started: 100,
+      pause_offered: 40,
+      paused: 12,
+      cancelled: 70,
+      pause_offer_declined: 25,
+    });
+  });
+
+  it('computes save-rate as paused over pause_offered', async () => {
+    const repo = buildRepo({
+      subscription_cancel_started: 100,
+      subscription_pause_offered: 40,
+      subscription_paused: 12,
+      subscription_cancelled: 70,
+    });
+    const service = new CancelFunnelService({ eventsRepo: repo });
+
+    const result = await service.getMetrics(SINCE);
+
+    expect(result.save_rate_pct).toBe(30);
+  });
+
+  it('computes offer-reach as pause_offered over cancel_started', async () => {
+    const repo = buildRepo({
+      subscription_cancel_started: 200,
+      subscription_pause_offered: 50,
+      subscription_paused: 10,
+      subscription_cancelled: 100,
+    });
+    const service = new CancelFunnelService({ eventsRepo: repo });
+
+    const result = await service.getMetrics(SINCE);
+
+    expect(result.offer_reach_pct).toBe(25);
+  });
+
+  it('returns zero rates instead of dividing by zero when denominators are empty', async () => {
+    const repo = buildRepo({});
+    const service = new CancelFunnelService({ eventsRepo: repo });
+
+    const result = await service.getMetrics(SINCE);
+
+    expect(result.save_rate_pct).toBe(0);
+    expect(result.offer_reach_pct).toBe(0);
+    expect(result.stages).toEqual({
+      cancel_started: 0,
+      pause_offered: 0,
+      paused: 0,
+      cancelled: 0,
+      pause_offer_declined: 0,
+    });
+  });
+
+  it('queries every stage against the provided since date', async () => {
+    const repo = buildRepo({});
+    const service = new CancelFunnelService({ eventsRepo: repo });
+
+    await service.getMetrics(SINCE);
+
+    expect(repo.countByName).toHaveBeenCalledWith(
+      'subscription_cancel_started',
+      SINCE
+    );
+    expect(repo.countByName).toHaveBeenCalledWith(
+      'subscription_pause_offered',
+      SINCE
+    );
+    expect(repo.countByName).toHaveBeenCalledWith('subscription_paused', SINCE);
+    expect(repo.countByName).toHaveBeenCalledWith(
+      'subscription_cancelled',
+      SINCE
+    );
+    expect(repo.countByName).toHaveBeenCalledWith(
+      'subscription_pause_offer_declined',
+      SINCE
+    );
+  });
+
+  it('returns a null stages payload with an error message when the repository fails', async () => {
+    const countByName = jest
+      .fn()
+      .mockRejectedValue(new Error('connection reset'));
+    const repo = { countByName } as unknown as IEventsRepository;
+    const service = new CancelFunnelService({ eventsRepo: repo });
+
+    const result = await service.getMetrics(SINCE);
+
+    expect(result.stages).toBeNull();
+    expect(result.save_rate_pct).toBe(0);
+    expect(result.offer_reach_pct).toBe(0);
+    expect(result.error).toBe('connection reset');
+  });
+});

--- a/src/services/ops/CancelFunnelService.ts
+++ b/src/services/ops/CancelFunnelService.ts
@@ -1,0 +1,79 @@
+import type { IEventsRepository } from '../../data_layer/EventsRepository';
+
+export interface CancelFunnelStages {
+  cancel_started: number;
+  pause_offered: number;
+  paused: number;
+  cancelled: number;
+  pause_offer_declined: number;
+}
+
+export interface CancelFunnelResponse {
+  stages: CancelFunnelStages | null;
+  save_rate_pct: number;
+  offer_reach_pct: number;
+  since: string;
+  as_of: string;
+  error?: string;
+}
+
+interface CancelFunnelServiceDeps {
+  eventsRepo: IEventsRepository;
+}
+
+const rate = (numerator: number, denominator: number): number =>
+  denominator > 0 ? (numerator / denominator) * 100 : 0;
+
+export class CancelFunnelService {
+  private readonly eventsRepo: IEventsRepository;
+
+  constructor(deps: CancelFunnelServiceDeps) {
+    this.eventsRepo = deps.eventsRepo;
+  }
+
+  async getMetrics(since: Date): Promise<CancelFunnelResponse> {
+    const as_of = new Date().toISOString();
+    const sinceStr = since.toISOString();
+
+    let stages: CancelFunnelStages;
+    try {
+      const [
+        cancel_started,
+        pause_offered,
+        paused,
+        cancelled,
+        pause_offer_declined,
+      ] = await Promise.all([
+        this.eventsRepo.countByName('subscription_cancel_started', since),
+        this.eventsRepo.countByName('subscription_pause_offered', since),
+        this.eventsRepo.countByName('subscription_paused', since),
+        this.eventsRepo.countByName('subscription_cancelled', since),
+        this.eventsRepo.countByName('subscription_pause_offer_declined', since),
+      ]);
+      stages = {
+        cancel_started,
+        pause_offered,
+        paused,
+        cancelled,
+        pause_offer_declined,
+      };
+    } catch (err) {
+      return {
+        stages: null,
+        save_rate_pct: 0,
+        offer_reach_pct: 0,
+        since: sinceStr,
+        as_of,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+
+    return {
+      stages,
+      save_rate_pct: rate(stages.paused, stages.pause_offered),
+      offer_reach_pct: rate(stages.pause_offered, stages.cancel_started),
+      since: sinceStr,
+      as_of,
+    };
+  }
+}

--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -94,6 +94,9 @@ export const KNOWN_EVENTS = new Set([
   'subscription_paused',
   'subscription_pause_resumed',
   'subscription_cancelled_during_pause',
+  'subscription_cancel_started',
+  'subscription_pause_offer_declined',
+  'subscription_cancelled',
   'language_changed',
 ] as const);
 

--- a/src/usecases/ops/GetCancelFunnelUseCase.test.ts
+++ b/src/usecases/ops/GetCancelFunnelUseCase.test.ts
@@ -1,0 +1,50 @@
+import { GetCancelFunnelUseCase } from './GetCancelFunnelUseCase';
+import {
+  CancelFunnelResponse,
+  CancelFunnelService,
+} from '../../services/ops/CancelFunnelService';
+
+const buildService = () => {
+  const getMetrics = jest.fn().mockResolvedValue({
+    stages: null,
+    save_rate_pct: 0,
+    offer_reach_pct: 0,
+    since: '',
+    as_of: '',
+  } as CancelFunnelResponse);
+  return {
+    service: { getMetrics } as unknown as CancelFunnelService,
+    getMetrics,
+  };
+};
+
+const daysAgo = (call: jest.Mock): number => {
+  const since = call.mock.calls[0][0] as Date;
+  return Math.round((Date.now() - since.getTime()) / (24 * 60 * 60 * 1000));
+};
+
+describe('GetCancelFunnelUseCase', () => {
+  it('defaults to a 30-day window when none is provided', async () => {
+    const { service, getMetrics } = buildService();
+
+    await new GetCancelFunnelUseCase(service).execute(undefined);
+
+    expect(daysAgo(getMetrics)).toBe(30);
+  });
+
+  it('honours a recognised window', async () => {
+    const { service, getMetrics } = buildService();
+
+    await new GetCancelFunnelUseCase(service).execute('7d');
+
+    expect(daysAgo(getMetrics)).toBe(7);
+  });
+
+  it('falls back to the default window for an unrecognised value', async () => {
+    const { service, getMetrics } = buildService();
+
+    await new GetCancelFunnelUseCase(service).execute('nonsense');
+
+    expect(daysAgo(getMetrics)).toBe(30);
+  });
+});

--- a/src/usecases/ops/GetCancelFunnelUseCase.ts
+++ b/src/usecases/ops/GetCancelFunnelUseCase.ts
@@ -1,0 +1,28 @@
+import {
+  CancelFunnelResponse,
+  CancelFunnelService,
+} from '../../services/ops/CancelFunnelService';
+
+const SECONDS_PER_DAY = 24 * 60 * 60;
+
+const WINDOW_DAYS: Record<string, number> = {
+  '7d': 7,
+  '14d': 14,
+  '30d': 30,
+  '60d': 60,
+  '90d': 90,
+};
+
+const DEFAULT_WINDOW = '30d';
+
+export class GetCancelFunnelUseCase {
+  constructor(private readonly service: CancelFunnelService) {}
+
+  execute(window: string | undefined): Promise<CancelFunnelResponse> {
+    const key =
+      window != null && WINDOW_DAYS[window] != null ? window : DEFAULT_WINDOW;
+    const days = WINDOW_DAYS[key];
+    const since = new Date(Date.now() - days * SECONDS_PER_DAY * 1000);
+    return this.service.getMetrics(since);
+  }
+}

--- a/web/src/lib/analytics/events.ts
+++ b/web/src/lib/analytics/events.ts
@@ -70,6 +70,8 @@ export const KNOWN_EVENTS = new Set([
   'subscription_pause_offered',
   'subscription_paused',
   'subscription_cancelled_during_pause',
+  'subscription_cancel_started',
+  'subscription_pause_offer_declined',
   'language_changed',
 ] as const);
 

--- a/web/src/lib/backend/cancelSubscription.test.ts
+++ b/web/src/lib/backend/cancelSubscription.test.ts
@@ -82,7 +82,7 @@ describe('cancelSubscription', () => {
     await expect(cancelSubscription()).rejects.toThrow('Internal Server Error');
   });
 
-  it('does not send a reason or comment with the cancel request', async () => {
+  it('does not send a reason when none is provided', async () => {
     vi.mocked(api.post).mockResolvedValue(
       createMockResponse(200, { message: 'ok' })
     );
@@ -91,6 +91,19 @@ describe('cancelSubscription', () => {
 
     expect(api.post).toHaveBeenCalledWith('/api/users/cancel-subscription', {
       mode: 'period_end',
+    });
+  });
+
+  it('sends the reason alongside the mode when provided', async () => {
+    vi.mocked(api.post).mockResolvedValue(
+      createMockResponse(200, { message: 'ok' })
+    );
+
+    await cancelSubscription('period_end', "I don't use it enough");
+
+    expect(api.post).toHaveBeenCalledWith('/api/users/cancel-subscription', {
+      mode: 'period_end',
+      reason: "I don't use it enough",
     });
   });
 });

--- a/web/src/lib/backend/cancelSubscription.ts
+++ b/web/src/lib/backend/cancelSubscription.ts
@@ -6,9 +6,11 @@ const OK = 200;
 export type CancelMode = 'immediate' | 'period_end';
 
 export const cancelSubscription = async (
-  mode: CancelMode = 'period_end'
+  mode: CancelMode = 'period_end',
+  reason?: string
 ): Promise<{ message: string }> => {
-  const response = await post('/api/users/cancel-subscription', { mode });
+  const body = reason == null ? { mode } : { mode, reason };
+  const response = await post('/api/users/cancel-subscription', body);
 
   if (response?.status === UNAUTHORIZED) {
     globalThis.location.href = '/login';

--- a/web/src/pages/AccountPage/components/CancelFlow.tsx
+++ b/web/src/pages/AccountPage/components/CancelFlow.tsx
@@ -15,7 +15,7 @@ export const LIFECYCLE_REASONS: readonly CancellationReason[] = [
   "I don't use it enough",
 ];
 
-const isLifecycleReason = (reason: CancellationReason | ''): boolean =>
+export const isLifecycleReason = (reason: CancellationReason | ''): boolean =>
   LIFECYCLE_REASONS.includes(reason as CancellationReason);
 
 interface CancelFlowProps {

--- a/web/src/pages/AccountPage/components/SubscriptionManagement.tsx
+++ b/web/src/pages/AccountPage/components/SubscriptionManagement.tsx
@@ -7,7 +7,7 @@ import { usePauseSubscription } from '../hooks/usePauseSubscription';
 import { useStripeSubscriptions } from '../../../lib/hooks/useStripeSubscriptions';
 import { StripeSubscriptionSummary } from '../../../lib/backend/getSubscriptionStatus';
 import { track } from '../../../lib/analytics/track';
-import { CancelFlow } from './CancelFlow';
+import { CancelFlow, isLifecycleReason } from './CancelFlow';
 import { CancellationReason } from './CancellationFollowUp';
 import styles from '../AccountPage.module.css';
 import sharedStyles from '../../../styles/shared.module.css';
@@ -390,11 +390,31 @@ function StripeSubscriptionManagement({
     tenureDaysOf(activeSub) >= MIN_TENURE_DAYS_TO_PAUSE &&
     !hasMultipleActive;
 
+  const handleOpenCancelFlow = () => {
+    if (activeSub != null) {
+      track('subscription_cancel_started', {
+        tenure_days: tenureDaysOf(activeSub),
+        interval: isAnnual(activeSub) ? 'year' : 'month',
+      });
+    }
+    setConfirming(true);
+  };
+
   const handleCancelFromFlow = (reason: CancellationReasonInput) => {
     if (reason) {
       submitFeedback(reason, '');
     }
-    cancelUserSubscription('period_end', activeSub?.current_period_end);
+    if (pauseEligible && isLifecycleReason(reason)) {
+      track('subscription_pause_offer_declined', {
+        reason,
+        tenure_days: activeSub == null ? 0 : tenureDaysOf(activeSub),
+      });
+    }
+    cancelUserSubscription(
+      'period_end',
+      activeSub?.current_period_end,
+      reason || undefined
+    );
     setConfirming(false);
   };
 
@@ -438,7 +458,7 @@ function StripeSubscriptionManagement({
                   <button
                     type="button"
                     className={styles.secondaryButton}
-                    onClick={() => setConfirming(true)}
+                    onClick={handleOpenCancelFlow}
                     disabled={isCancelling}
                   >
                     {t('subscription.cancelSubscription')}

--- a/web/src/pages/AccountPage/hooks/useSubscriptionCancellation.test.ts
+++ b/web/src/pages/AccountPage/hooks/useSubscriptionCancellation.test.ts
@@ -39,7 +39,30 @@ describe('useSubscriptionCancellation', () => {
     });
 
     await waitFor(() => {
-      expect(cancelSubscription).toHaveBeenCalledWith('period_end');
+      expect(cancelSubscription).toHaveBeenCalledWith('period_end', undefined);
+    });
+  });
+
+  it('forwards the cancellation reason to the backend call', async () => {
+    vi.mocked(cancelSubscription).mockResolvedValue({ message: 'ok' });
+
+    const { result } = renderHook(() => useSubscriptionCancellation(), {
+      wrapper: buildWrapper(),
+    });
+
+    act(() => {
+      result.current.cancelUserSubscription(
+        'period_end',
+        1_800_000_000,
+        "I don't use it enough"
+      );
+    });
+
+    await waitFor(() => {
+      expect(cancelSubscription).toHaveBeenCalledWith(
+        'period_end',
+        "I don't use it enough"
+      );
     });
   });
 

--- a/web/src/pages/AccountPage/hooks/useSubscriptionCancellation.ts
+++ b/web/src/pages/AccountPage/hooks/useSubscriptionCancellation.ts
@@ -22,8 +22,14 @@ export function useSubscriptionCancellation(onSuccess?: () => void) {
   const [showFollowUp, setShowFollowUp] = useState<boolean>(false);
 
   const { mutate, isPending: isCancelling } = useMutation({
-    mutationFn: ({ mode }: { mode: CancelMode; periodEnd?: number | null }) =>
-      cancelSubscription(mode),
+    mutationFn: ({
+      mode,
+      reason,
+    }: {
+      mode: CancelMode;
+      periodEnd?: number | null;
+      reason?: string;
+    }) => cancelSubscription(mode, reason),
     onSuccess: (_data, variables) => {
       setCancelError('');
       setCancelSuccess(
@@ -54,11 +60,12 @@ export function useSubscriptionCancellation(onSuccess?: () => void) {
 
   const cancelUserSubscription = (
     mode: CancelMode = 'period_end',
-    periodEnd?: number | null
+    periodEnd?: number | null,
+    reason?: string
   ) => {
     setCancelError('');
     setCancelSuccess('');
-    mutate({ mode, periodEnd });
+    mutate({ mode, periodEnd, reason });
   };
 
   const submitFeedback = (reason: CancellationReason, comment: string) => {

--- a/web/src/pages/OpsPage/BusinessTab.test.tsx
+++ b/web/src/pages/OpsPage/BusinessTab.test.tsx
@@ -255,10 +255,24 @@ describe('BusinessTab', () => {
     const secondFetchPromise = new Promise<void>((r) => {
       resolveSecondFetch = r;
     });
-    let callCount = 0;
+    let businessCallCount = 0;
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockImplementation(
-      async () => {
-        const idx = callCount++;
+      async (url: string) => {
+        if (typeof url === 'string' && url.includes('cancel-funnel')) {
+          return {
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            json: async () => ({
+              stages: null,
+              save_rate_pct: 0,
+              offer_reach_pct: 0,
+              since: '',
+              as_of: '',
+            }),
+          };
+        }
+        const idx = businessCallCount++;
         if (idx === 1) {
           await secondFetchPromise;
         }

--- a/web/src/pages/OpsPage/BusinessTab.tsx
+++ b/web/src/pages/OpsPage/BusinessTab.tsx
@@ -13,6 +13,7 @@ import { buildClaudePrompt } from './buildClaudePrompt';
 import CopyForClaudeButton from './CopyForClaudeButton';
 import MetricCard, { formatNumberOrDash } from './MetricCard';
 import ActiveSubsTimeseriesChart from './charts/ActiveSubsTimeseriesChart';
+import CancelFunnelChart from './charts/CancelFunnelChart';
 import CancellationCommentsList from './charts/CancellationCommentsList';
 import CancellationReasonsChart from './charts/CancellationReasonsChart';
 import ChartPanel from './charts/ChartPanel';
@@ -26,6 +27,7 @@ import ReEngagementReasonsChart from './charts/ReEngagementReasonsChart';
 import SignupCountriesChart from './charts/SignupCountriesChart';
 import styles from './OpsPage.module.css';
 import { useBusinessMetrics } from './useBusinessMetrics';
+import { useCancelFunnel } from './useCancelFunnel';
 
 const buildMrrFootnote = (
   asOf: string | null,
@@ -41,6 +43,8 @@ const buildMrrFootnote = (
 
 export default function BusinessTab() {
   const { data, error, isLoading, isFetching } = useBusinessMetrics();
+  const { data: cancelFunnel, isLoading: cancelFunnelLoading } =
+    useCancelFunnel();
   const [lastSnapshot, setLastSnapshot] =
     useState<BusinessMetricsResponse | null>(null);
 
@@ -235,6 +239,20 @@ export default function BusinessTab() {
           </p>
         </header>
         <div className={styles.grid}>
+          <ChartPanel
+            title="Cancel-flow funnel, last 30 days"
+            subtitle="How many cancels the pause offer saves"
+            isLoading={cancelFunnelLoading && cancelFunnel == null}
+            isEmpty={
+              cancelFunnel?.stages == null ||
+              cancelFunnel.stages.cancel_started === 0
+            }
+            emptyText="No cancel-flow activity in this window."
+            autoHeight
+          >
+            <CancelFunnelChart data={cancelFunnel ?? null} />
+          </ChartPanel>
+
           <ChartPanel
             title="Why users cancel, last 90 days"
             isLoading={showInitialSkeleton}

--- a/web/src/pages/OpsPage/OpsPage.module.css
+++ b/web/src/pages/OpsPage/OpsPage.module.css
@@ -1148,3 +1148,66 @@
   font-weight: var(--font-semibold);
   color: var(--color-text-primary);
 }
+
+/* ── Cancel funnel ──────────────────────────────────────────────── */
+
+.cancelFunnelHeadline {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  margin: 0 0 0.375rem;
+}
+
+.cancelFunnelHeadlineNum {
+  font-size: var(--text-4xl, 2.5rem);
+  color: var(--color-primary);
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--font-semibold);
+  line-height: 1.1;
+}
+
+.cancelFunnelHeadlineRest {
+  font-size: var(--text-base);
+  color: var(--color-text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.cancelFunnelReach {
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  font-variant-numeric: tabular-nums;
+  margin: 0 0 1rem;
+}
+
+.cancelStageList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.cancelStageRow {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.cancelStageLabel {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.cancelStageValue {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  text-align: right;
+}

--- a/web/src/pages/OpsPage/cancelFunnelTypes.ts
+++ b/web/src/pages/OpsPage/cancelFunnelTypes.ts
@@ -1,0 +1,16 @@
+export interface CancelFunnelStages {
+  cancel_started: number;
+  pause_offered: number;
+  paused: number;
+  cancelled: number;
+  pause_offer_declined: number;
+}
+
+export interface CancelFunnelResponse {
+  stages: CancelFunnelStages | null;
+  save_rate_pct: number;
+  offer_reach_pct: number;
+  since: string;
+  as_of: string;
+  error?: string;
+}

--- a/web/src/pages/OpsPage/charts/CancelFunnelChart.test.tsx
+++ b/web/src/pages/OpsPage/charts/CancelFunnelChart.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import CancelFunnelChart from './CancelFunnelChart';
+import { CancelFunnelResponse } from '../cancelFunnelTypes';
+
+const buildData = (
+  overrides?: Partial<CancelFunnelResponse>
+): CancelFunnelResponse => ({
+  stages: {
+    cancel_started: 100,
+    pause_offered: 40,
+    paused: 12,
+    cancelled: 70,
+    pause_offer_declined: 25,
+  },
+  save_rate_pct: 30,
+  offer_reach_pct: 40,
+  since: '2026-06-18T00:00:00.000Z',
+  as_of: '2026-07-18T00:00:00.000Z',
+  ...overrides,
+});
+
+describe('CancelFunnelChart', () => {
+  it('renders the saved headline with the named denominator and rate', () => {
+    render(<CancelFunnelChart data={buildData()} />);
+
+    const headline = screen.getByText('saved').closest('p');
+    expect(headline).toHaveTextContent('saved 12 of 40 offered — 30%');
+  });
+
+  it('shows offer-reach as the share of cancels that saw the offer', () => {
+    render(<CancelFunnelChart data={buildData()} />);
+
+    expect(
+      screen.getByText('40% of cancels saw the pause offer')
+    ).toBeInTheDocument();
+  });
+
+  it('renders each stage count', () => {
+    render(<CancelFunnelChart data={buildData()} />);
+
+    expect(screen.getByText('cancel started')).toBeInTheDocument();
+    expect(screen.getByText('100')).toBeInTheDocument();
+    expect(screen.getByText('pause offer declined')).toBeInTheDocument();
+    expect(screen.getByText('25')).toBeInTheDocument();
+  });
+
+  it('rounds fractional rates to one decimal place', () => {
+    render(
+      <CancelFunnelChart
+        data={buildData({ save_rate_pct: 33.333, offer_reach_pct: 12.345 })}
+      />
+    );
+
+    expect(screen.getByText('of 40 offered — 33.3%')).toBeInTheDocument();
+    expect(
+      screen.getByText('12.3% of cancels saw the pause offer')
+    ).toBeInTheDocument();
+  });
+
+  it('shows an empty message when there are no stages', () => {
+    render(<CancelFunnelChart data={{ ...buildData(), stages: null }} />);
+
+    expect(
+      screen.getByText('No cancellations recorded yet.')
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/OpsPage/charts/CancelFunnelChart.tsx
+++ b/web/src/pages/OpsPage/charts/CancelFunnelChart.tsx
@@ -1,0 +1,54 @@
+import { CancelFunnelResponse } from '../cancelFunnelTypes';
+import styles from '../OpsPage.module.css';
+
+interface CancelFunnelChartProps {
+  data: CancelFunnelResponse | null;
+}
+
+const STAGE_LABELS: ReadonlyArray<{
+  key: keyof NonNullable<CancelFunnelResponse['stages']>;
+  label: string;
+}> = [
+  { key: 'cancel_started', label: 'cancel started' },
+  { key: 'pause_offered', label: 'pause offered' },
+  { key: 'paused', label: 'paused' },
+  { key: 'cancelled', label: 'cancelled' },
+  { key: 'pause_offer_declined', label: 'pause offer declined' },
+];
+
+const roundPct = (value: number): number => Math.round(value * 10) / 10;
+
+export default function CancelFunnelChart({
+  data,
+}: Readonly<CancelFunnelChartProps>) {
+  if (data == null || data.stages == null) {
+    return (
+      <div className={styles.chartEmpty}>No cancellations recorded yet.</div>
+    );
+  }
+
+  const { stages } = data;
+
+  return (
+    <div>
+      <p className={styles.cancelFunnelHeadline}>
+        <span className={styles.cancelFunnelHeadlineRest}>saved</span>{' '}
+        <span className={styles.cancelFunnelHeadlineNum}>{stages.paused}</span>{' '}
+        <span className={styles.cancelFunnelHeadlineRest}>
+          of {stages.pause_offered} offered — {roundPct(data.save_rate_pct)}%
+        </span>
+      </p>
+      <p className={styles.cancelFunnelReach}>
+        {roundPct(data.offer_reach_pct)}% of cancels saw the pause offer
+      </p>
+      <ul className={styles.cancelStageList}>
+        {STAGE_LABELS.map(({ key, label }) => (
+          <li key={key} className={styles.cancelStageRow}>
+            <span className={styles.cancelStageLabel}>{label}</span>
+            <span className={styles.cancelStageValue}>{stages[key]}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/web/src/pages/OpsPage/useCancelFunnel.ts
+++ b/web/src/pages/OpsPage/useCancelFunnel.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { CancelFunnelResponse } from './cancelFunnelTypes';
+
+const REFRESH_MS = 60_000;
+
+const fetchCancelFunnel = async (): Promise<CancelFunnelResponse> => {
+  const response = await fetch('/api/ops/cancel-funnel?window=30d', {
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`);
+  }
+  return response.json();
+};
+
+export const useCancelFunnel = () => {
+  return useQuery<CancelFunnelResponse, Error>({
+    queryKey: ['ops-cancel-funnel'],
+    queryFn: fetchCancelFunnel,
+    refetchInterval: REFRESH_MS,
+    refetchOnWindowFocus: true,
+    refetchIntervalInBackground: false,
+  });
+};


### PR DESCRIPTION
## What
Instruments the subscription cancel flow end to end so we can measure how many cancels the pause offer saves. Adds three analytics events (`subscription_cancel_started`, `subscription_pause_offer_declined` on the client; `subscription_cancelled` authoritatively on the server), threads the cancel reason into the cancel request, and exposes a `/api/ops/cancel-funnel` endpoint rendered as a Swiss-Panel funnel chart on the ops BusinessTab.

## Why
The cancel flow already fired `subscription_pause_offered` and `subscription_paused`, but there was no authoritative "cancel happened" event and no view of the pause save-rate. 79% of churn is lifecycle and this surface owns the retention offer — without the funnel we can't see whether the pause offer works or size PR 2's data-driven retention offer.

## How
- **Events:** added the three names to the server registry (`src/types/AnalyticsEvents.ts`) and the two client-fired ones to the web registry (`web/src/lib/analytics/events.ts`).
- **Server (authoritative):** `UsersControllers.cancelSubscription` / `cancelSubscriptionById` fire `track('subscription_cancelled', { userId, props: { reason, cancel_type } })` once per request, after the `processedCount > 0` guard, before the response. `cancel_type` = the requested mode; `reason` = `req.body.reason` (null when unselected). Deliberately **not** fired in the `customer.subscription.deleted` webhook to avoid double-counting.
- **Reason threading:** `cancelSubscription(mode, reason)` adds `reason` to the POST body only when present; `useSubscriptionCancellation` forwards it; `handleCancelFromFlow` passes the survey reason.
- **Client fires:** `subscription_cancel_started` on the cancel-open click (`{ tenure_days, interval }`); `subscription_pause_offer_declined` when a pause-eligible lifecycle reason is chosen but the user cancels anyway (`{ reason, tenure_days }`).
- **Ops funnel:** new `CancelFunnelService` (5 `countByName` calls, save-rate = paused ÷ pause_offered, offer-reach = pause_offered ÷ cancel_started, both divide-by-zero guarded) → `GetCancelFunnelUseCase` → `/api/ops/cancel-funnel` → `CancelFunnelChart` on BusinessTab.
- `cancelUserSubscriptions`' `Promise<number>` return is unchanged, so no controller/mocks break.

## Measuring success
After deploy, `/api/ops/cancel-funnel?window=30d` returns the five stage counts plus `save_rate_pct` and `offer_reach_pct`; the BusinessTab "Cancel-flow funnel" panel reads "saved N of M offered — X%". Confirm events land by querying the `events` table for `name in ('subscription_cancel_started','subscription_pause_offer_declined','subscription_cancelled')` after the first prod cancels.

## Testing
- Unit tests added:
  - `UsersControllers.test.ts` — `subscription_cancelled` fires once with reason + `cancel_type` for both cancel endpoints; not fired on 422/401/not-owned.
  - `CancelFunnelService.test.ts` — stage mapping, save-rate, offer-reach, divide-by-zero guard, repository-failure path.
  - `GetCancelFunnelUseCase.test.ts` — window defaulting.
  - `OpsController.test.ts` — `getCancelFunnel` passes window, 500 when unconfigured / on throw.
  - `cancelSubscription.test.ts` + `useSubscriptionCancellation.test.ts` — reason threading.
  - `CancelFunnelChart.test.tsx` — headline, offer-reach, stage counts, rounding, empty state.
- Full server jest on touched suites (169) and full web vitest (2603) green; `tsc -p .` (compiles tests) and `pnpm format:check` (tree-wide) clean.

## Browser check
Browser check: not applicable — the cancel-flow changes are analytics-only (track() calls, no rendered change); the only new rendered surface is the internal ops BusinessTab funnel chart, covered by a Vitest component test.

## Security
/security-review pending (payments-adjacent cancel path) — no Stripe/charging logic changed, only a track() added after the existing cancel.

## Changelog
No changelog entry — internal analytics + ops-only chart, no user-visible behavior change.

## Risks
- Double-counting `subscription_cancelled`: mitigated by firing only on the intent path, never on the webhook.
- The funnel adds a second fetch to BusinessTab (`/api/ops/cancel-funnel`); it fails independently and shows an empty panel, never blocking the business metrics.
- Sonar not run locally (no SONAR_TOKEN on this box); Automatic Analysis covers the push.

## Goal alignment
Measurement infrastructure for the churn lever (18.2%/mo on 719 active subs); unblocks PR 2's data-driven retention offer. No revenue metric moves this PR.
