### PR TITLE
feat: MCP create_deck tool with deck persistence and download links

### DIFF
--- a/src/controllers/Upload/DropboxController.test.ts
+++ b/src/controllers/Upload/DropboxController.test.ts
@@ -39,6 +39,7 @@ function makeController(
     getLastReconvertibleUpload: jest.fn().mockResolvedValue(null),
     findByOwnerAndDedupeKey: jest.fn().mockResolvedValue(null),
     insertNativeDeck: jest.fn(),
+    insertConvertedDeck: jest.fn(),
   };
   const notionRepository: INotionRepository = {
     getNotionData: jest

--- a/src/controllers/Upload/GoogleDriveController.test.ts
+++ b/src/controllers/Upload/GoogleDriveController.test.ts
@@ -38,6 +38,7 @@ function makeController(
     getLastReconvertibleUpload: jest.fn().mockResolvedValue(null),
     findByOwnerAndDedupeKey: jest.fn().mockResolvedValue(null),
     insertNativeDeck: jest.fn(),
+    insertConvertedDeck: jest.fn(),
   };
   const notionRepository: INotionRepository = {
     getNotionData: jest

--- a/src/controllers/Upload/UploadController.test.ts
+++ b/src/controllers/Upload/UploadController.test.ts
@@ -86,6 +86,9 @@ describe('Upload file', () => {
       insertNativeDeck: function (): Promise<Uploads> {
         return Promise.reject(new Error('not implemented'));
       },
+      insertConvertedDeck: function (): Promise<Uploads> {
+        return Promise.reject(new Error('not implemented'));
+      },
     };
     const notionRepository: INotionRepository = {
       getNotionData: function (owner: string | number): Promise<NotionTokens> {
@@ -173,6 +176,7 @@ describe('Upload file — multer error handling', () => {
       getLastReconvertibleUpload: jest.fn().mockResolvedValue(null),
       findByOwnerAndDedupeKey: jest.fn().mockResolvedValue(null),
       insertNativeDeck: jest.fn(),
+      insertConvertedDeck: jest.fn(),
     };
     const notionRepository: INotionRepository = {
       getNotionData: jest.fn() as INotionRepository['getNotionData'],
@@ -232,6 +236,7 @@ describe('UploadController.retryPdfWithCredential rate limit', () => {
       getLastReconvertibleUpload: jest.fn().mockResolvedValue(null),
       findByOwnerAndDedupeKey: jest.fn().mockResolvedValue(null),
       insertNativeDeck: jest.fn(),
+      insertConvertedDeck: jest.fn(),
     };
     const notionRepository: INotionRepository = {
       getNotionData: jest.fn() as INotionRepository['getNotionData'],
@@ -312,6 +317,7 @@ describe('UploadController.retryPdfWithCredential rate limit', () => {
       getLastReconvertibleUpload: jest.fn().mockResolvedValue(null),
       findByOwnerAndDedupeKey: jest.fn().mockResolvedValue(null),
       insertNativeDeck: jest.fn(),
+      insertConvertedDeck: jest.fn(),
     };
     const notionRepository: INotionRepository = {
       getNotionData: jest.fn() as INotionRepository['getNotionData'],

--- a/src/data_layer/UploadRespository.ts
+++ b/src/data_layer/UploadRespository.ts
@@ -21,6 +21,14 @@ export interface NativeDeckInsert {
   dedupe_key: string | null;
 }
 
+export interface ConvertedDeckInsert {
+  owner: number;
+  object_id: string;
+  key: string;
+  filename: string;
+  size_mb: number;
+}
+
 export interface IUploadRepository {
   deleteUpload(owner: number, key: string): Promise<number>;
   getUploadsByOwner(owner: number): Promise<Uploads[]>;
@@ -46,6 +54,7 @@ export interface IUploadRepository {
     dedupeKey: string
   ): Promise<Uploads | null>;
   insertNativeDeck(row: NativeDeckInsert): Promise<Uploads>;
+  insertConvertedDeck(row: ConvertedDeckInsert): Promise<Uploads>;
 }
 class UploadRepository implements IUploadRepository {
   private readonly table = 'uploads';
@@ -182,6 +191,20 @@ class UploadRepository implements IUploadRepository {
         object_id: null,
         source: 'app',
         dedupe_key: row.dedupe_key,
+      })
+      .returning('*');
+    return inserted;
+  }
+
+  async insertConvertedDeck(row: ConvertedDeckInsert): Promise<Uploads> {
+    const [inserted] = await this.database<Uploads>(this.table)
+      .insert({
+        owner: row.owner,
+        object_id: row.object_id,
+        key: row.key,
+        filename: row.filename,
+        size_mb: row.size_mb,
+        source: 'app',
       })
       .returning('*');
     return inserted;

--- a/src/routes/McpRouter.ts
+++ b/src/routes/McpRouter.ts
@@ -20,6 +20,7 @@ import ApkgPreviewService from '../services/ApkgPreviewService/ApkgPreviewServic
 import AuthenticationService from '../services/AuthenticationService';
 import { KnexOAuthProvider } from '../services/mcp/oauth/KnexOAuthProvider';
 import { McpToolsService } from '../services/mcp/McpToolsService';
+import { McpDeckPersistence } from '../services/mcp/McpDeckPersistence';
 import { buildMcpServer } from '../services/mcp/McpServerFactory';
 import { applyUserLocals } from './middleware/configureUserLocal';
 import { getEventsSink } from '../services/events/eventsSinkInstance';
@@ -62,12 +63,18 @@ const McpRouter = () => {
     new ConversionOutputStatsRepository(database),
     new ParsePathSignatureRepository(database)
   );
+  const storage = new StorageHandler();
   const toolsService = new McpToolsService(
     new JobRepository(database),
     new DownloadService(new DownloadRepository(database)),
     new ApkgPreviewService(),
     (req, res) => uploadService.handleUpload(req, res),
-    new StorageHandler()
+    storage,
+    new McpDeckPersistence(
+      new JobRepository(database),
+      new UploadRepository(database),
+      storage
+    )
   );
 
   const onAuthenticatedPost: RequestHandler = async (req, res) => {

--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -109,6 +109,8 @@ function buildRepository(): IUploadRepository {
       Promise.resolve(null),
     insertNativeDeck: () =>
       Promise.reject(new Error('not implemented')) as Promise<Uploads>,
+    insertConvertedDeck: () =>
+      Promise.reject(new Error('not implemented')) as Promise<Uploads>,
   };
 }
 

--- a/src/services/mcp/McpDeckPersistence.test.ts
+++ b/src/services/mcp/McpDeckPersistence.test.ts
@@ -1,0 +1,45 @@
+import { McpDeckPersistence } from './McpDeckPersistence';
+import type JobRepository from '../../data_layer/JobRepository';
+import type { IUploadRepository } from '../../data_layer/UploadRespository';
+import type StorageHandler from '../../lib/storage/StorageHandler';
+
+describe('McpDeckPersistence', () => {
+  it('creates a done job, uploads the bytes, and records the upload row', async () => {
+    const create = jest.fn(async () => undefined);
+    const updateJobStatus = jest.fn(async () => ({}) as never);
+    const jobRepository = {
+      create,
+      updateJobStatus,
+    } as unknown as JobRepository;
+
+    const insertConvertedDeck = jest.fn(async () => ({}) as never);
+    const uploadRepository = {
+      insertConvertedDeck,
+    } as unknown as IUploadRepository;
+
+    const uniqify = jest.fn(() => 'owner-9-1700-deck.apkg');
+    const uploadFile = jest.fn(async () => undefined);
+    const storage = { uniqify, uploadFile } as unknown as StorageHandler;
+
+    const persistence = new McpDeckPersistence(
+      jobRepository,
+      uploadRepository,
+      storage
+    );
+    const bytes = Buffer.from('APKG');
+    const key = await persistence.persist('9', 'obj-1', 'Pharmacology', bytes);
+
+    expect(key).toBe('owner-9-1700-deck.apkg');
+    expect(create).toHaveBeenCalledWith('obj-1', '9', 'Pharmacology', 'mcp');
+    expect(updateJobStatus).toHaveBeenCalledWith('obj-1', '9', 'done', '');
+    expect(uploadFile).toHaveBeenCalledWith('owner-9-1700-deck.apkg', bytes);
+    expect(insertConvertedDeck).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 9,
+        object_id: 'obj-1',
+        key: 'owner-9-1700-deck.apkg',
+        filename: 'Pharmacology',
+      })
+    );
+  });
+});

--- a/src/services/mcp/McpDeckPersistence.ts
+++ b/src/services/mcp/McpDeckPersistence.ts
@@ -1,0 +1,43 @@
+import JobRepository from '../../data_layer/JobRepository';
+import { IUploadRepository } from '../../data_layer/UploadRespository';
+import StorageHandler from '../../lib/storage/StorageHandler';
+import { DECK_NAME_SUFFIX } from '../../lib/anki/format';
+import { BytesToMegaBytes } from '../../lib/misc/file';
+
+export interface DeckPersistence {
+  persist(
+    owner: string,
+    objectId: string,
+    title: string,
+    bytes: Buffer
+  ): Promise<string>;
+}
+
+export class McpDeckPersistence implements DeckPersistence {
+  constructor(
+    private readonly jobRepository: JobRepository,
+    private readonly uploadRepository: IUploadRepository,
+    private readonly storage: StorageHandler
+  ) {}
+
+  async persist(
+    owner: string,
+    objectId: string,
+    title: string,
+    bytes: Buffer
+  ): Promise<string> {
+    await this.jobRepository.create(objectId, owner, title, 'mcp');
+    await this.jobRepository.updateJobStatus(objectId, owner, 'done', '');
+
+    const key = this.storage.uniqify(objectId, owner, 200, DECK_NAME_SUFFIX);
+    await this.storage.uploadFile(key, bytes);
+    await this.uploadRepository.insertConvertedDeck({
+      owner: Number(owner),
+      object_id: objectId,
+      key,
+      filename: title,
+      size_mb: BytesToMegaBytes(bytes.byteLength),
+    });
+    return key;
+  }
+}

--- a/src/services/mcp/McpServerFactory.test.ts
+++ b/src/services/mcp/McpServerFactory.test.ts
@@ -13,13 +13,14 @@ describe('buildMcpServer', () => {
     expect(() => buildMcpServer(buildContext())).not.toThrow();
   });
 
-  it('registers the three tools on the real MCP server', () => {
+  it('registers the four tools on the real MCP server', () => {
     const server = buildMcpServer(buildContext());
     const registered = (
       server as unknown as { _registeredTools: Record<string, unknown> }
     )._registeredTools;
     expect(Object.keys(registered).sort()).toEqual([
       'convert_to_deck',
+      'create_deck',
       'get_deck_preview',
       'list_my_decks',
     ]);

--- a/src/services/mcp/McpServerFactory.ts
+++ b/src/services/mcp/McpServerFactory.ts
@@ -139,6 +139,49 @@ export function buildMcpServer(context: McpRequestContext): McpServer {
       context.recordToolCall('convert_to_deck');
       const result = await context.toolsService.convertToDeck(
         { url, text, filename },
+        context.owner,
+        context.locals
+      );
+      if (result.kind === 'error') {
+        return errorResult(result.message);
+      }
+      return textResult(result);
+    }
+  );
+
+  registerTool<{ cards: { front: string; back: string }[]; deckName?: string }>(
+    server,
+    'create_deck',
+    {
+      title: 'Create an Anki deck from cards',
+      description:
+        'Build an Anki deck from structured front/back cards. Returns a deck preview and a no-login download link for the .apkg, plus a job id you can find later with list_my_decks.',
+      inputSchema: {
+        cards: z
+          .array(
+            z.object({
+              front: z
+                .string()
+                .min(1)
+                .describe('The question or prompt shown first.'),
+              back: z.string().describe('The answer shown after.'),
+            })
+          )
+          .min(1)
+          .max(500)
+          .describe('The Basic front/back cards to put in the deck.'),
+        deckName: z
+          .string()
+          .optional()
+          .describe('Optional deck name, e.g. Pharmacology.'),
+      },
+    },
+    async ({ cards, deckName }) => {
+      context.recordToolCall('create_deck');
+      const result = await context.toolsService.createDeck(
+        cards,
+        deckName,
+        context.owner,
         context.locals
       );
       if (result.kind === 'error') {

--- a/src/services/mcp/McpToolsService.test.ts
+++ b/src/services/mcp/McpToolsService.test.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 
 import { McpToolsService, UploadEntrypoint } from './McpToolsService';
+import { DeckPersistence } from './McpDeckPersistence';
 import { JobWithDownloadKey } from '../../data_layer/JobRepository';
 import ApkgPreviewService from '../ApkgPreviewService/ApkgPreviewService';
 import DownloadService from '../DownloadService';
@@ -11,6 +12,8 @@ function makeService(overrides: {
   uploadEntry?: UploadEntrypoint;
   getFileBody?: DownloadService['getFileBody'];
   preview?: Partial<ApkgPreviewService>;
+  persist?: DeckPersistence['persist'];
+  getPresignedUrl?: StorageHandler['getPresignedUrl'];
 }) {
   const jobLister = {
     getJobsByOwner: jest.fn(async () => overrides.jobs ?? []),
@@ -36,14 +39,23 @@ function makeService(overrides: {
     ((_req: express.Request, res: express.Response) => {
       res.status(200);
     });
+  const persist = jest.fn(
+    overrides.persist ?? (async () => 'owner-9-123-deck.apkg')
+  );
+  const deckPersistence = { persist } as unknown as DeckPersistence;
+  const getPresignedUrl = jest.fn(
+    overrides.getPresignedUrl ?? (async () => 'https://s3.example/presigned')
+  );
+  const storage = { getPresignedUrl } as unknown as StorageHandler;
   const service = new McpToolsService(
     jobLister,
     downloadService,
     previewService,
     uploadEntry,
-    {} as unknown as StorageHandler
+    storage,
+    deckPersistence
   );
-  return { service, jobLister, downloadService };
+  return { service, jobLister, downloadService, persist, getPresignedUrl };
 }
 
 describe('McpToolsService.listMyDecks', () => {
@@ -145,14 +157,12 @@ describe('McpToolsService.convertToDeck', () => {
     const uploadEntry: UploadEntrypoint = (_req, res) => {
       res.status(202).json({ jobId: 'job-async' });
     };
-    const { service } = makeService({ uploadEntry });
-    const result = await service.convertToDeck(
-      { text: '# hi' },
-      {
-        owner: 'o',
-      }
-    );
+    const { service, persist } = makeService({ uploadEntry });
+    const result = await service.convertToDeck({ text: '# hi' }, 'owner', {
+      owner: 'o',
+    });
     expect(result).toMatchObject({ kind: 'processing', jobId: 'job-async' });
+    expect(persist).not.toHaveBeenCalled();
   });
 
   it('maps a batch response to download URLs', async () => {
@@ -165,7 +175,7 @@ describe('McpToolsService.convertToDeck', () => {
       });
     };
     const { service } = makeService({ uploadEntry });
-    const result = await service.convertToDeck({ text: 'x' }, {});
+    const result = await service.convertToDeck({ text: 'x' }, 'owner', {});
     expect(result).toEqual({
       kind: 'batch',
       deckCount: 1,
@@ -174,22 +184,31 @@ describe('McpToolsService.convertToDeck', () => {
     });
   });
 
-  it('maps a single-deck byte response to a card-count summary with an inline preview', async () => {
+  it('persists a single-deck byte response and returns a jobId + presigned download URL', async () => {
     const uploadEntry: UploadEntrypoint = (_req, res) => {
       res.set('X-Card-Count', '42');
       res.set('File-Name', 'deck.apkg');
       res.status(200).send(Buffer.from('APKG-BYTES'));
     };
-    const { service } = makeService({ uploadEntry });
-    const result = await service.convertToDeck({ text: 'x' }, {});
+    const { service, persist, getPresignedUrl } = makeService({ uploadEntry });
+    const result = await service.convertToDeck({ text: 'x' }, 'owner-9', {});
     expect(result).toMatchObject({
       kind: 'deck',
       cardCount: 42,
       filename: 'deck.apkg',
+      downloadUrl: 'https://s3.example/presigned',
       deckCount: 1,
       decks: [{ id: 1, name: 'Bio', cardCount: 3 }],
       sampleCards: [{ front: 'Q', back: 'A' }],
     });
+    expect((result as { jobId?: string }).jobId).toEqual(expect.any(String));
+    expect(persist).toHaveBeenCalledWith(
+      'owner-9',
+      expect.any(String),
+      'deck.apkg',
+      Buffer.from('APKG-BYTES')
+    );
+    expect(getPresignedUrl).toHaveBeenCalledWith('owner-9-123-deck.apkg');
   });
 
   it('still returns the deck when inline preview parsing fails', async () => {
@@ -206,26 +225,145 @@ describe('McpToolsService.convertToDeck', () => {
         }),
       },
     });
-    const result = await service.convertToDeck({ text: 'x' }, {});
+    const result = await service.convertToDeck({ text: 'x' }, 'owner', {});
     expect(result).toMatchObject({ kind: 'deck', cardCount: 7 });
     expect((result as { decks?: unknown }).decks).toBeUndefined();
   });
 
   it('returns an error result when neither url nor text is given', async () => {
-    const { service } = makeService({});
-    const result = await service.convertToDeck({}, {});
+    const { service, persist } = makeService({});
+    const result = await service.convertToDeck({}, 'owner', {});
     expect(result).toMatchObject({ kind: 'error' });
+    expect(persist).not.toHaveBeenCalled();
   });
 
   it('surfaces the upload error message on a 400', async () => {
     const uploadEntry: UploadEntrypoint = (_req, res) => {
       res.status(400).json({ message: 'This file type is not supported.' });
     };
-    const { service } = makeService({ uploadEntry });
-    const result = await service.convertToDeck({ text: 'x' }, {});
+    const { service, persist } = makeService({ uploadEntry });
+    const result = await service.convertToDeck({ text: 'x' }, 'owner', {});
     expect(result).toEqual({
       kind: 'error',
       message: 'This file type is not supported.',
     });
+    expect(persist).not.toHaveBeenCalled();
+  });
+});
+
+describe('McpToolsService.createDeck', () => {
+  const captureUpload = (): {
+    entry: UploadEntrypoint;
+    markdown: () => string;
+  } => {
+    let captured = '';
+    const entry: UploadEntrypoint = (req, res) => {
+      const files = (req as unknown as { files: { buffer: Buffer }[] }).files;
+      captured = files[0].buffer.toString('utf-8');
+      res.set('X-Card-Count', '2');
+      res.set('File-Name', 'deck.apkg');
+      res.status(200).send(Buffer.from('APKG-BYTES'));
+    };
+    return { entry, markdown: () => captured };
+  };
+
+  it('serializes cards to heading markdown, persists, and returns a download URL', async () => {
+    const { entry, markdown } = captureUpload();
+    const { service, persist, getPresignedUrl } = makeService({
+      uploadEntry: entry,
+    });
+    const result = await service.createDeck(
+      [
+        { front: 'What is ATP?', back: 'Energy currency.' },
+        { front: 'What is DNA?', back: 'Heredity molecule.' },
+      ],
+      'Biochemistry',
+      'owner-9',
+      {}
+    );
+    expect(markdown()).toBe(
+      '## What is ATP?\n\nEnergy currency.\n\n' +
+        '## What is DNA?\n\nHeredity molecule.\n\n'
+    );
+    expect(result).toMatchObject({
+      kind: 'deck',
+      cardCount: 2,
+      downloadUrl: 'https://s3.example/presigned',
+    });
+    expect((result as { jobId?: string }).jobId).toEqual(expect.any(String));
+    expect(persist).toHaveBeenCalledWith(
+      'owner-9',
+      expect.any(String),
+      'deck.apkg',
+      Buffer.from('APKG-BYTES')
+    );
+    expect(getPresignedUrl).toHaveBeenCalled();
+  });
+
+  it('falls back to the card count when the pipeline reports none', async () => {
+    const entry: UploadEntrypoint = (_req, res) => {
+      res.set('File-Name', 'deck.apkg');
+      res.status(200).send(Buffer.from('APKG-BYTES'));
+    };
+    const { service } = makeService({ uploadEntry: entry });
+    const result = await service.createDeck(
+      [
+        { front: 'A', back: 'alpha' },
+        { front: 'B', back: 'beta' },
+        { front: 'C', back: 'gamma' },
+      ],
+      undefined,
+      'owner-9',
+      {}
+    );
+    expect(result).toMatchObject({ kind: 'deck', cardCount: 3 });
+  });
+
+  it('names the upload file from the deck name', async () => {
+    let uploadedName = '';
+    const entry: UploadEntrypoint = (req, res) => {
+      const files = (req as unknown as { files: { originalname: string }[] })
+        .files;
+      uploadedName = files[0].originalname;
+      res.status(200).send(Buffer.from('APKG-BYTES'));
+    };
+    const { service } = makeService({ uploadEntry: entry });
+    await service.createDeck(
+      [{ front: 'Q', back: 'A' }],
+      'Pharmacology',
+      'owner-9',
+      {}
+    );
+    expect(uploadedName).toBe('Pharmacology.md');
+  });
+
+  it('rejects an empty cards array without touching persistence', async () => {
+    const { service, persist } = makeService({});
+    const result = await service.createDeck([], 'Deck', 'owner-9', {});
+    expect(result).toMatchObject({ kind: 'error' });
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  it('rejects a card with an empty front', async () => {
+    const { service, persist } = makeService({});
+    const result = await service.createDeck(
+      [{ front: '   ', back: 'answer' }],
+      'Deck',
+      'owner-9',
+      {}
+    );
+    expect(result).toMatchObject({ kind: 'error' });
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  it('rejects more than 500 cards', async () => {
+    const { service, persist } = makeService({});
+    const cards = Array.from({ length: 501 }, (_v, i) => ({
+      front: `Q${i}`,
+      back: `A${i}`,
+    }));
+    const result = await service.createDeck(cards, 'Deck', 'owner-9', {});
+    expect(result).toMatchObject({ kind: 'error' });
+    expect(persist).not.toHaveBeenCalled();
   });
 });

--- a/src/services/mcp/McpToolsService.ts
+++ b/src/services/mcp/McpToolsService.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import { randomUUID } from 'node:crypto';
 
 import { JobWithDownloadKey } from '../../data_layer/JobRepository';
 import ApkgPreviewService from '../ApkgPreviewService/ApkgPreviewService';
@@ -6,11 +7,15 @@ import DownloadService from '../DownloadService';
 import StorageHandler from '../../lib/storage/StorageHandler';
 import instrumentedAxios from '../observability/instrumentedAxios';
 import { getSafeFilename } from '../../lib/getSafeFilename';
+import { DeckPersistence } from './McpDeckPersistence';
+import { McpCard, serializeCardsToMarkdown } from './serializeCardsToMarkdown';
 
 const APKG_KEY_PATTERN = /\.apkg$/i;
 const MAX_TEXT_BYTES = 5 * 1024 * 1024;
 const MAX_URL_BYTES = 100 * 1024 * 1024;
 const PREVIEW_CARD_LIMIT = 20;
+const MAX_CARDS = 500;
+const DEFAULT_DECK_NAME = 'MCP deck';
 
 export interface DeckSummary {
   jobId: string;
@@ -37,8 +42,10 @@ export type ConvertResult =
     }
   | {
       kind: 'deck';
+      jobId?: string;
       cardCount: number | null;
       filename: string | null;
+      downloadUrl?: string;
       deckCount?: number;
       decks?: { id: number; name: string; cardCount: number }[];
       sampleCards?: { front: string; back: string }[];
@@ -134,7 +141,8 @@ export class McpToolsService {
     private readonly downloadService: DownloadService,
     private readonly previewService: ApkgPreviewService,
     private readonly uploadEntry: UploadEntrypoint,
-    private readonly storage: StorageHandler
+    private readonly storage: StorageHandler,
+    private readonly deckPersistence: DeckPersistence
   ) {}
 
   async listMyDecks(owner: string): Promise<DeckSummary[]> {
@@ -198,6 +206,7 @@ export class McpToolsService {
 
   async convertToDeck(
     input: ConvertInput,
+    owner: string,
     locals: Record<string, unknown>
   ): Promise<ConvertResult> {
     const file = await this.buildFile(input);
@@ -207,7 +216,60 @@ export class McpToolsService {
         message: 'Provide either a url or text to convert.',
       };
     }
+    const res = await this.runUpload(file, locals);
+    return this.mapUploadResult(res, owner, file.originalname);
+  }
 
+  async createDeck(
+    cards: McpCard[],
+    deckName: string | undefined,
+    owner: string,
+    locals: Record<string, unknown>
+  ): Promise<ConvertResult> {
+    if (!Array.isArray(cards) || cards.length === 0) {
+      return { kind: 'error', message: 'Provide at least 1 card.' };
+    }
+    if (cards.length > MAX_CARDS) {
+      return {
+        kind: 'error',
+        message: `Too many cards — the limit is ${MAX_CARDS}. Split into smaller decks.`,
+      };
+    }
+    if (cards.some((card) => card.front == null || card.front.trim() === '')) {
+      return { kind: 'error', message: 'Every card needs a non-empty front.' };
+    }
+
+    const title =
+      deckName != null && deckName.trim().length > 0
+        ? deckName.trim()
+        : DEFAULT_DECK_NAME;
+    const markdown = serializeCardsToMarkdown(cards);
+    const buffer = Buffer.from(markdown, 'utf-8');
+    if (buffer.byteLength > MAX_TEXT_BYTES) {
+      return {
+        kind: 'error',
+        message:
+          'These cards are over the 5 MB limit. Split into smaller decks.',
+      };
+    }
+
+    const file: UploadedFile = {
+      originalname: getSafeFilename(`${title}.md`),
+      size: buffer.byteLength,
+      buffer,
+    };
+    const res = await this.runUpload(file, locals);
+    const result = await this.mapUploadResult(res, owner, title);
+    if (result.kind === 'deck' && result.cardCount == null) {
+      return { ...result, cardCount: cards.length };
+    }
+    return result;
+  }
+
+  private async runUpload(
+    file: UploadedFile,
+    locals: Record<string, unknown>
+  ): Promise<CapturingResponse> {
     const req = {
       files: [file],
       body: {},
@@ -217,7 +279,7 @@ export class McpToolsService {
     const res = new CapturingResponse(req);
     res.locals = locals;
     await this.uploadEntry(req, res as unknown as express.Response);
-    return this.mapUploadResult(res);
+    return res;
   }
 
   private async previewFromBytes(
@@ -288,7 +350,9 @@ export class McpToolsService {
   }
 
   private async mapUploadResult(
-    res: CapturingResponse
+    res: CapturingResponse,
+    owner: string,
+    fallbackTitle: string
   ): Promise<ConvertResult> {
     if (res.statusCode === 202 && this.isJobBody(res.body)) {
       return {
@@ -310,20 +374,45 @@ export class McpToolsService {
       };
     }
     if (res.statusCode === 200 && res.bodyBuffer != null) {
-      const cardCountHeader = res.get('X-Card-Count');
-      const cardCount =
-        cardCountHeader != null ? Number(cardCountHeader) : null;
-      const filename = res.get('File-Name') ?? null;
-      const preview = await this.previewFromBytes(res.bodyBuffer, filename);
-      const summary =
-        cardCount != null
-          ? `${cardCount} cards. Find it in your 2anki downloads.`
-          : 'Deck ready. Find it in your 2anki downloads.';
-      return { kind: 'deck', cardCount, filename, ...preview, summary };
+      return this.persistDeckResult(res.bodyBuffer, res, owner, fallbackTitle);
     }
     return {
       kind: 'error',
       message: this.errorMessage(res.body),
+    };
+  }
+
+  private async persistDeckResult(
+    bytes: Buffer,
+    res: CapturingResponse,
+    owner: string,
+    fallbackTitle: string
+  ): Promise<ConvertResult> {
+    const cardCountHeader = res.get('X-Card-Count');
+    const cardCount = cardCountHeader != null ? Number(cardCountHeader) : null;
+    const filename = res.get('File-Name') ?? null;
+    const title = filename ?? fallbackTitle;
+    const objectId = randomUUID();
+    const key = await this.deckPersistence.persist(
+      owner,
+      objectId,
+      title,
+      bytes
+    );
+    const downloadUrl = await this.storage.getPresignedUrl(key);
+    const preview = await this.previewFromBytes(bytes, filename);
+    const summary =
+      cardCount != null
+        ? `${cardCount} cards. Ready to download.`
+        : 'Deck ready to download.';
+    return {
+      kind: 'deck',
+      jobId: objectId,
+      cardCount,
+      filename,
+      downloadUrl,
+      ...preview,
+      summary,
     };
   }
 

--- a/src/services/mcp/serializeCardsToMarkdown.test.ts
+++ b/src/services/mcp/serializeCardsToMarkdown.test.ts
@@ -1,0 +1,104 @@
+import { serializeCardsToMarkdown } from './serializeCardsToMarkdown';
+import { guessMarkdownCards } from '../../lib/parser/guessMarkdownCards';
+
+function parseCards(markdown: string) {
+  const result = guessMarkdownCards(markdown);
+  return { format: result?.formatDetected, notes: result?.notes ?? [] };
+}
+
+describe('serializeCardsToMarkdown', () => {
+  it('emits one heading-body block per card', () => {
+    const markdown = serializeCardsToMarkdown([
+      { front: 'What is ATP?', back: 'The energy currency of the cell.' },
+      { front: 'What is DNA?', back: 'The molecule of heredity.' },
+    ]);
+    expect(markdown).toBe(
+      '## What is ATP?\n\nThe energy currency of the cell.\n\n' +
+        '## What is DNA?\n\nThe molecule of heredity.\n\n'
+    );
+  });
+
+  it('parses back into the same number of cards via the heading heuristic', () => {
+    const cards = [
+      { front: 'A', back: 'alpha' },
+      { front: 'B', back: 'beta' },
+      { front: 'C', back: 'gamma' },
+    ];
+    const { format, notes } = parseCards(serializeCardsToMarkdown(cards));
+    expect(format).toBe('heading-body');
+    expect(notes).toHaveLength(3);
+  });
+
+  it('flattens a multi-line front into a single heading line', () => {
+    const markdown = serializeCardsToMarkdown([
+      { front: 'Line one\nLine two\r\nLine three', back: 'answer' },
+    ]);
+    expect(markdown).toBe('## Line one Line two Line three\n\nanswer\n\n');
+    const { notes } = parseCards(markdown);
+    expect(notes).toHaveLength(1);
+    expect(notes[0].name).toContain('Line one Line two Line three');
+  });
+
+  it('renders markdown in the front and back', () => {
+    const markdown = serializeCardsToMarkdown([
+      { front: 'Bold **term**', back: 'A list:\n\n- one\n- two' },
+    ]);
+    const { notes } = parseCards(markdown);
+    expect(notes).toHaveLength(1);
+    expect(notes[0].name).toContain('<strong>term</strong>');
+    expect(notes[0].back).toContain('<li>one</li>');
+  });
+
+  it('keeps a card body containing :: as one card, not a colon split', () => {
+    const { format, notes } = parseCards(
+      serializeCardsToMarkdown([
+        { front: 'Anki hierarchy', back: 'Parent::Child is a subdeck path.' },
+      ])
+    );
+    expect(format).toBe('heading-body');
+    expect(notes).toHaveLength(1);
+    expect(notes[0].back).toContain('Parent::Child');
+  });
+
+  it('keeps a card body containing Q: as one card, not a QA split', () => {
+    const { format, notes } = parseCards(
+      serializeCardsToMarkdown([
+        { front: 'Study tip', back: 'Q: is a common flashcard prefix.' },
+      ])
+    );
+    expect(format).toBe('heading-body');
+    expect(notes).toHaveLength(1);
+  });
+
+  it('neutralizes a <details> block in the body so it does not pre-empt', () => {
+    const markdown = serializeCardsToMarkdown([
+      {
+        front: 'First card',
+        back: '<details><summary>Hint</summary>Secret</details>',
+      },
+      { front: 'Second card', back: 'Plain answer' },
+    ]);
+    expect(markdown).not.toMatch(/<details/i);
+    const { format, notes } = parseCards(markdown);
+    expect(format).toBe('heading-body');
+    expect(notes).toHaveLength(2);
+  });
+
+  it('escapes a markdown heading inside the body so it does not split the card', () => {
+    const markdown = serializeCardsToMarkdown([
+      { front: 'Outline', back: '## Overview\nSome detail' },
+      { front: 'Next', back: 'Done' },
+    ]);
+    const { notes } = parseCards(markdown);
+    expect(notes).toHaveLength(2);
+  });
+
+  it('escapes a leading heading in the front so it stays a single heading', () => {
+    const markdown = serializeCardsToMarkdown([
+      { front: '## Already a heading', back: 'answer' },
+    ]);
+    const { notes } = parseCards(markdown);
+    expect(notes).toHaveLength(1);
+    expect(markdown.startsWith('## \\## Already a heading')).toBe(true);
+  });
+});

--- a/src/services/mcp/serializeCardsToMarkdown.ts
+++ b/src/services/mcp/serializeCardsToMarkdown.ts
@@ -1,0 +1,32 @@
+export interface McpCard {
+  front: string;
+  back: string;
+}
+
+function escapeDetailsTags(text: string): string {
+  return text.replace(/<(\/?)(details|summary)\b/gi, '&lt;$1$2');
+}
+
+function escapeLeadingHeadings(text: string): string {
+  return text.replace(/^(#+)/gm, '\\$1');
+}
+
+function flattenFront(front: string): string {
+  const oneLine = front
+    .replace(/[\r\n]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return escapeLeadingHeadings(escapeDetailsTags(oneLine));
+}
+
+function guardBack(back: string): string {
+  return escapeLeadingHeadings(escapeDetailsTags(back.trim()));
+}
+
+export function serializeCardsToMarkdown(cards: McpCard[]): string {
+  return cards
+    .map(
+      (card) => `## ${flattenFront(card.front)}\n\n${guardBack(card.back)}\n\n`
+    )
+    .join('');
+}

--- a/src/usecases/jobs/BuildDeckForJobUseCase.test.ts
+++ b/src/usecases/jobs/BuildDeckForJobUseCase.test.ts
@@ -38,6 +38,7 @@ function buildUploadRepository(): jest.Mocked<IUploadRepository> {
     getLastReconvertibleUpload: jest.fn().mockResolvedValue(null),
     findByOwnerAndDedupeKey: jest.fn().mockResolvedValue(null),
     insertNativeDeck: jest.fn(),
+    insertConvertedDeck: jest.fn(),
   };
 }
 

--- a/src/usecases/ops/SendInactivityWarningsUseCase.test.ts
+++ b/src/usecases/ops/SendInactivityWarningsUseCase.test.ts
@@ -47,6 +47,7 @@ function makeUploadRepo(
     getLastReconvertibleUpload: jest.fn().mockResolvedValue(null),
     findByOwnerAndDedupeKey: jest.fn().mockResolvedValue(null),
     insertNativeDeck: jest.fn(),
+    insertConvertedDeck: jest.fn(),
   };
 }
 

--- a/src/usecases/ops/SendInactivityWarningsUseCase.ts
+++ b/src/usecases/ops/SendInactivityWarningsUseCase.ts
@@ -41,6 +41,11 @@ class NoOpUploadRepository implements IUploadRepository {
       new Error('NoOpUploadRepository does not support insertNativeDeck')
     );
   }
+  insertConvertedDeck(): Promise<never> {
+    return Promise.reject(
+      new Error('NoOpUploadRepository does not support insertConvertedDeck')
+    );
+  }
 }
 
 export class SendInactivityWarningsUseCase {

--- a/src/usecases/uploads/SaveNativeDeckUseCase.test.ts
+++ b/src/usecases/uploads/SaveNativeDeckUseCase.test.ts
@@ -15,6 +15,7 @@ function makeRepository(): jest.Mocked<IUploadRepository> {
     getLastReconvertibleUpload: jest.fn(),
     findByOwnerAndDedupeKey: jest.fn(),
     insertNativeDeck: jest.fn(),
+    insertConvertedDeck: jest.fn(),
   };
 }
 


### PR DESCRIPTION
## What
Adds a new `create_deck` MCP tool that turns structured Basic front/back cards into an Anki deck, persists the built `.apkg`, and returns a deck preview plus a short-lived no-login download link — the foundation of the chat-to-deck loop inside claude.ai. Also closes a persistence gap in the existing `convert_to_deck` sync path.

## Why
For a world-class MCP connector, a user should be able to say "make flashcards," have Claude call `create_deck`, and get back a preview + a downloadable `.apkg` without leaving the chat. Until now the MCP tools could preview and list decks, but a synchronously-built deck was never persisted — it had no download and never showed in `list_my_decks`. This PR makes a built deck a first-class, retrievable artifact.

## How
- **`serializeCardsToMarkdown`** (new, pure, unit-tested): serializes each card to a `## {front}\n\n{back}` heading-body block. Guards the parser precedence so the heading heuristic always wins — flattens multi-line fronts to one line, escapes leading `#` runs so a body heading can't split a card, and neutralizes `<details>/<summary>` tags so the details pattern can't pre-empt. `Q:` / `::` bodies are safe because heading-body runs before those patterns.
- **`McpDeckPersistence`** (new, injected via constructor): mirrors the `BuildDeckForJobUseCase` pattern — inserts a `jobs` row (`type: 'mcp'`, status `done`), `storage.uniqify` → `storage.uploadFile`, then an `uploads` row keyed on the same `object_id`. The `jobs`+`uploads` join on `object_id` is what makes the deck appear in `list_my_decks`. No knex in the service; a new `UploadRepository.insertConvertedDeck` owns the SQL.
- **`McpToolsService.createDeck`**: validates (non-empty array, ≤500 cards, non-empty fronts, ≤5 MB serialized), reuses the shared `runUpload` + `CapturingResponse` capture step, then persists via `persistDeckResult` and returns `{ kind: 'deck', jobId, cardCount, preview, downloadUrl }`.
- **`convert_to_deck` fix**: its 200-byte sync path now runs through the same `persistDeckResult`, so a sync conversion also gets a `jobId` + `downloadUrl` and shows in `list_my_decks`. The async 202/job path already persisted and is untouched.
- **Download link**: `storage.getPresignedUrl(key)` (3600s), no new route/token/migration.

**No schema change** — reuses existing `jobs` and `uploads` tables; no migration, no kanel.

**No LLM/cost impact** — this PR adds no Anthropic/Claude calls and does not touch Notion export processing. Latency is the existing conversion pipeline plus one S3 put + one presign.

**Files/methods touched (for the follow-up options PR to coordinate):**
- `McpServerFactory.ts` — registers `create_deck` (zod schema `{ cards, deckName? }`); passes `owner` into the `convert_to_deck` call.
- `McpToolsService.ts` — new `createDeck`, `runUpload`, `persistDeckResult`; `convertToDeck(input, owner, locals)` signature; `ConvertResult` 'deck' variant gains `jobId?` + `downloadUrl?`.
- `McpDeckPersistence.ts` (new), `serializeCardsToMarkdown.ts` (new).
- `UploadRespository.ts` — `insertConvertedDeck` + `ConvertedDeckInsert`.
- `McpRouter.ts` — wires `McpDeckPersistence`.

## Measuring success
- Adoption: the `mcp_tool_called` event fires with `props.tool = 'create_deck'` on every call (recorded first in the handler) — read at `/api/ops/metrics`. Day-7 prod check: is `create_deck` being called, and does each call produce an `uploads` row (query `uploads` where the matching `jobs.type = 'mcp'`)?
- Correctness: a `create_deck` call should produce a job visible in `list_my_decks` with a working `downloadUrl`.

## Testing
- Unit tests added:
  - `serializeCardsToMarkdown.test.ts` — heading-body shape, round-trips to N cards via `guessMarkdownCards`, multi-line front flatten, markdown rendering, and the `::` / `Q:` / `<details>` / body-heading / front-heading guards.
  - `McpDeckPersistence.test.ts` — asserts the job create + done, `uploadFile`, and `insertConvertedDeck` call args and the returned key.
  - `McpToolsService.test.ts` — `createDeck` success (markdown + persist args + presigned URL), card-count fallback, filename-from-deck-name, and empty/empty-front/>500 rejections; `convert_to_deck` now asserts the sync path persists + returns a presigned URL, and that non-deck paths never persist.
- Full server `tsc -p . --noEmit` green (interface change swept across all `IUploadRepository` mocks + the `NoOpUploadRepository`). MCP + affected Upload/UploadService/BuildDeck/SendInactivity/SaveNativeDeck suites green. `pnpm format:check` (tree-wide) green. `pnpm lint` exit 0. `pnpm arch` 0 errors.
- **e2e (real genanki `.apkg` build) verifies in prod after merge** — the Python venv doesn't run in a worktree, so the pipeline is mocked at the `uploadEntry` boundary here (established MCP test pattern).
- Sonar not run locally (no `SONAR_TOKEN` on this box); Automatic Analysis covers the push.

## Browser check
Browser check: not applicable — no `web/src` changes; backend-only MCP tool.

## Changelog
No changelog entry — beta MCP tool gated behind `users.developer_access`, not user-visible in the app yet.

## Risks
- If the serialized markdown ever trips a non-heading parser branch, card counts could differ; the guards + round-trip tests cover the known pre-empting patterns. A card with an empty back is dropped by the heading heuristic (front is validated non-empty; back is not) — `cardCount` reflects the input count.
- Persistence failure surfaces as a tool error (no partial state returned). Rollback is trivial — revert the branch; no migration to unwind.

## Goal alignment
Directly serves the mission (simplest/fastest path from what you're studying to a clean deck) by making "chat → deck → download" work end-to-end inside claude.ai. It's a new surface on the MCP connector: **T+30d adoption review obligation** — a keep/remove review issue should be opened at merge with the review date in the title, verdict driven by the `create_deck` `mcp_tool_called` signal. Revenue: none directly — MCP is a `developer_access` beta; the funnel metric to watch is `create_deck` adoption before any wider rollout.
