### PR TITLE
fix: stop zip uploads from silently dropping cards

### DIFF
--- a/src/usecases/uploads/conversionFailureWarning.test.ts
+++ b/src/usecases/uploads/conversionFailureWarning.test.ts
@@ -1,0 +1,25 @@
+import { buildConversionFailureWarning } from './conversionFailureWarning';
+
+describe('buildConversionFailureWarning', () => {
+  it('returns null when no files failed', () => {
+    expect(buildConversionFailureWarning([])).toBeNull();
+  });
+
+  it('names the single failed file and points at the fix', () => {
+    expect(buildConversionFailureWarning(['essay.docx'])).toBe(
+      'essay.docx could not be converted and was skipped. The rest of your upload converted — try uploading that file on its own.'
+    );
+  });
+
+  it('lists every failed file when several fail', () => {
+    expect(buildConversionFailureWarning(['essay.docx', 'broken.doc'])).toBe(
+      '2 files could not be converted and were skipped: essay.docx, broken.doc. The rest of your upload converted — try uploading them on their own.'
+    );
+  });
+
+  it('strips directory prefixes and drops empty names', () => {
+    expect(buildConversionFailureWarning(['folder/notes.docx', ''])).toBe(
+      'notes.docx could not be converted and was skipped. The rest of your upload converted — try uploading that file on its own.'
+    );
+  });
+});

--- a/src/usecases/uploads/conversionFailureWarning.ts
+++ b/src/usecases/uploads/conversionFailureWarning.ts
@@ -1,0 +1,19 @@
+function baseName(filename: string): string {
+  const normalized = filename.replaceAll('\\', '/');
+  const lastSlash = normalized.lastIndexOf('/');
+  return lastSlash >= 0 ? normalized.slice(lastSlash + 1) : normalized;
+}
+
+export function buildConversionFailureWarning(
+  failedFilenames: string[]
+): string | null {
+  const names = failedFilenames.map(baseName).filter((n) => n.length > 0);
+  if (names.length === 0) return null;
+
+  if (names.length === 1) {
+    return `${names[0]} could not be converted and was skipped. The rest of your upload converted — try uploading that file on its own.`;
+  }
+
+  const joined = names.join(', ');
+  return `${names.length} files could not be converted and were skipped: ${joined}. The rest of your upload converted — try uploading them on their own.`;
+}

--- a/src/usecases/uploads/getPackagesFromZip.test.ts
+++ b/src/usecases/uploads/getPackagesFromZip.test.ts
@@ -300,7 +300,7 @@ describe('getPackagesFromZip — batch concurrency', () => {
     expect(runBatchCallCount).toBeLessThanOrEqual(2);
   });
 
