### PR TITLE
fix: bound zip decompressed size and derive memory guard from worker cap

### DIFF
--- a/src/lib/conversionMemoryLimits.ts
+++ b/src/lib/conversionMemoryLimits.ts
@@ -1,0 +1,6 @@
+// Piscina conversion workers run with a bounded V8 old-generation heap. Both the
+// pool (which applies it via resourceLimits) and the zip extractor (which sizes
+// its own in-memory / decompressed ceilings below it) need this number, so it
+// lives in a dependency-free leaf module — importing conversionPool.ts into the
+// extraction hot path would drag knex, Piscina, and the Notion client into it.
+export const MAX_OLD_GENERATION_SIZE_MB = 1024;

--- a/src/lib/conversionPool.ts
+++ b/src/lib/conversionPool.ts
@@ -19,6 +19,7 @@ import {
   resolveConversionWorkers,
   resolveConversionWorkerRecycleTasks,
 } from './pythonWorkerBudget';
+import { MAX_OLD_GENERATION_SIZE_MB } from './conversionMemoryLimits';
 
 export { resolveConversionWorkers } from './pythonWorkerBudget';
 
@@ -46,8 +47,10 @@ export const POOL_CLOSE_TIMEOUT_MS = 80_000;
 // resets periodically instead of only on restart. The old-gen cap stays at
 // 1024MB: lowering it risks OOMing the comprehensive/big-media path (which would
 // turn a slow leak into failed conversions), so recycling — not a smaller cap —
-// is the mechanism that bounds RSS.
-export const MAX_OLD_GENERATION_SIZE_MB = 1024;
+// is the mechanism that bounds RSS. The cap value lives in
+// conversionMemoryLimits.ts so the zip extractor can size its ceilings under it
+// without importing this heavy module (knex, Piscina, the Notion client).
+export { MAX_OLD_GENERATION_SIZE_MB };
 
 let completedTaskCount = 0;
 let recyclingPool = false;

--- a/src/lib/zip/zip.test.tsx
+++ b/src/lib/zip/zip.test.tsx
@@ -3,7 +3,8 @@ import os from 'os';
 import path from 'path';
 import { strToU8, zipSync } from 'fflate';
 
-import { ZipHandler } from './zip';
+import { ZipHandler, MAX_IN_MEMORY_BYTES, MAX_DECOMPRESSED_BYTES } from './zip';
+import { MAX_OLD_GENERATION_SIZE_MB } from '../conversionMemoryLimits';
 import CardOption from '../parser/Settings';
 
 function makeSpillDir(): string {
@@ -116,6 +117,57 @@ describe('ZipHandler in-memory text guard', () => {
     await expect(
       handler.build(outer, true, new CardOption({}))
     ).rejects.toThrow(/too large to process/);
+  });
+});
+
+describe('ZipHandler decompressed-size ceiling', () => {
+  it('rejects a highly-compressible zip that decompresses past the ceiling before inflating it', async () => {
+    const highlyCompressible = 'a'.repeat(64 * 1024);
+    const zip = buildZip({ 'bomb.html': highlyCompressible });
+    // The compressed archive is a tiny fraction of its decompressed size — a
+    // zip bomb's defining shape — so the compressed-size guard alone lets it in.
+    expect(zip.length).toBeLessThan(highlyCompressible.length / 10);
+
+    const handler = new ZipHandler(10, 8 * 1024 * 1024, 16 * 1024);
+    await expect(handler.build(zip, true, new CardOption({}))).rejects.toThrow(
+      /decompresses to over/
+    );
+    // Aborted in the filter before any entry was inflated into memory.
+    expect(handler.files).toHaveLength(0);
+  });
+
+  it('accepts a zip whose decompressed size stays under the ceiling', async () => {
+    const zip = buildZip({ 'a.html': 'a'.repeat(8 * 1024) });
+
+    const handler = new ZipHandler(10, 8 * 1024 * 1024, 64 * 1024);
+    await handler.build(zip, true, new CardOption({}));
+
+    expect(handler.getFileNames()).toEqual(['a.html']);
+  });
+
+  it('enforces the decompressed ceiling across nested zips via a shared counter', async () => {
+    const inner = buildZip({ 'big.html': 'a'.repeat(32 * 1024) });
+    const outer = zipSync({ 'nested.zip': inner }, { level: 0 });
+
+    const handler = new ZipHandler(10, 8 * 1024 * 1024, 16 * 1024);
+    await expect(
+      handler.build(outer, true, new CardOption({}))
+    ).rejects.toThrow(/decompresses to over/);
+  });
+});
+
+describe('ZipHandler memory ceilings derive from the worker heap cap', () => {
+  it('sets the in-memory text ceiling to half the worker old-gen cap, not a 4 GB literal', () => {
+    const workerBytes = MAX_OLD_GENERATION_SIZE_MB * 1024 * 1024;
+    expect(MAX_IN_MEMORY_BYTES).toBe(Math.floor(workerBytes * 0.5));
+    expect(MAX_IN_MEMORY_BYTES).toBeLessThan(workerBytes);
+    expect(MAX_IN_MEMORY_BYTES).not.toBe(4 * 1024 * 1024 * 1024);
+  });
+
+  it('sets the decompressed ceiling below the worker cap so a bomb fails before OOM', () => {
+    const workerBytes = MAX_OLD_GENERATION_SIZE_MB * 1024 * 1024;
+    expect(MAX_DECOMPRESSED_BYTES).toBe(Math.floor(workerBytes * 0.6));
+    expect(MAX_DECOMPRESSED_BYTES).toBeLessThan(workerBytes);
   });
 });
 

