### PR TITLE
chore: wire SonarQube MCP server and secret-scan hooks

### DIFF
--- a/.claude/hooks/sonar-secrets/build-scripts/pretool-secrets.sh
+++ b/.claude/hooks/sonar-secrets/build-scripts/pretool-secrets.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if ! command -v sonar &> /dev/null; then
+  exit 0
+fi
+sonar hook claude-pre-tool-use

--- a/.claude/hooks/sonar-secrets/build-scripts/prompt-secrets.sh
+++ b/.claude/hooks/sonar-secrets/build-scripts/prompt-secrets.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if ! command -v sonar &> /dev/null; then
+  exit 0
+fi
+sonar hook claude-prompt-submit

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,15 +31,12 @@
       "Bash(git fetch --prune *)",
       "Bash(git worktree remove *)",
       "Bash(git worktree prune)",
-
       "Write(src/**/*.test.ts)",
       "Write(web/src/**/*.test.ts)",
       "Write(web/src/**/*.test.tsx)",
-
       "Edit(src/**)",
       "Edit(web/src/**)",
       "Edit(web/public/**)",
-
       "Write(Documentation/specs/*.md)",
       "Edit(Documentation/specs/*.md)",
       "Write(Documentation/ankify/*.md)",
@@ -61,6 +58,16 @@
           {
             "type": "command",
             "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/caveman-run.sh $CLAUDE_PROJECT_DIR/.claude/caveman/hooks/caveman-mode-tracker.js"
+          }
+        ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/sonar-secrets/build-scripts/prompt-secrets.sh",
+            "timeout": 60
           }
         ]
       }
@@ -127,6 +134,16 @@
           {
             "type": "command",
             "command": "python3 $CLAUDE_PROJECT_DIR/.claude/hooks/pre-write-secret-scan.py"
+          }
+        ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/sonar-secrets/build-scripts/pretool-secrets.sh",
+            "timeout": 60
           }
         ]
       }

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,15 +3,30 @@
     "ide": {
       "type": "stdio",
       "command": "claude",
-      "args": ["mcp", "serve-ide"]
+      "args": [
+        "mcp",
+        "serve-ide"
+      ]
     },
     "github": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-github"
+      ],
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
       }
+    },
+    "sonarqube": {
+      "command": "sonar",
+      "args": [
+        "run",
+        "mcp",
+        "--project",
+        "2anki_server"
+      ]
     }
   }
 }


### PR DESCRIPTION
## What
Adds the `sonarqube` MCP server to `.mcp.json` and registers the sonar-secrets pre-tool and prompt-submit hooks in `.claude/settings.json`. Generated by `sonar integrate claude` (SonarCloud org `2anki`, project `2anki_server`).

## Why
Moves SonarCloud's rule engine + secret scanning from per-machine setup to repo-standard, so every contributor gets in-loop Sonar findings and hardcoded-secret blocking instead of relying on the PR-gate Automatic Analysis alone. The repo already enables the `sonarqube` plugin per-project, so this is consistent with existing config.

## How
- `.mcp.json`: new `sonarqube` server → `sonar run mcp --project 2anki_server` (no secret; token lives in the OS keychain).
- `.claude/settings.json`: UserPromptSubmit + PreToolUse(Read) hooks calling the sonar-secrets scripts.
- `.claude/hooks/sonar-secrets/build-scripts/*.sh`: thin wrappers that **no-op when the `sonar` CLI is absent**, so contributors without it are unaffected.

## Testing
Hook scripts are trivial (exit 0 if no `sonar` on PATH, else delegate to `sonar hook`). No app code touched.

## Risks
None to runtime — tooling/config only, no `src/` or `web/src/` changes.

## Goal alignment
None — internal developer tooling, no user-facing or funnel/revenue impact.

Browser check: not applicable — no web/src changes, tooling config only.