### PR TITLE
docs: route native/ASO/store work to the 2anki.app repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,15 @@
 
 Express/TypeScript server that converts Notion pages and uploaded files (HTML, markdown, xlsx, zip) into Anki `.apkg` decks. Frontend is the sibling workspace under `web/`.
 
+## Repos — route work to the right one
+
+This checkout (`2anki/server`) is the backend + web app. The **native iOS app is a separate repo**: `Laer-Smart/2anki.app` (Swift/Xcode project at `/Users/a/src/github.com/Laer-Smart/2anki`, with its own `.claude/agents/` trio and an `AppStore/` metadata dir). Match the checkout to the surface:
+
+- **Native app / ASO / App Store listing / store metadata / StoreKit / Swift** → `2anki.app` repo and **its** agents (they have the app, the current listing, the screenshots, the feature set in front of them). Do NOT draft ASO or store copy from this server checkout — it's context-poor and the metadata PR lands over there.
+- **Backend, web app, conversion pipeline, Notion/Stripe/Claude integrations, funnel instrumentation** → here in `2anki/server`.
+
+A strategy issue may be *filed* in `2anki/server` for tracking (e.g. #3582 ASO, #3688 native) while the *work* executes in `2anki.app` — create/mirror the actionable issue in `2anki.app` and cross-link (`2anki/server#NNNN`). Open app issues with `gh issue create --repo Laer-Smart/2anki.app`.
+
 ## Goal
 
 Mission: give people the simplest, fastest way to turn what they're studying into beautiful Anki flashcards. Drop something in, get a clean deck back.


### PR DESCRIPTION
Adds a **Repos — route work to the right one** section to CLAUDE.md.

## Why
The native iOS app is a separate repo — `Laer-Smart/2anki.app` (Swift/Xcode, its own `.claude/agents/` trio, an `AppStore/` metadata dir). ASO / store-listing work was about to be drafted from this server checkout, which has none of the app context (current listing, screenshots, features). The rule now says: native / ASO / StoreKit / Swift → `2anki.app` and its agents; backend / web / pipeline → here. Strategy issues filed here for tracking get mirrored into the app repo and cross-linked.

## Companion issues
Created in the app repo for the current native work:
- Laer-Smart/2anki.app#41 — ASO pass (mirrors 2anki/server#3582)
- Laer-Smart/2anki.app#42 — P6 native: instrument then ASO (mirrors 2anki/server#3688)

No changelog — internal docs, no user-visible change. No `web/src/` files touched.