### PR TITLE
fix: translate docs sidebar for German + tighten language picker spacing

### DIFF
--- a/web/src/components/LanguagePicker/LanguagePicker.module.css
+++ b/web/src/components/LanguagePicker/LanguagePicker.module.css
@@ -18,14 +18,21 @@
 }
 
 .selectWrap {
-  position: relative;
   display: inline-flex;
   align-items: center;
+  gap: 8px;
+  padding: var(--space-2) var(--space-4);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-full);
+  background: var(--color-bg-tertiary);
+  transition: background var(--transition-fast);
+}
+
+.selectWrap:hover {
+  background: var(--color-bg-primary);
 }
 
 .globe {
-  position: absolute;
-  left: 10px;
   font-size: 14px;
   line-height: 1;
   pointer-events: none;
@@ -33,24 +40,24 @@
 
 .select {
   appearance: none;
-  padding: var(--space-2) var(--space-4) var(--space-2) 32px;
-  border: 1px solid var(--color-border-light);
-  border-radius: var(--radius-full);
-  background: var(--color-bg-tertiary);
+  padding: 0;
+  border: none;
+  background: transparent;
   color: var(--color-text-primary);
   font-size: var(--text-sm);
+  line-height: 1.2;
   cursor: pointer;
-  transition:
-    background var(--transition-fast),
-    color var(--transition-fast);
-}
-
-.select:hover {
-  color: var(--color-text-primary);
-  background: var(--color-bg-primary);
 }
 
 .compact {
+  gap: 6px;
+  padding: 6px var(--space-3);
+}
+
+.compact .globe {
+  font-size: 13px;
+}
+
+.compact .select {
   font-size: var(--text-xs);
-  padding: 6px var(--space-3) 6px 28px;
 }

--- a/web/src/components/LanguagePicker/LanguagePicker.tsx
+++ b/web/src/components/LanguagePicker/LanguagePicker.tsx
@@ -68,12 +68,12 @@ export function LanguagePicker({ variant = 'compact' }: LanguagePickerProps) {
   }
 
   return (
-    <div className={styles.selectWrap}>
+    <div className={`${styles.selectWrap} ${styles.compact}`}>
       <span className={styles.globe} aria-hidden="true">
         🌐
       </span>
       <select
-        className={`${styles.select} ${styles.compact}`}
+        className={styles.select}
         value={current}
         onChange={handleChange}
         aria-label={t('language.picker')}

--- a/web/src/pages/DocsPage/DocsSidebar.tsx
+++ b/web/src/pages/DocsPage/DocsSidebar.tsx
@@ -1,5 +1,7 @@
 import { NavLink } from 'react-router-dom';
-import { findGroupForSlug, sidebar } from './sidebar';
+import { useTranslation } from 'react-i18next';
+import { findGroupForSlug, localizeGroupLabel, sidebar } from './sidebar';
+import { loadDoc } from './loader';
 import { DocsSearchTrigger } from './DocsSearchTrigger';
 import styles from './DocsPage.module.css';
 
@@ -16,9 +18,15 @@ export function DocsSidebar({
   isDrawer,
   activeSlug,
 }: Readonly<DocsSidebarProps>) {
+  const { i18n } = useTranslation();
+  const language = i18n.resolvedLanguage ?? i18n.language;
   const activeGroupLabel = activeSlug
     ? findGroupForSlug(activeSlug)?.label
     : undefined;
+
+  const itemLabel = (slug: string, fallback: string) =>
+    (language === 'de' ? loadDoc(slug, 'de')?.frontmatter.title : undefined) ??
+    fallback;
 
   return (
     <nav
@@ -30,7 +38,9 @@ export function DocsSidebar({
         const isActiveGroup = group.label === activeGroupLabel;
         return (
           <div key={group.label} className={styles.sidebarGroup}>
-            <div className={styles.sidebarGroupLabel}>{group.label}</div>
+            <div className={styles.sidebarGroupLabel}>
+              {localizeGroupLabel(group.label, language)}
+            </div>
             <ul
               className={`${styles.sidebarList} ${
                 isActiveGroup ? styles.sidebarListActive : ''
@@ -45,7 +55,7 @@ export function DocsSidebar({
                       target="_blank"
                       rel="noopener noreferrer"
                     >
-                      {item.label}
+                      {itemLabel(item.slug, item.label)}
                     </a>
                   ) : (
                     <NavLink
@@ -58,7 +68,7 @@ export function DocsSidebar({
                       onClick={onNavigate}
                       end
                     >
-                      {item.label}
+                      {itemLabel(item.slug, item.label)}
                     </NavLink>
                   )}
                 </li>

--- a/web/src/pages/DocsPage/sidebar.test.ts
+++ b/web/src/pages/DocsPage/sidebar.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { findAdjacent, findGroupForSlug, redirects, sidebar } from './sidebar';
+import {
+  findAdjacent,
+  findGroupForSlug,
+  localizeGroupLabel,
+  redirects,
+  sidebar,
+} from './sidebar';
 
 describe('sidebar', () => {
   it('every internal item maps to a unique slug', () => {
@@ -76,5 +82,21 @@ describe('redirects', () => {
     expect(redirects['troubleshooting/limits']).toBe('help/limits');
     expect(redirects['advanced/strategy']).toBeDefined();
     expect(redirects['misc/privacy-policy']).toBe('reference/privacy');
+  });
+
+  it('translates every group header for German', () => {
+    for (const group of sidebar) {
+      expect(localizeGroupLabel(group.label, 'de')).not.toBe('');
+    }
+    expect(localizeGroupLabel('Start here', 'de')).toBe("Los geht's");
+    expect(localizeGroupLabel('Make better cards', 'de')).toBe(
+      'Bessere Karten erstellen'
+    );
+  });
+
+  it('leaves group headers in English for English and unknown locales', () => {
+    expect(localizeGroupLabel('Start here', 'en')).toBe('Start here');
+    expect(localizeGroupLabel('Start here', undefined)).toBe('Start here');
+    expect(localizeGroupLabel('Reference', 'fr')).toBe('Reference');
   });
 });

--- a/web/src/pages/DocsPage/sidebar.ts
+++ b/web/src/pages/DocsPage/sidebar.ts
@@ -148,3 +148,21 @@ export function findGroupForSlug(slug: string): SidebarGroup | null {
     null
   );
 }
+
+// Group headers aren't per-page docs, so the German mirror can't carry them.
+// Translate them here; item labels localize from each page's frontmatter title.
+const groupLabelDe: Record<string, string> = {
+  'Start here': "Los geht's",
+  'Make better cards': 'Bessere Karten erstellen',
+  'Sync with Notion': 'Mit Notion synchronisieren',
+  'When something breaks': 'Wenn etwas nicht klappt',
+  Reference: 'Referenz',
+  Links: 'Links',
+};
+
+export function localizeGroupLabel(label: string, language?: string): string {
+  if (language === 'de' && Object.hasOwn(groupLabelDe, label)) {
+    return groupLabelDe[label];
+  }
+  return label;
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-18-german-docs-sidebar.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-18-german-docs-sidebar.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-18-german-docs-sidebar",
+  "date": "2026-07-18",
+  "type": "fix",
+  "title": "German documentation shows translated titles in the sidebar, not just the page"
+}


### PR DESCRIPTION
## What
Two locale UI fixes you reported together.

1. **German docs sidebar** — `/documentation` showed English nav titles ("What is 2anki?") and section headers ("START HERE") while the page body was German. Now item labels resolve from each German page's frontmatter `title` (e.g. "Was ist 2anki?", "Foto zu Deck") and the six group headers are translated, so the whole sidebar localizes with the content.
2. **Language picker spacing** — the pill faked its globe-to-text gap with an absolutely-positioned globe over the select's left padding, which drifted with emoji glyph width. Replaced with a flex row + a real `gap`, so spacing is deterministic and matches the sidebar's icon-text rhythm.

## Why
German users saw a half-translated docs page — content in German, navigation in English. The picker gap looked uneven.

## How
- `DocsSidebar`: reads the UI language; item labels via `loadDoc(slug, 'de').frontmatter.title`, group headers via a new `localizeGroupLabel` map in `sidebar.ts`. Only German is mirrored, so other locales fall back to the English labels (matching their English docs) — no behavior change for them.
- `LanguagePicker.module.css`: pill is now `inline-flex` with `gap`; the globe is a normal flex child, not an absolute overlay; the `<select>` is transparent/borderless inside the pill.

## Testing
- `sidebar.test.ts`: German group-header translations + English/unknown-locale fallthrough.
- Docs + LanguagePicker suites green (65 tests); web `tsc` clean; tree-wide `oxfmt --check` clean.

## Risks
Low. German-only localization with English fallback; the picker change is CSS-only layout.

## Goal alignment
Removes friction/inconsistency for German users (the largest non-English locale, ~4.5%) on the docs surface. No metric wired (polish/i18n fix).

No changelog for the picker (spacing polish a user wouldn't look up); one entry for the docs-sidebar translation.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Runtime-visible but I couldn't switch locale + load /documentation in this environment. Verify before merge: set language to Deutsch, open /documentation (sidebar titles + section headers should read German), and check the language-picker pill spacing. Logic covered by the sidebar + docs/picker unit suites.