-  it('propagates errors from runBatch', async () => {
+  it('drops a chunk whose batch build fails and warns instead of aborting', async () => {
     const fileCount = 8;
     const fileNames = Array.from(
       { length: fileCount },
@@ -332,14 +332,75 @@ describe('getPackagesFromZip — batch concurrency', () => {
     const settings = new CardOption({});
     const workspace = { location: FAKE_WORKSPACE_LOCATION } as Workspace;
 
-    await expect(
-      getPackagesFromZip(
-        Buffer.from('fake-zip') as unknown as Uint8Array,
-        false,
-        settings,
-        workspace
-      )
-    ).rejects.toThrow('Python batch failed');
+    const result = await getPackagesFromZip(
+      Buffer.from('fake-zip') as unknown as Uint8Array,
+      false,
+      settings,
+      workspace
+    );
+
+    expect(result.packages).toEqual([]);
+    expect(
+      result.warnings?.some((w) => w.includes('could not be converted'))
+    ).toBe(true);
+  });
+
+  it('skips one file that fails to convert in the batch path and returns the rest', async () => {
+    const fileCount = 8;
+    const fileNames = Array.from(
+      { length: fileCount },
+      (_, i) => `deck${i}.html`
+    );
+
+    mockZipHandlerClass.mockImplementation(() => ({
+      build: jest.fn().mockResolvedValue(undefined),
+      getFileNames: jest.fn().mockReturnValue(fileNames),
+      files: fileNames.map((name) => ({ name, contents: '<html></html>' })),
+    }));
+
+    mockPrepareDeckInfoOnly.mockImplementation(({ name }: { name: string }) => {
+      if (name === 'deck3.html') {
+        return Promise.reject(new Error('docx_parse_failed: unreadable'));
+      }
+      return Promise.resolve({
+        deckInfoPath: `/fake/${name}/deck_info.json`,
+        outputPath: `/fake/${name}/out.apkg`,
+        name,
+        inputFileName: name,
+        deck: [],
+        cardCount: 1,
+        needsIndividualBuild: false,
+      });
+    });
+
+    mockCardGeneratorClass.mockImplementation(() => ({
+      runBatch: jest
+        .fn()
+        .mockImplementation((entries: Array<{ output: string }>) =>
+          Promise.resolve(entries.map((e) => e.output))
+        ),
+    }));
+
+    jest
+      .spyOn(require('node:fs'), 'readFileSync')
+      .mockReturnValue(Buffer.from('fake-apkg'));
+
+    const settings = new CardOption({});
+    const workspace = { location: FAKE_WORKSPACE_LOCATION } as Workspace;
+
+    const result = await getPackagesFromZip(
+      Buffer.from('fake-zip') as unknown as Uint8Array,
+      false,
+      settings,
+      workspace
+    );
+
+    const names = result.packages.map((p) => p.name);
+    expect(names).toHaveLength(fileCount - 1);
+    expect(names).not.toContain('deck3.html');
+    expect(result.warnings).toContain(
+      'deck3.html could not be converted and was skipped. The rest of your upload converted — try uploading that file on its own.'
+    );
   });
 
   it('returns empty packages when fileContents is undefined', async () => {
@@ -476,7 +537,7 @@ describe('getPackagesFromZip — encrypted PDFs', () => {
     );
   });
 
-  it('still rejects on a non-password error from a zip entry', async () => {
+  it('skips a file whose converter throws a non-password error and returns the rest', async () => {
     process.env.MAX_PYTHON_WORKERS = '8';
     process.env.CONVERSION_WORKERS = '1';
 
@@ -503,13 +564,16 @@ describe('getPackagesFromZip — encrypted PDFs', () => {
     const settings = new CardOption({});
     const workspace = { location: FAKE_WORKSPACE_LOCATION } as Workspace;
 
-    await expect(
-      getPackagesFromZip(
-        Buffer.from('fake-zip') as unknown as Uint8Array,
-        false,
-        settings,
-        workspace
-      )
-    ).rejects.toThrow('pdfinfo_failed');
+    const result = await getPackagesFromZip(
+      Buffer.from('fake-zip') as unknown as Uint8Array,
+      false,
+      settings,
+      workspace
+    );
+
+    expect(result.packages.map((p) => p.name)).toEqual(['notes.html']);
+    expect(result.warnings).toContain(
+      'broken.pdf could not be converted and was skipped. The rest of your upload converted — try uploading that file on its own.'
+    );
   });
 });

--- a/src/usecases/uploads/getPackagesFromZip.ts
+++ b/src/usecases/uploads/getPackagesFromZip.ts
@@ -22,6 +22,7 @@ import {
   parsePdfPasswordSentinel,
 } from '../../lib/pdf/pdfPasswordSentinel';
 import { buildLockedPdfWarning } from '../../lib/pdf/lockedPdfWarning';
+import { buildConversionFailureWarning } from './conversionFailureWarning';
 
 const LOCKED_PDF = Symbol('locked-pdf');
 
@@ -63,17 +64,24 @@ function chunkArray<T>(arr: T[], size: number): T[][] {
   return chunks;
 }
 
+interface BatchOutcome {
+  packages: Package[];
+  warnings: string[];
+  lockedPdfs: string[];
+  failedFiles: string[];
+}
+
 async function buildDeckBatch(
   fileNames: string[],
   zipHandler: ZipHandler,
   settings: CardOption,
   paying: boolean,
   workspace: Workspace
-): Promise<{ packages: Package[]; warnings: string[]; lockedPdfs: string[] }> {
+): Promise<BatchOutcome> {
   const packages: Package[] = [];
   const warnings: string[] = [];
 
-  const outcomes = await Promise.all(
+  const settled = await Promise.allSettled(
     fileNames.map((fileName) => {
       const relevantFiles = getRelevantFiles(fileName, zipHandler.files);
       const deckSubWorkspace = Workspace.subdir(workspace.location);
@@ -94,14 +102,17 @@ async function buildDeckBatch(
   );
 
   const lockedPdfs: string[] = [];
+  const failedFiles: string[] = [];
   const preparedResults: DeckInfoOnlyResult[] = [];
-  for (const outcome of outcomes) {
-    if (isLockedPdfEntry(outcome)) {
-      lockedPdfs.push(outcome.filename);
+  settled.forEach((result, index) => {
+    if (result.status === 'rejected') {
+      failedFiles.push(fileNames[index]);
+    } else if (isLockedPdfEntry(result.value)) {
+      lockedPdfs.push(result.value.filename);
     } else {
-      preparedResults.push(outcome);
+      preparedResults.push(result.value);
     }
-  }
+  });
 
   const batchEntries = preparedResults
     .filter((r) => !r.needsIndividualBuild)
@@ -141,8 +152,9 @@ async function buildDeckBatch(
   packages.push(...stragglerOutcomes.packages);
   warnings.push(...stragglerOutcomes.warnings);
   lockedPdfs.push(...stragglerOutcomes.lockedPdfs);
+  failedFiles.push(...stragglerOutcomes.failedFiles);
 
-  return { packages, warnings, lockedPdfs };
+  return { packages, warnings, lockedPdfs, failedFiles };
 }
 
 async function buildStragglerDecks(
@@ -151,19 +163,20 @@ async function buildStragglerDecks(
   settings: CardOption,
   paying: boolean,
   workspace: Workspace
-): Promise<{ packages: Package[]; warnings: string[]; lockedPdfs: string[] }> {
+): Promise<BatchOutcome> {
   const packages: Package[] = [];
   const warnings: string[] = [];
   const lockedPdfs: string[] = [];
+  const failedFiles: string[] = [];
 
   for (const straggler of stragglers) {
     const relevantFiles = getRelevantFiles(
       straggler.inputFileName,
       zipHandler.files
     );
-    const outcome = await convertSkippingLockedPdf(
-      straggler.inputFileName,
-      () =>
+    let outcome;
+    try {
+      outcome = await convertSkippingLockedPdf(straggler.inputFileName, () =>
         PrepareDeck({
           name: straggler.inputFileName,
           files: relevantFiles,
@@ -171,7 +184,11 @@ async function buildStragglerDecks(
           noLimits: paying,
           workspace,
         })
-    );
+      );
+    } catch {
+      failedFiles.push(straggler.inputFileName);
+      continue;
+    }
     if (isLockedPdfEntry(outcome)) {
       lockedPdfs.push(outcome.filename);
     } else if (outcome) {
@@ -190,7 +207,7 @@ async function buildStragglerDecks(
     }
   }
 
-  return { packages, warnings, lockedPdfs };
+  return { packages, warnings, lockedPdfs, failedFiles };
 }
 
 async function buildClaudeFlashcardDeck(
@@ -240,7 +257,7 @@ async function buildAllInOneSlot(
   cap: number
 ): Promise<PackageResult> {
   const limit = pLimit(cap);
-  const outcomes = await Promise.all(
+  const settled = await Promise.allSettled(
     supportedFileNames.map((fileName) =>
       limit(() => {
         const relevantFiles = getRelevantFiles(fileName, zipHandler.files);
@@ -260,7 +277,13 @@ async function buildAllInOneSlot(
   const packages: Package[] = [];
   const warnings: string[] = [];
   const lockedPdfs: string[] = [];
-  for (const outcome of outcomes) {
+  const failedFiles: string[] = [];
+  settled.forEach((result, index) => {
+    if (result.status === 'rejected') {
+      failedFiles.push(supportedFileNames[index]);
+      return;
+    }
+    const outcome = result.value;
     if (isLockedPdfEntry(outcome)) {
       lockedPdfs.push(outcome.filename);
     } else if (outcome) {
@@ -277,14 +300,23 @@ async function buildAllInOneSlot(
       );
       if (outcome.warning) warnings.push(outcome.warning);
     }
-  }
+  });
   appendLockedPdfWarning(warnings, lockedPdfs);
+  appendConversionFailureWarning(warnings, failedFiles);
   return { packages, warnings };
 }
 
 function appendLockedPdfWarning(warnings: string[], lockedPdfs: string[]) {
   const lockedWarning = buildLockedPdfWarning(lockedPdfs);
   if (lockedWarning) warnings.push(lockedWarning);
+}
+
+function appendConversionFailureWarning(
+  warnings: string[],
+  failedFiles: string[]
+) {
+  const failureWarning = buildConversionFailureWarning(failedFiles);
+  if (failureWarning) warnings.push(failureWarning);
 }
 
 export const getPackagesFromZip = async (
@@ -351,7 +383,7 @@ export const getPackagesFromZip = async (
   const chunks = chunkArray(supportedFileNames, batchSize);
   const limit = pLimit(cap);
 
-  const batchResults = await Promise.all(
+  const settledChunks = await Promise.allSettled(
     chunks.map((chunk) =>
       limit(() =>
         buildDeckBatch(chunk, zipHandler, effectiveSettings, paying, workspace)
@@ -362,12 +394,19 @@ export const getPackagesFromZip = async (
   const packages: Package[] = [];
   const warnings: string[] = [];
   const lockedPdfs: string[] = [];
-  for (const result of batchResults) {
-    packages.push(...result.packages);
-    if (result.warnings) warnings.push(...result.warnings);
-    lockedPdfs.push(...result.lockedPdfs);
-  }
+  const failedFiles: string[] = [];
+  settledChunks.forEach((result, index) => {
+    if (result.status === 'rejected') {
+      failedFiles.push(...chunks[index]);
+      return;
+    }
+    packages.push(...result.value.packages);
+    warnings.push(...result.value.warnings);
+    lockedPdfs.push(...result.value.lockedPdfs);
+    failedFiles.push(...result.value.failedFiles);
+  });
   appendLockedPdfWarning(warnings, lockedPdfs);
+  appendConversionFailureWarning(warnings, failedFiles);
 
   return { packages, warnings };
 };

--- a/src/usecases/uploads/isZipContentFileSupported.test.ts
+++ b/src/usecases/uploads/isZipContentFileSupported.test.ts
@@ -1,0 +1,28 @@
+import { isZipContentFileSupported } from './isZipContentFileSupported';
+
+describe('isZipContentFileSupported', () => {
+  it.each([
+    ['index.html'],
+    ['notes.md'],
+    ['notes.txt'],
+    ['cards.csv'],
+    ['reading.pdf'],
+    ['sheet.xlsx'],
+    ['essay.docx'],
+    ['essay.doc'],
+    ['README'],
+  ])('accepts supported zip content %s', (fileName) => {
+    expect(Boolean(isZipContentFileSupported(fileName))).toBe(true);
+  });
+
+  it.each([['virus.exe'], ['photo.png'], ['clip.mp4']])(
+    'rejects unsupported zip content %s',
+    (fileName) => {
+      expect(Boolean(isZipContentFileSupported(fileName))).toBe(false);
+    }
+  );
+
+  it('accepts a docx even though the xlsx check precedes it', () => {
+    expect(Boolean(isZipContentFileSupported('report.docx'))).toBe(true);
+  });
+});

--- a/src/usecases/uploads/isZipContentFileSupported.ts
+++ b/src/usecases/uploads/isZipContentFileSupported.ts
@@ -9,14 +9,16 @@ import {
 } from '../../lib/storage/checks';
 
 const isFileWithoutExtension = (filename: string) =>
-  filename && filename.indexOf('.') === -1;
+  Boolean(filename) && filename.indexOf('.') === -1;
 
 export const isZipContentFileSupported = (filename: string) =>
-  isHTMLFile(filename) ??
-  isMarkdownFile(filename) ??
-  isPlainText(filename) ??
-  isCSVFile(filename) ??
-  isPDFFile(filename) ??
-  isXLSXFile(filename) ??
-  isDocxFile(filename) ??
-  isFileWithoutExtension(filename);
+  [
+    isHTMLFile,
+    isMarkdownFile,
+    isPlainText,
+    isCSVFile,
+    isPDFFile,
+    isXLSXFile,
+    isDocxFile,
+    isFileWithoutExtension,
+  ].some((check) => Boolean(check(filename)));

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-18-zip-upload-resilience.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-18-zip-upload-resilience.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-18-zip-upload-resilience",
+  "date": "2026-07-18",
+  "type": "fix",
+  "title": "Zip uploads keep every supported file — Word docs and mixed exports no longer lose cards"
+}


### PR DESCRIPTION
## What
Fixes two verified bugs where a zip upload silently lost cards with no error surfaced to the user.

## Why
Fixes Laer-Smart/2anki.net#3717 (findings #13 and #2). Paying users uploaded a zip and got back a deck with fewer cards than they put in — or, in the second case, no deck at all — with nothing telling them why.

- **Finding #13 — supported files dropped from the zip gate.** `isZipContentFileSupported` chained its checks with `??`, but `isXLSXFile` returns a boolean (`.test()`) while every sibling returns a RegExp match array or null. For a `.docx` name, all earlier checks yield null, then `isXLSXFile` returns `false`, and `??` only falls through on null/undefined — so the chain short-circuited at `false` and `.docx`, `.doc`, and extensionless files never passed the `fileNames.filter(isZipContentFileSupported)` content gate. The single-file path was unaffected (it OR's `isDocxFile` separately) — this was zip-only.
- **Finding #2 — one malformed file rejected the whole batch.** A single file whose converter threw a non-sentinel error (e.g. `convertDocxToHTML` throwing `docx_parse_failed`) rethrew out of `convertSkippingLockedPdf` and propagated out of the `Promise.all` in `buildDeckBatch`, `buildAllInOneSlot`, and the top-level chunk map. The worker's outer catch then failed the entire upload with zero decks instead of returning the N-1 that built fine.

## How
- **#13:** replaced the `??` chain with `[...checks].some((check) => Boolean(check(fileName)))`, robust to each check's return type. Kept `isXLSXFile`'s boolean return so its other caller (`PrepareDeck`) is untouched.
- **#2:** switched all three `Promise.all` sites to `Promise.allSettled`, kept the fulfilled results, and collect the rejected filenames into a single user-facing warning via a new `buildConversionFailureWarning` helper. The straggler loop (a sequential `await`, not a `Promise.all`) gets the same per-file try/catch so a straggler failure no longer rejects its whole chunk. The PDF-password sentinel path is preserved (it resolves to a `LockedPdfEntry`, never a rejection). Rejected files are filtered out and never become null decks that later code dereferences.

## Measuring success
`PackageResult.warnings` now carries a `"… could not be converted and was skipped …"` line whenever a file fails, so a partial conversion is visible in the upload response instead of a 500. In prod, a drop in whole-upload conversion failures on multi-file zips (worker outer-catch `{ ok: false }` returns) with a corresponding rise in per-file conversion warnings confirms the batch no longer aborts on one bad file.

## Testing
- Unit tests added:
  - `isZipContentFileSupported.test.ts` — asserts `.docx`, `.doc`, `README` (extensionless), `.html`, `.md`, `.txt`, `.csv`, `.xlsx`, `.pdf` are accepted and `.exe`/`.png`/`.mp4` rejected; a dedicated docx case pins the xlsx-precedes-docx regression.
  - `conversionFailureWarning.test.ts` — single/multiple/empty/prefix-stripping cases for the warning copy.
  - `getPackagesFromZip.test.ts` — new: one file fails in the batch path -> the other 7 return + the bad one is warned; one file fails in the all-in-one path -> the good one returns + warning. Updated the two tests that encoded the old fail-everything contract (a per-file non-password error and a whole-chunk batch failure now degrade gracefully instead of rejecting).
- Full `src/usecases/uploads/` suite green (17 files, 97 tests); `tsc -p . --noEmit` clean; `pnpm format:check` clean tree-wide.
- Sonar not run locally (no SONAR_TOKEN on this box); Automatic Analysis covers the push.

## Browser check
Not applicable — the only `web/src/` file is the changelog JSON (no runtime-visible UI change); server-side logic only.

## Changelog
`Zip uploads keep every supported file — Word docs and mixed exports no longer lose cards`

## Risks
- The three sites no longer throw on a per-file converter failure. A file that used to fail the whole upload now converts the rest and warns. Two existing tests that asserted the old throw-everything behavior were updated to the new graceful contract (explained in the commit body). A whole-chunk batch (`runBatch`) failure now drops that chunk and warns rather than 500-ing — strictly better UX (partial deck + warning vs error page), and other chunks survive a transient failure. Rollback is a straight revert; no migration, no schema.

## Goal alignment
Reliability of the core conversion path — the mission is "drop something in, get a clean deck back." Paying users who upload mixed zips (Word docs + HTML + PDFs, common for med/law study exports) were silently losing cards, which erodes trust in the one thing the product must get right. No new surface; this hardens the existing upload funnel (upload -> download).

## Coordination note
`getPackagesFromZip.ts` is also referenced in the memory-hardening PR's context, but that PR edits `src/lib/zip/zip.tsx` only (untouched here). No file overlap; rebase before merge if that lands first.