--- a/src/lib/zip/zip.tsx
+++ b/src/lib/zip/zip.tsx
@@ -15,21 +15,37 @@ import { isSafeZipEntryName } from './isSafeZipEntryName';
 import CardOption from '../parser/Settings';
 import { getRandomUUID } from '../../shared/helpers/getRandomUUID';
 import { convertImageToHTML } from '../../infrastracture/adapters/fileConversion/convertImageToHTML';
+import { MAX_OLD_GENERATION_SIZE_MB } from '../conversionMemoryLimits';
 
 interface File {
   name: string;
   contents?: Buffer | Uint8Array | string;
 }
 
-// Binary entries (images, audio, misc media) are spilled to the workspace on
-// disk during extraction and backed by a lazy read, so they no longer sit
-// resident in memory — a deck of thousands of screenshots used to inflate the
-// whole archive into RAM at once and OOM-crash the shared server (#3709/#3711).
-// Only entries we KEEP in memory (decoded HTML/markdown text, the OCR html) are
-// counted toward this heap ceiling; disk-backed media is bounded instead by the
-// compressed-upload cap (`getUploadLimits().fileSize`). 4 GB of in-memory text
-// leaves headroom under the 16 GB prod heap.
-const MAX_IN_MEMORY_BYTES = 4 * 1024 * 1024 * 1024;
+// Conversion runs in a Piscina worker whose V8 old-generation heap is capped at
+// MAX_OLD_GENERATION_SIZE_MB. Both ceilings below are derived from that cap so
+// the friendly "too large" error fires BEFORE V8 kills the worker with
+// ERR_WORKER_OUT_OF_MEMORY. The previous 4 GB literal sat far above the 1 GB
+// worker cap, so it was dead code — the worker OOMed first (#3717).
+const WORKER_OLD_GEN_BYTES = MAX_OLD_GENERATION_SIZE_MB * 1024 * 1024;
+
+// Text we KEEP in memory (decoded HTML/markdown, the OCR html) is stored as
+// UTF-16 strings — roughly 2× the counted byte length — so hold this ceiling to
+// about half the worker old-gen cap to leave headroom for that overhead, the
+// inflated archive map, and other allocations. Binary entries (images, audio,
+// misc media) are spilled to disk and bounded instead by the compressed-upload
+// cap (`getUploadLimits().fileSize`); they do not count here (#3709/#3711).
+const MAX_IN_MEMORY_BYTES = Math.floor(WORKER_OLD_GEN_BYTES * 0.5);
+
+// The whole archive is inflated into a { name: bytes } map by unzipSync before
+// any entry spills to disk, so peak resident bytes during extraction equal the
+// total DECOMPRESSED size. A highly-compressible zip bomb (DEFLATE of zeros,
+// ~1000:1) under the compressed cap inflates to tens of GB and OOM-kills the
+// worker; nested archives compound it. Bound the cumulative decompressed size
+// below the worker cap, summing each entry's declared size from the central
+// directory (which fflate also caps its own inflation at) BEFORE inflating, so a
+// bomb aborts with the friendly error instead of crashing the worker (#3717).
+const MAX_DECOMPRESSED_BYTES = Math.floor(WORKER_OLD_GEN_BYTES * 0.6);
 
 function formatGigabytes(bytes: number): string {
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
@@ -57,11 +73,14 @@ class ZipHandler {
   combinedHTML: string;
   inMemoryBytes: number;
   maxInMemoryBytes: number;
+  decompressedBytes: number;
+  maxDecompressedBytes: number;
   spillLocation?: string;
 
   constructor(
     maxNestedZipFiles: number,
-    maxInMemoryBytes: number = MAX_IN_MEMORY_BYTES
+    maxInMemoryBytes: number = MAX_IN_MEMORY_BYTES,
+    maxDecompressedBytes: number = MAX_DECOMPRESSED_BYTES
   ) {
     this.files = [];
     this.zipFileCount = 0;
@@ -69,6 +88,8 @@ class ZipHandler {
     this.combinedHTML = '';
     this.inMemoryBytes = 0;
     this.maxInMemoryBytes = maxInMemoryBytes;
+    this.decompressedBytes = 0;
+    this.maxDecompressedBytes = maxDecompressedBytes;
   }
 
   private trackInMemoryBytes(byteLength: number) {
@@ -78,6 +99,20 @@ class ZipHandler {
         `This upload is too large to process — it holds over ${formatGigabytes(
           this.maxInMemoryBytes
         )} of text in memory. Split it into smaller uploads and try again.`
+      );
+    }
+  }
+
+  // Sum each entry's declared decompressed size (shared across nested archives
+  // via this instance counter) before fflate inflates it, so a zip bomb aborts
+  // early instead of materializing the whole inflated map into the worker heap.
+  private trackDecompressedBytes(originalSize: number) {
+    this.decompressedBytes += originalSize;
+    if (this.decompressedBytes > this.maxDecompressedBytes) {
+      throw new Error(
+        `This upload is too large to process — it decompresses to over ${formatGigabytes(
+          this.maxDecompressedBytes
+        )}. Split it into smaller uploads and try again.`
       );
     }
   }
@@ -134,7 +169,11 @@ class ZipHandler {
 
     try {
       const loadedZip = unzipSync(zipData, {
-        filter: (file) => !isHiddenFileOrDirectory(file.name),
+        filter: (file) => {
+          if (isHiddenFileOrDirectory(file.name)) return false;
+          this.trackDecompressedBytes(file.originalSize);
+          return true;
+        },
       });
 
       let noSuffixCount = 0;
@@ -242,4 +281,4 @@ ${this.combinedHTML}
   }
 }
 
-export { ZipHandler, File };
+export { ZipHandler, File, MAX_IN_MEMORY_BYTES, MAX_DECOMPRESSED_BYTES };

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-18-compressed-upload-guard.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-18-compressed-upload-guard.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-18-compressed-upload-guard",
+  "date": "2026-07-18",
+  "type": "fix",
+  "title": "Heavily compressed uploads fail with a clear size message instead of dropping the conversion"
+}


### PR DESCRIPTION
## What
Closes two verified memory-safety gaps in the zip conversion path (tracking issue https://github.com/Laer-Smart/2anki.net/issues/3717, findings #1 and #6) that let a within-cap upload OOM-kill the shared Piscina conversion worker instead of returning a clean error. Continues the #3710/#3712 OOM work.

## Why
- **Gap 1 (zip-bomb):** `ZipHandler.build` guarded only the **compressed** input against the upload cap. `unzipSync` then inflated **every** entry into one in-memory `{ name: bytes }` map before any disk spill ran, so a highly-compressible payload (DEFLATE of zeros, ~1000:1) under the compressed cap — or nested archives — inflated to tens of GB and OOM-killed the worker, dropping concurrent conversions with it.
- **Gap 2 (dead guard):** the in-memory text guard defaulted to 4 GB while the worker V8 old-gen heap caps at 1 GB (`MAX_OLD_GENERATION_SIZE_MB`), so `ERR_WORKER_OUT_OF_MEMORY` always fired first and the friendly 4xx was effectively dead code. UTF-16 string storage (~2×) made real heap use exceed the counter too.

## How
- Add a cumulative **decompressed** ceiling, summed from each entry's central-directory `originalSize` in the `unzipSync` filter **before** inflation (fflate caps its own per-entry inflation at that declared size, so the sum is a sound bound). The counter is a `ZipHandler` instance field, so it's shared across nested `processZip` recursion. Over-ceiling throws the friendly upload-too-large error and aborts before materializing the map. The existing compressed-size guard is unchanged — the decompressed ceiling is added alongside it.
- Derive both ceilings from the worker cap instead of hard-coding: in-memory `0.5×` (headroom for UTF-16 overhead + the inflated map), decompressed `0.6×`. Moved `MAX_OLD_GENERATION_SIZE_MB` into a dependency-free leaf module (`conversionMemoryLimits.ts`) so the extraction hot path doesn't import `conversionPool.ts` (knex, Piscina, the Notion client); `conversionPool.ts` re-exports it, so existing importers are unaffected.
- Constructor overrides for both ceilings preserved (tests inject small caps); only the defaults changed.
- Only production `new ZipHandler` site is `getPackagesFromZip.ts` (the worker-invoked path) — it uses the defaults, so both ceilings apply there without touching that file.

## Measuring success
Prod logs: the `ERR_WORKER_OUT_OF_MEMORY` / worker-exit lines that currently coincide with large-zip uploads should stop; instead the request returns the friendly "decompresses to over N GB" / "holds over N GB of text in memory" message. Watch worker RSS during a crafted-upload attempt — it should plateau near the derived ceiling instead of climbing to the OOM kill.

## Testing
Unit tests added to `src/lib/zip/zip.test.tsx`:
- Highly-compressible zip whose declared decompressed size exceeds a small injected ceiling → throws the friendly error and `handler.files` stays empty (proves it aborts before inflating the map). Also asserts the compressed archive is <10% of the decompressed size (bomb shape).
- A zip under the ceiling still extracts.
- Decompressed ceiling enforced across nested zips via the shared counter.
- Both default ceilings are derived from `MAX_OLD_GENERATION_SIZE_MB` (0.5× / 0.6×), below the worker cap, and not the old 4 GB literal.

Green locally: zip suite 15/15, `conversionPool` suite 20/20, `tsc -p . --noEmit` clean, `oxlint` clean, `pnpm format:check` (tree-wide) clean, `pnpm arch` 0 errors, web changelog loader 4/4. Sonar not run locally (no `SONAR_TOKEN` on this box); Automatic Analysis covers the push.

## Browser check
Browser check: not applicable — only web change is a changelog JSON, no rendered/runtime code.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-07-18-compressed-upload-guard.json` — "Heavily compressed uploads fail with a clear size message instead of dropping the conversion"

## Risks
- The decompressed ceiling (0.6× of 1 GB ≈ 614 MB) will now reject genuinely huge exports that decompress past it — but those already OOM-killed the worker, so a clean error is strictly better than a crash. Both ceilings are single-constant tunable if prod shows a legit path near the bound.
- The code-13 `processAndPrepareArchiveData` fallback (corrupt-archive path only, not reached by well-formed bombs) is intentionally out of scope here.
- **Shared-file coordination:** this PR edits `zip.tsx` / `conversionPool.ts`; a sibling PR (zip-upload-resilience) edits `getPackagesFromZip.ts` / `isZipContentFileSupported.ts` — no file overlap, but rebase before merge.

## Goal alignment
Reliability, not a funnel metric (none — internal): the shared conversion server must not OOM on a crafted or oversized upload. One bomb currently drops every concurrent user's in-flight conversion; bounding peak memory protects the "drop something in, get a clean deck back" mission for everyone converting at the same time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs4pvvQ4BKVpvEtGA9GXTn
