### PR TITLE
fix: pin sanitize-html to 2.17.5 to unblock the test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,8 @@
       "picomatch": ">=4.0.4",
       "path-to-regexp": ">=8.4.0",
       "2anki-web>yaml": ">=2.8.3",
-      "@xmldom/xmldom": ">=0.8.13 <0.9.0"
+      "@xmldom/xmldom": ">=0.8.13 <0.9.0",
+      "sanitize-html": "2.17.5"
     },
     "onlyBuiltDependencies": [
       "better-sqlite3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   path-to-regexp: '>=8.4.0'
   2anki-web>yaml: '>=2.8.3'
   '@xmldom/xmldom': '>=0.8.13 <0.9.0'
+  sanitize-html: 2.17.5
 
 importers:
 
@@ -188,8 +189,8 @@ importers:
         specifier: ^19.2.5
         version: 19.2.7(react@19.2.7)
       sanitize-html:
-        specifier: ^2.17.4
-        version: 2.17.6
+        specifier: 2.17.5
+        version: 2.17.5
       sql.js:
         specifier: ^1.13.0
         version: 1.14.1
@@ -3834,10 +3835,6 @@ packages:
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
-  dom-serializer@3.1.1:
-    resolution: {integrity: sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==}
-    engines: {node: '>=20.19.0'}
-
   domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
 
@@ -3861,10 +3858,6 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
-
-  domutils@4.0.2:
-    resolution: {integrity: sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==}
-    engines: {node: '>=20.19.0'}
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
@@ -4394,10 +4387,6 @@ packages:
 
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
-
-  htmlparser2@12.0.0:
-    resolution: {integrity: sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==}
-    engines: {node: '>=20.19.0'}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -6346,9 +6335,8 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  sanitize-html@2.17.6:
-    resolution: {integrity: sha512-M4bo9tfv1yfhQZZKkc6dL07ALrGJtfvNOuhX3hU9AVPR/uPQ+nKOJBqTYc7LfMQblTW04mtSWDJWEyLvygJsLA==}
-    engines: {node: '>=22.12.0'}
+  sanitize-html@2.17.5:
+    resolution: {integrity: sha512-ZmU1joGRrvoyctKIiuwUxqR6moLoU2Wk+2bMccN6f7UwhAmwYDvWziqPxRDDN2Qip62NqnIrVrT9akbL6Wretg==}
 
   sass@1.51.0:
     resolution: {integrity: sha512-haGdpTgywJTvHC2b91GSq+clTKGbtkkZmVAb82jZQN/wTy6qs8DdFm2lhEQbEwrY0QDRgSQ3xDurqM977C3noA==}
@@ -10824,12 +10812,6 @@ snapshots:
       domhandler: 5.0.3
       entities: 4.5.0
 
-  dom-serializer@3.1.1:
-    dependencies:
-      domelementtype: 3.0.0
-      domhandler: 6.0.1
-      entities: 8.0.0
-
   domelementtype@2.3.0: {}
 
   domelementtype@3.0.0: {}
@@ -10855,12 +10837,6 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
-
-  domutils@4.0.2:
-    dependencies:
-      dom-serializer: 3.1.1
-      domelementtype: 3.0.0
-      domhandler: 6.0.1
 
   dot-case@3.0.4:
     dependencies:
@@ -11480,13 +11456,6 @@ snapshots:
       domhandler: 5.0.3
       domutils: 3.2.2
       entities: 7.0.1
-
-  htmlparser2@12.0.0:
-    dependencies:
-      domelementtype: 3.0.0
-      domhandler: 6.0.1
-      domutils: 4.0.2
-      entities: 8.0.0
 
   http-cache-semantics@4.2.0: {}
 
@@ -13890,11 +13859,11 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sanitize-html@2.17.6:
+  sanitize-html@2.17.5:
     dependencies:
       deepmerge: 4.3.1
       escape-string-regexp: 4.0.0
-      htmlparser2: 12.0.0
+      htmlparser2: 10.1.0
       is-plain-object: 5.0.0
       launder: 1.7.1
       parse-srcset: 1.0.2


### PR DESCRIPTION
## What
Pins `sanitize-html` to `2.17.5` via `pnpm.overrides` (reverting the #3691 bump to 2.17.6).

## Why — main's `test` job is red, blocking every PR
The #3691 dependency-group bump moved `sanitize-html` 2.17.5 → 2.17.6. Version 2.17.6 requires `htmlparser2 ^12.0.0`, which is **ESM-only** (its `dist/index.js` starts with a top-level `import`). The CommonJS jest runtime cannot load an ESM module, so **every test suite that imports the sanitize-html chain fails at import** with `SyntaxError: Cannot use import statement outside a module`.

Result: 11 conversion/upload/ops suites fail to run — **5232 tests pass, 0 fail, but 11 suites crash at load** — and the `test` job is red on `main` and on every open PR. This is exactly the ESM-only-transitive-dep foot-gun in `.claude/rules/dependencies.md`.

## How
`sanitize-html: "2.17.5"` override → resolves `htmlparser2@10.1.0` (CJS) again. `sanitize-html` isn't downgradable via htmlparser2 alone (2.17.6 hard-requires `^12`), so the pin is on sanitize-html itself. No source changes.

## Testing
Before: `parseAnkiAppXml`, `sanitize`, `getPackagesFromZip`, `worker`, `ApkgPreviewService`, `OpsRouter`, … fail to run. After the pin (fresh install → htmlparser2@10.1.0): `parseAnkiAppXml.test.ts` + `sanitize.test.ts` → 2 suites / 30 tests green. The full `test` job green is the CI check on this PR.

## Risks
None to runtime — sanitize-html 2.17.5 is the version that ran in prod until ~40 min ago. This holds a dependabot patch back; future `sanitize-html` bumps must stay pinned until jest supports ESM or htmlparser2@12 ships a CJS entry. Follow-up option (not this PR): a `moduleNameMapper` stub — but sanitize-html is exercised by real tests, so pinning is the correct fix, not stubbing.

## Goal alignment
None — unblocks the merge queue so the acquisition + reliability PRs behind it can ship.

Browser check: not applicable — dependency pin, no web/src or rendered-output changes.