### PR TITLE
fix: resize chat photo attachments so phone photos aren't rejected

### DIFF
--- a/web/src/components/ChatPanel/ChatPanel.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.tsx
@@ -9,6 +9,7 @@ import {
   suggestDeckName,
 } from '../../lib/chat/templates';
 import { useUserLocals } from '../../lib/hooks/useUserLocals';
+import { compressImageForUpload } from '../../lib/image/compressImageForUpload';
 import AssistantMarkdown from '../../pages/Chat/AssistantMarkdown';
 import CardPreview from '../../pages/Chat/CardPreview';
 import ConsentModal from '../ConsentModal/ConsentModal';
@@ -717,10 +718,10 @@ export default function ChatPanel({
     !isLoading &&
     !limitReached;
 
-  function addFiles(files: File[]) {
+  async function addFiles(incoming: File[]) {
     setNetworkError(null);
 
-    const disallowed = files.filter((f) => !ALLOWED_TYPES.has(f.type));
+    const disallowed = incoming.filter((f) => !ALLOWED_TYPES.has(f.type));
     if (disallowed.length > 0) {
       if (disallowed.length === 1) {
         setNetworkError(
@@ -733,6 +734,8 @@ export default function ChatPanel({
       }
       return;
     }
+
+    const files = await Promise.all(incoming.map(compressImageForUpload));
 
     const oversized = files.find((f) => f.size > MAX_FILE_BYTES);
     if (oversized != null) {
@@ -1109,7 +1112,7 @@ export default function ChatPanel({
       setIsDragging(false);
       const files = Array.from(e.dataTransfer.files);
       if (files.length > 0) {
-        addFiles(files);
+        void addFiles(files);
       }
     },
     [chips] // eslint-disable-line react-hooks/exhaustive-deps

--- a/web/src/lib/image/compressImageForUpload.test.ts
+++ b/web/src/lib/image/compressImageForUpload.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import {
+  compressImageForUpload,
+  compressedName,
+  scaledDimensions,
+  shouldCompressType,
+} from './compressImageForUpload';
+
+describe('shouldCompressType', () => {
+  it('compresses still images', () => {
+    expect(shouldCompressType('image/png')).toBe(true);
+    expect(shouldCompressType('image/jpeg')).toBe(true);
+    expect(shouldCompressType('image/webp')).toBe(true);
+  });
+
+  it('leaves gifs alone so animation survives', () => {
+    expect(shouldCompressType('image/gif')).toBe(false);
+  });
+
+  it('leaves non-images alone', () => {
+    expect(shouldCompressType('application/pdf')).toBe(false);
+    expect(shouldCompressType('')).toBe(false);
+  });
+});
+
+describe('compressedName', () => {
+  it('swaps the extension for .jpg', () => {
+    expect(compressedName('tempImage6NByyR.png')).toBe('tempImage6NByyR.jpg');
+    expect(compressedName('IMG_0495.HEIC')).toBe('IMG_0495.jpg');
+  });
+
+  it('falls back to image.jpg for an empty base name', () => {
+    expect(compressedName('.png')).toBe('image.jpg');
+  });
+});
+
+describe('scaledDimensions', () => {
+  it('keeps images within the cap unchanged', () => {
+    expect(scaledDimensions(1000, 800)).toEqual({ width: 1000, height: 800 });
+  });
+
+  it('scales the long edge down to the cap', () => {
+    // 4032x3024 (12 MP iPhone photo) → long edge 1568.
+    expect(scaledDimensions(4032, 3024)).toEqual({ width: 1568, height: 1176 });
+  });
+});
+
+describe('compressImageForUpload', () => {
+  it('returns a PDF untouched without touching the canvas', async () => {
+    const pdf = new File([new Uint8Array([1, 2, 3])], 'notes.pdf', {
+      type: 'application/pdf',
+    });
+    await expect(compressImageForUpload(pdf)).resolves.toBe(pdf);
+  });
+
+  it('returns a gif untouched', async () => {
+    const gif = new File([new Uint8Array([1])], 'anim.gif', {
+      type: 'image/gif',
+    });
+    await expect(compressImageForUpload(gif)).resolves.toBe(gif);
+  });
+});

--- a/web/src/lib/image/compressImageForUpload.ts
+++ b/web/src/lib/image/compressImageForUpload.ts
@@ -1,0 +1,75 @@
+// Chat and other multipart uploads gate on raw file size (10 MB per file). A
+// phone photo attached on iOS arrives as a lossless PNG (Safari converts HEIC
+// at pick time) that can be ~10 MB for a 12 MP image, tripping the gate even
+// though the picture itself is small. Downscale + re-encode to JPEG before the
+// gate so a normal photo attaches instead of being rejected. PDFs, GIFs
+// (animation), and anything that fails to decode pass through untouched.
+
+const MAX_EDGE = 1568;
+const QUALITY = 0.85;
+
+export function shouldCompressType(type: string): boolean {
+  return type.startsWith('image/') && type !== 'image/gif';
+}
+
+export function compressedName(name: string): string {
+  const base = name.replace(/\.[^.]+$/, '') || 'image';
+  return `${base}.jpg`;
+}
+
+export function scaledDimensions(
+  width: number,
+  height: number
+): { width: number; height: number } {
+  const longest = Math.max(width, height);
+  const scale = longest > MAX_EDGE ? MAX_EDGE / longest : 1;
+  return {
+    width: Math.max(1, Math.round(width * scale)),
+    height: Math.max(1, Math.round(height * scale)),
+  };
+}
+
+function loadImage(file: File): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(img);
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error('Could not read the image'));
+    };
+    img.src = url;
+  });
+}
+
+export async function compressImageForUpload(file: File): Promise<File> {
+  if (!shouldCompressType(file.type)) return file;
+
+  let img: HTMLImageElement;
+  try {
+    img = await loadImage(file);
+  } catch {
+    return file;
+  }
+
+  const { width, height } = scaledDimensions(
+    img.naturalWidth,
+    img.naturalHeight
+  );
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  if (ctx == null) return file;
+  ctx.drawImage(img, 0, 0, width, height);
+
+  const blob = await new Promise<Blob | null>((resolve) =>
+    canvas.toBlob(resolve, 'image/jpeg', QUALITY)
+  );
+  if (blob == null || blob.size >= file.size) return file;
+
+  return new File([blob], compressedName(file.name), { type: 'image/jpeg' });
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-18-chat-photo-attach.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-18-chat-photo-attach.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-18-chat-photo-attach",
+  "date": "2026-07-18",
+  "type": "fix",
+  "title": "Phone photos attach in chat — large images are resized instead of rejected"
+}


### PR DESCRIPTION
## What
Chat photo attachments are now downscaled + re-encoded to JPEG before the 10 MB per-file gate, so a normal phone photo attaches instead of being rejected.

## Why
A user picked a 1.2 MB iPhone HEIC to attach in chat and got "…ist 10.6 MB. Das Limit pro Datei liegt bei 10 MB." iOS/Safari converts a picked HEIC to a **lossless PNG** (`tempImage####.png`) at the OS level — ~10.6 MB for a 12 MP photo — before the web app sees it. The chat composer's `addFiles` gate rejected the raw file with **no downscaling**, unlike the photo-to-deck page which already re-encodes to JPEG. So ordinary phone photos couldn't be attached.

## How
- New `web/src/lib/image/compressImageForUpload.ts`: downscale to 1568px long edge + `toBlob('image/jpeg', 0.85)`. A 10.6 MB PNG becomes ~1.9 MB. Mirrors the existing `prepareImageForVision` canvas approach; no new dependency.
- `ChatPanel.addFiles` runs each attachment through it **before** the size/total gates. PDFs, GIFs (animation), and undecodable files pass through untouched; the compressed version is used only when it's actually smaller.
- The format allow-list check still runs first on the original type.

## Measuring success
Fewer "over the 10 MB limit" rejections on chat image attachments; phone photos attach on the first try. No metric wired (bug fix).

## Testing
- `compressImageForUpload.test.ts`: type gating (still images vs gif/pdf), `.jpg` renaming, 4032×3024 → 1568×1176 scaling, PDF/GIF pass-through.
- Full ChatPanel Vitest suite green with the now-async `addFiles`. Web `tsc` clean, tree-wide `oxfmt --check` clean, `pnpm lint` (only pre-existing warnings in unrelated files).
- The canvas encode path itself isn't unit-testable under jsdom (same limitation as `prepareImageForVision.test.ts`) — see the browser check below.

## Risks
Low. Image-only; non-images and undecodable files fall through to the original file. Worst case a decode failure returns the original and the existing gate behaves exactly as before.

## Goal alignment
Removes first-conversion friction on a core surface (chat) — a phone photo of notes is the fastest path from studying to cards, and it was silently blocked.

No security-review needed (no auth/payments/external-API change).

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Merge authorized by Alexander; attach verified on his side. Logic covered by the compressImageForUpload + ChatPanel unit suites.

