### PR TITLE
feat: convert_to_deck returns an inline preview for sync conversions

### DIFF
--- a/src/services/mcp/McpServerFactory.ts
+++ b/src/services/mcp/McpServerFactory.ts
@@ -118,7 +118,7 @@ export function buildMcpServer(context: McpRequestContext): McpServer {
     {
       title: 'Convert to Anki deck',
       description:
-        'Convert a URL or text into an Anki deck. Returns a download link or job id, never raw file bytes.',
+        'Convert a URL or text into an Anki deck. Returns the deck preview (card count and a sample of cards) for an immediate conversion, or a job id to check with list_my_decks for a queued one — never raw file bytes.',
       inputSchema: {
         url: z
           .string()

--- a/src/services/mcp/McpToolsService.test.ts
+++ b/src/services/mcp/McpToolsService.test.ts
@@ -174,7 +174,7 @@ describe('McpToolsService.convertToDeck', () => {
     });
   });
 
-  it('maps a single-deck byte response to a card-count summary', async () => {
+  it('maps a single-deck byte response to a card-count summary with an inline preview', async () => {
     const uploadEntry: UploadEntrypoint = (_req, res) => {
       res.set('X-Card-Count', '42');
       res.set('File-Name', 'deck.apkg');
@@ -186,7 +186,29 @@ describe('McpToolsService.convertToDeck', () => {
       kind: 'deck',
       cardCount: 42,
       filename: 'deck.apkg',
+      deckCount: 1,
+      decks: [{ id: 1, name: 'Bio', cardCount: 3 }],
+      sampleCards: [{ front: 'Q', back: 'A' }],
     });
+  });
+
+  it('still returns the deck when inline preview parsing fails', async () => {
+    const uploadEntry: UploadEntrypoint = (_req, res) => {
+      res.set('X-Card-Count', '7');
+      res.set('File-Name', 'deck.apkg');
+      res.status(200).send(Buffer.from('CORRUPT'));
+    };
+    const { service } = makeService({
+      uploadEntry,
+      preview: {
+        parse: jest.fn(async () => {
+          throw new Error('bad apkg');
+        }),
+      },
+    });
+    const result = await service.convertToDeck({ text: 'x' }, {});
+    expect(result).toMatchObject({ kind: 'deck', cardCount: 7 });
+    expect((result as { decks?: unknown }).decks).toBeUndefined();
   });
 
   it('returns an error result when neither url nor text is given', async () => {

--- a/src/services/mcp/McpToolsService.ts
+++ b/src/services/mcp/McpToolsService.ts
@@ -39,6 +39,9 @@ export type ConvertResult =
       kind: 'deck';
       cardCount: number | null;
       filename: string | null;
+      deckCount?: number;
+      decks?: { id: number; name: string; cardCount: number }[];
+      sampleCards?: { front: string; back: string }[];
       summary: string;
     }
   | { kind: 'error'; message: string };
@@ -217,6 +220,39 @@ export class McpToolsService {
     return this.mapUploadResult(res);
   }
 
+  private async previewFromBytes(
+    buffer: Buffer,
+    filename: string | null
+  ): Promise<Pick<DeckPreview, 'deckCount' | 'decks' | 'sampleCards'> | null> {
+    try {
+      const parsed = await this.previewService.parse(
+        filename ?? 'deck.apkg',
+        buffer
+      );
+      const meta = this.previewService.getMeta(parsed);
+      const page = this.previewService.getCardsPage(
+        parsed,
+        0,
+        PREVIEW_CARD_LIMIT,
+        ''
+      );
+      return {
+        deckCount: meta.decks.length,
+        decks: meta.decks.map((deck) => ({
+          id: deck.id,
+          name: deck.fullName,
+          cardCount: deck.cardCount,
+        })),
+        sampleCards: page.cards.map((card) => ({
+          front: card.front,
+          back: card.back,
+        })),
+      };
+    } catch {
+      return null;
+    }
+  }
+
   private async buildFile(input: ConvertInput): Promise<UploadedFile | null> {
     if (typeof input.text === 'string' && input.text.length > 0) {
       const buffer = Buffer.from(input.text, 'utf-8');
@@ -251,7 +287,9 @@ export class McpToolsService {
     }
   }
 
-  private mapUploadResult(res: CapturingResponse): ConvertResult {
+  private async mapUploadResult(
+    res: CapturingResponse
+  ): Promise<ConvertResult> {
     if (res.statusCode === 202 && this.isJobBody(res.body)) {
       return {
         kind: 'processing',
@@ -276,11 +314,12 @@ export class McpToolsService {
       const cardCount =
         cardCountHeader != null ? Number(cardCountHeader) : null;
       const filename = res.get('File-Name') ?? null;
+      const preview = await this.previewFromBytes(res.bodyBuffer, filename);
       const summary =
         cardCount != null
           ? `${cardCount} cards. Find it in your 2anki downloads.`
           : 'Deck ready. Find it in your 2anki downloads.';
-      return { kind: 'deck', cardCount, filename, summary };
+      return { kind: 'deck', cardCount, filename, ...preview, summary };
     }
     return {
       kind: 'error',


### PR DESCRIPTION
## What
Closes the convert→inspect gap found in the MCP connector smoke test: after converting text/markdown, an agent had no way to see the resulting deck.

## Why
A sync single-deck conversion (text/markdown → immediate `.apkg` bytes) is **never persisted as a job**, so it doesn't appear in `list_my_decks` and has no jobId for `get_deck_preview` (fixed for jobs in #3729). The agent got a filename it couldn't do anything with.

## How
`convert_to_deck` now parses the `.apkg` bytes it **already captured** on the sync path and returns the preview inline — `deckCount` + `decks` + a sample of cards — alongside the card count. No second call, no persistence needed. Preview parsing is **best-effort**: a parse failure still returns the deck (card count + filename), never fails the conversion. Media URLs are omitted (the sync deck isn't persisted, so there's no key to serve media from) — sample card text is what an agent needs.

The async/queued path (202 → jobId) is unchanged — those decks are in `list_my_decks` and previewable by jobId via #3729.

## Scope
MCP-only. `McpToolsService` is not imported outside `src/services/mcp/`; the web conversion path is untouched.

## Testing
Sync deck response now asserts the inline `deckCount`/`decks`/`sampleCards`; added a test that a preview parse failure still returns the deck (no preview fields, no thrown error). 44 MCP tests green; `tsc` clean; format clean.

## Trio note
Agent-facing JSON, no human UI or copy → designer N/A; pm already ruled this the right fix for the broken convert→inspect chain; engineer implemented.

## Goal alignment
Makes the MCP `convert_to_deck` tool self-sufficient for the beta connector — convert and see the result in one turn.

no changelog entry — `developer_access`-gated beta MCP tool, not user-visible.

Browser check: not applicable — server-only change, no web/src.