### PR TITLE
fix: get_deck_preview takes a jobId, not a raw storage key

### DIFF
--- a/src/services/mcp/McpServerFactory.ts
+++ b/src/services/mcp/McpServerFactory.ts
@@ -83,7 +83,7 @@ export function buildMcpServer(context: McpRequestContext): McpServer {
     }
   );
 
-  registerTool<{ key: string }>(
+  registerTool<{ jobId: string }>(
     server,
     'get_deck_preview',
     {
@@ -91,17 +91,17 @@ export function buildMcpServer(context: McpRequestContext): McpServer {
       description:
         'Preview an .apkg deck you own — total cards, decks, and a sample of cards.',
       inputSchema: {
-        key: z
+        jobId: z
           .string()
-          .describe('The storage key of the .apkg upload (ends in .apkg).'),
+          .describe('The jobId of the deck, as returned by list_my_decks.'),
       },
     },
-    async ({ key }) => {
+    async ({ jobId }) => {
       context.recordToolCall('get_deck_preview');
       try {
         const preview = await context.toolsService.getDeckPreview(
           context.owner,
-          key
+          jobId
         );
         return textResult(preview);
       } catch (error) {

--- a/src/services/mcp/McpToolsService.test.ts
+++ b/src/services/mcp/McpToolsService.test.ts
@@ -80,30 +80,62 @@ describe('McpToolsService.listMyDecks', () => {
 });
 
 describe('McpToolsService.getDeckPreview', () => {
-  it('rejects a non-apkg key without hitting storage', async () => {
-    const { service, downloadService } = makeService({});
-    await expect(service.getDeckPreview('owner', 'notes.txt')).rejects.toThrow(
-      /Not an .apkg/
+  const jobFixture = (
+    overrides: Partial<JobWithDownloadKey>
+  ): JobWithDownloadKey =>
+    ({
+      object_id: 'job-1',
+      title: 'Bio',
+      status: 'done',
+      created_at: null,
+      download_key: 'deck.apkg',
+      ...overrides,
+    }) as unknown as JobWithDownloadKey;
+
+  it('rejects an unknown jobId as not found', async () => {
+    const { service, downloadService } = makeService({
+      jobs: [jobFixture({ object_id: 'job-1' })],
+    });
+    await expect(service.getDeckPreview('owner', 'nope')).rejects.toThrow(
+      /Deck not found/
     );
     expect(downloadService.getFileBody).not.toHaveBeenCalled();
   });
 
-  it('returns meta and sample cards for an owned deck', async () => {
-    const { service } = makeService({
-      getFileBody: jest.fn(async () => Buffer.from('apkg')),
+  it('rejects a job with no .apkg without hitting storage', async () => {
+    const { service, downloadService } = makeService({
+      jobs: [jobFixture({ object_id: 'job-1', download_key: null })],
     });
-    const preview = await service.getDeckPreview('owner', 'deck.apkg');
+    await expect(service.getDeckPreview('owner', 'job-1')).rejects.toThrow(
+      /no .apkg/
+    );
+    expect(downloadService.getFileBody).not.toHaveBeenCalled();
+  });
+
+  it('resolves the jobId to its download_key and returns meta + sample cards', async () => {
+    const getFileBody = jest.fn(async () => Buffer.from('apkg'));
+    const { service } = makeService({
+      jobs: [jobFixture({ object_id: 'job-1', download_key: 'deck.apkg' })],
+      getFileBody,
+    });
+    const preview = await service.getDeckPreview('owner', 'job-1');
+    expect(getFileBody).toHaveBeenCalledWith(
+      'owner',
+      'deck.apkg',
+      expect.anything()
+    );
     expect(preview.cardCount).toBe(3);
     expect(preview.decks).toEqual([{ id: 1, name: 'Bio', cardCount: 3 }]);
     expect(preview.sampleCards).toEqual([{ front: 'Q', back: 'A' }]);
   });
 
-  it('reports when the deck is not owned or missing', async () => {
+  it('reports when the resolved file is missing from storage', async () => {
     const { service } = makeService({
+      jobs: [jobFixture({ object_id: 'job-1', download_key: 'deck.apkg' })],
       getFileBody: jest.fn(async () => null),
     });
-    await expect(service.getDeckPreview('owner', 'deck.apkg')).rejects.toThrow(
-      /not found/
+    await expect(service.getDeckPreview('owner', 'job-1')).rejects.toThrow(
+      /Upload not found/
     );
   });
 });

--- a/src/services/mcp/McpToolsService.ts
+++ b/src/services/mcp/McpToolsService.ts
@@ -148,9 +148,15 @@ export class McpToolsService {
     }));
   }
 
-  async getDeckPreview(owner: string, key: string): Promise<DeckPreview> {
-    if (!APKG_KEY_PATTERN.test(key)) {
-      throw new Error('Not an .apkg upload.');
+  async getDeckPreview(owner: string, jobId: string): Promise<DeckPreview> {
+    const jobs = await this.jobLister.getJobsByOwner(owner);
+    const job = jobs.find((entry) => entry.object_id === jobId);
+    if (!job) {
+      throw new Error('Deck not found.');
+    }
+    const key = job.download_key;
+    if (key == null || !APKG_KEY_PATTERN.test(key)) {
+      throw new Error('This deck has no .apkg to preview yet.');
     }
     const body = await this.downloadService.getFileBody(
       owner,


### PR DESCRIPTION
## What
Fixes the MCP `get_deck_preview` tool so it chains from `list_my_decks` — found during the prod connector smoke test.

## Why
`list_my_decks` returns `jobId`, but `get_deck_preview` required the `.apkg` **storage key**, which the list never exposed. An agent had no way to bridge the two — every preview attempt returned "Upload not found."

## How
`get_deck_preview` now accepts the `jobId` from `list_my_decks` and resolves it to the job's `download_key` server-side via `getJobsByOwner(owner)` (owner-scoped → no IDOR, and the S3 key is never exposed to the client). Error messages distinguish deck-not-found, no-`.apkg`-yet, and file-missing-from-storage.

## Scope / blast radius
MCP-only. `getDeckPreview` has exactly one caller (the `get_deck_preview` tool); `McpToolsService` is not imported outside `src/services/mcp/`. The web deck-preview path (`/api/apkg/*`) is untouched.

## Testing
Rewrote the `getDeckPreview` tests for the jobId contract: unknown jobId → not found (no storage hit), job with no `.apkg` → clean error (no storage hit), valid jobId → resolves `download_key` and returns meta + sample cards, resolved-but-missing file → upload-not-found. 43 MCP tests green; `tsc -p . --noEmit` clean; format clean.

## Known follow-up (separate PR)
Sync single-deck conversions (text/markdown → 200 + apkg bytes) are **not** persisted as a job, so they don't appear in `list_my_decks` and can't be previewed by jobId. Best fix: have `convert_to_deck` return the preview inline on the sync path (it already holds the bytes). Trio-worthy — tracked as a follow-up.

## Goal alignment
Makes the MCP tool chain usable (list → preview) for the beta connector.

no changelog entry — `developer_access`-gated beta MCP tool, not user-visible.

Browser check: not applicable — server-only change, no web/src.