### PR TITLE
fix: bind registerTool so the MCP server builds at runtime

### DIFF
--- a/src/services/mcp/McpServerFactory.test.ts
+++ b/src/services/mcp/McpServerFactory.test.ts
@@ -1,0 +1,27 @@
+import { buildMcpServer, type McpRequestContext } from './McpServerFactory';
+import type { McpToolsService } from './McpToolsService';
+
+const buildContext = (): McpRequestContext => ({
+  owner: 'user-1',
+  locals: {},
+  toolsService: {} as McpToolsService,
+  recordToolCall: () => {},
+});
+
+describe('buildMcpServer', () => {
+  it('builds a server without throwing', () => {
+    expect(() => buildMcpServer(buildContext())).not.toThrow();
+  });
+
+  it('registers the three tools on the real MCP server', () => {
+    const server = buildMcpServer(buildContext());
+    const registered = (
+      server as unknown as { _registeredTools: Record<string, unknown> }
+    )._registeredTools;
+    expect(Object.keys(registered).sort()).toEqual([
+      'convert_to_deck',
+      'get_deck_preview',
+      'list_my_decks',
+    ]);
+  });
+});

--- a/src/services/mcp/McpServerFactory.ts
+++ b/src/services/mcp/McpServerFactory.ts
@@ -38,8 +38,10 @@ function registerTool<Args>(
   config: ToolConfig,
   handler: (args: Args) => Promise<ToolResult>
 ): void {
-  const erased = server.registerTool as unknown as ErasedRegisterTool;
-  erased(
+  const erasedServer = server as unknown as {
+    registerTool: ErasedRegisterTool;
+  };
+  erasedServer.registerTool(
     name,
     config,
     handler as (args: Record<string, unknown>) => Promise<ToolResult>


### PR DESCRIPTION
## What
Fixes the just-shipped MCP connector (#3726) failing to connect — every authenticated `POST /mcp` 400'd, so claude.ai showed "2anki returned an error when connecting."

## Why
The #3726 TS2589 fix erased `registerTool`'s type by grabbing `server.registerTool` as an **unbound function reference**. Calling that reference lost the `this` binding, so at runtime the SDK's `registerTool` threw `TypeError: Cannot read properties of undefined (reading '_registeredTools')`. `buildMcpServer` throws → `onAuthenticatedPost` 400s → the connector errors right after a successful OAuth token exchange. Confirmed live in prod logs. Blast radius contained to the `developer_access` beta (the connector never worked for anyone).

## How
Call `registerTool` as a **method on the type-erased server** (`erasedServer.registerTool(...)`) instead of an unbound reference — preserves the `this` binding while keeping the TS2589 suppression that made the type check pass.

## Testing
The existing MCP tests mocked `registerTool` and never built a real server, so the crash shipped green. Adds `McpServerFactory.test.ts` that builds a **real** `McpServer` and asserts all 3 tools register — reproduces the crash before the fix, passes after. All 42 MCP tests green; `tsc -p . --noEmit` clean; format clean.

## Risks
None beyond the MCP surface. No auth/crypto/migration change — the CSRF/consent path and token handling from #3726 are untouched.

## Goal alignment
Unbreaks the MCP connector (new surface) so the prod smoke test can complete.

no changelog entry — fixes a `developer_access`-gated beta connector that never reached users; no user-visible regression to announce.

Browser check: not applicable — server-only change, no web/src.