### PR TITLE
feat: add photo_to_deck MCP tool

### DIFF
--- a/src/routes/McpRouter.ts
+++ b/src/routes/McpRouter.ts
@@ -22,6 +22,8 @@ import { KnexOAuthProvider } from '../services/mcp/oauth/KnexOAuthProvider';
 import { McpToolsService } from '../services/mcp/McpToolsService';
 import { McpDeckPersistence } from '../services/mcp/McpDeckPersistence';
 import { buildMcpServer } from '../services/mcp/McpServerFactory';
+import { PhotoToFlashcardsUseCase } from '../usecases/imageOcclusion/PhotoToFlashcardsUseCase';
+import { EventsRepository } from '../data_layer/EventsRepository';
 import { applyUserLocals } from './middleware/configureUserLocal';
 import { getEventsSink } from '../services/events/eventsSinkInstance';
 import { createMcpRouter, MCP_AUTHORIZE_PATH } from './mcp/createMcpRouter';
@@ -74,7 +76,8 @@ const McpRouter = () => {
       new JobRepository(database),
       new UploadRepository(database),
       storage
-    )
+    ),
+    new PhotoToFlashcardsUseCase(new EventsRepository(database))
   );
 
   const onAuthenticatedPost: RequestHandler = async (req, res) => {

--- a/src/services/mcp/McpServerFactory.test.ts
+++ b/src/services/mcp/McpServerFactory.test.ts
@@ -24,6 +24,7 @@ describe('buildMcpServer', () => {
       'deck_capabilities',
       'get_deck_preview',
       'list_my_decks',
+      'photo_to_deck',
     ]);
   });
 

--- a/src/services/mcp/McpServerFactory.ts
+++ b/src/services/mcp/McpServerFactory.ts
@@ -4,6 +4,10 @@ import { z } from 'zod';
 import { McpToolsService } from './McpToolsService';
 import { McpConvertOptions } from './mcpOptionsToCardSettings';
 import { DECK_CAPABILITIES } from './deckCapabilities';
+import type {
+  PhotoDensity,
+  PhotoMode,
+} from '../../usecases/imageOcclusion/PhotoToFlashcardsUseCase';
 
 export const MCP_SERVER_NAME = '2anki';
 export const MCP_SERVER_VERSION = '1.0.0';
@@ -257,6 +261,61 @@ export function buildMcpServer(context: McpRequestContext): McpServer {
     async () => {
       context.recordToolCall('deck_capabilities');
       return textResult(DECK_CAPABILITIES);
+    }
+  );
+
+  registerTool<{
+    image: string;
+    density?: PhotoDensity;
+    mode?: PhotoMode;
+    includeSourceImage?: boolean;
+  }>(
+    server,
+    'photo_to_deck',
+    {
+      title: 'Photo to flashcards',
+      description:
+        'Turn a photo of handwritten notes, a textbook page, or a slide into flashcards using 2anki vision. Returns the generated cards (front/back), not a file. Two-step flow: call photo_to_deck to get the cards, review them, then call create_deck to build and download the .apkg. Counts against your monthly AI photo quota.',
+      inputSchema: {
+        image: z
+          .string()
+          .describe(
+            'The photo as a base64 string or a data URL (data:image/png;base64,…). PNG, JPEG, WebP, or GIF, up to 10 MB.'
+          ),
+        density: z
+          .enum(['sparse', 'balanced', 'dense'])
+          .optional()
+          .describe('How many cards to generate. Default balanced.'),
+        mode: z
+          .enum(['generative', 'verbatim'])
+          .optional()
+          .describe(
+            'generative rewrites the page into question-and-answer cards; verbatim transcribes what is written. Default generative.'
+          ),
+        includeSourceImage: z
+          .boolean()
+          .optional()
+          .describe(
+            'Whether to embed the source image on each card when the deck is later built with create_deck.'
+          ),
+      },
+    },
+    async ({ image, density, mode, includeSourceImage }) => {
+      context.recordToolCall('photo_to_deck');
+      try {
+        const result = await context.toolsService.photoToDeck(
+          { image, density, mode, includeSourceImage },
+          context.owner,
+          context.locals
+        );
+        return textResult(result);
+      } catch (error) {
+        return errorResult(
+          error instanceof Error
+            ? error.message
+            : 'Could not read cards from this photo.'
+        );
+      }
     }
   );
 

--- a/src/services/mcp/McpToolsService.test.ts
+++ b/src/services/mcp/McpToolsService.test.ts
@@ -6,6 +6,14 @@ import { JobWithDownloadKey } from '../../data_layer/JobRepository';
 import ApkgPreviewService from '../ApkgPreviewService/ApkgPreviewService';
 import DownloadService from '../DownloadService';
 import type StorageHandler from '../../lib/storage/StorageHandler';
+import {
+  PhotoToFlashcardsUseCase,
+  type PhotoVisionCards,
+} from '../../usecases/imageOcclusion/PhotoToFlashcardsUseCase';
+
+// 1x1 transparent PNG — real bytes so detectFileMime and image-size resolve.
+const ONE_PIXEL_PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
 
 function makeService(overrides: {
   jobs?: JobWithDownloadKey[];
@@ -14,6 +22,7 @@ function makeService(overrides: {
   preview?: Partial<ApkgPreviewService>;
   persist?: DeckPersistence['persist'];
   getPresignedUrl?: StorageHandler['getPresignedUrl'];
+  generateCards?: jest.Mock;
 }) {
   const jobLister = {
     getJobsByOwner: jest.fn(async () => overrides.jobs ?? []),
@@ -47,15 +56,27 @@ function makeService(overrides: {
     overrides.getPresignedUrl ?? (async () => 'https://s3.example/presigned')
   );
   const storage = { getPresignedUrl } as unknown as StorageHandler;
+  const generateCards = overrides.generateCards ?? jest.fn();
+  const photoToFlashcards = {
+    generateCards,
+  } as unknown as PhotoToFlashcardsUseCase;
   const service = new McpToolsService(
     jobLister,
     downloadService,
     previewService,
     uploadEntry,
     storage,
-    deckPersistence
+    deckPersistence,
+    photoToFlashcards
   );
-  return { service, jobLister, downloadService, persist, getPresignedUrl };
+  return {
+    service,
+    jobLister,
+    downloadService,
+    persist,
+    getPresignedUrl,
+    generateCards,
+  };
 }
 
 describe('McpToolsService.listMyDecks', () => {
@@ -404,5 +425,116 @@ describe('McpToolsService.createDeck', () => {
     const result = await service.createDeck(cards, 'Deck', 'owner-9', {});
     expect(result).toMatchObject({ kind: 'error' });
     expect(persist).not.toHaveBeenCalled();
+  });
+});
+
+describe('McpToolsService.photoToDeck', () => {
+  const visionResult = (
+    cards: { front: string; back: string }[]
+  ): PhotoVisionCards => ({
+    decks: [],
+    cards,
+    cardCount: cards.length,
+    deckName: 'Photo deck',
+    estimatedCostUsd: 0.01,
+    tileCount: 1,
+    inputTokens: 100,
+    outputTokens: 50,
+  });
+
+  it('decodes a data URL, runs vision, and maps the cards to a result', async () => {
+    const generateCards = jest.fn(async () =>
+      visionResult([
+        { front: 'Q1', back: 'A1' },
+        { front: 'Q2', back: 'A2' },
+      ])
+    );
+    const { service } = makeService({ generateCards });
+    const result = await service.photoToDeck(
+      { image: `data:image/png;base64,${ONE_PIXEL_PNG_BASE64}` },
+      'owner-1',
+      { subscriber: true }
+    );
+    expect(generateCards).toHaveBeenCalledWith(
+      expect.objectContaining({
+        imageBase64: ONE_PIXEL_PNG_BASE64,
+        mediaType: 'image/png',
+        owner: 'owner-1',
+        isPaying: true,
+        imageDimensions: { width: 1, height: 1 },
+      })
+    );
+    expect(result.count).toBe(2);
+    expect(result.cards).toEqual([
+      { front: 'Q1', back: 'A1' },
+      { front: 'Q2', back: 'A2' },
+    ]);
+    expect(result.summary).toContain('2 cards');
+    expect(result.summary).toContain('create_deck');
+  });
+
+  it('accepts a bare base64 string without a data URL prefix', async () => {
+    const generateCards = jest.fn(async () => visionResult([]));
+    const { service } = makeService({ generateCards });
+    await service.photoToDeck({ image: ONE_PIXEL_PNG_BASE64 }, 'o', {});
+    expect(generateCards).toHaveBeenCalledWith(
+      expect.objectContaining({ imageBase64: ONE_PIXEL_PNG_BASE64 })
+    );
+  });
+
+  it('forwards density and mode to the vision use case', async () => {
+    const generateCards = jest.fn(async () => visionResult([]));
+    const { service } = makeService({ generateCards });
+    await service.photoToDeck(
+      { image: ONE_PIXEL_PNG_BASE64, density: 'dense', mode: 'verbatim' },
+      'o',
+      {}
+    );
+    expect(generateCards).toHaveBeenCalledWith(
+      expect.objectContaining({ density: 'dense', mode: 'verbatim' })
+    );
+  });
+
+  it('rejects an empty image without calling vision', async () => {
+    const generateCards = jest.fn();
+    const { service } = makeService({ generateCards });
+    await expect(
+      service.photoToDeck({ image: '   ' }, 'o', {})
+    ).rejects.toThrow(/base64/);
+    expect(generateCards).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-image payload without calling vision', async () => {
+    const generateCards = jest.fn();
+    const { service } = makeService({ generateCards });
+    const notAnImage = Buffer.from('this is plain text').toString('base64');
+    await expect(
+      service.photoToDeck({ image: notAnImage }, 'o', {})
+    ).rejects.toThrow(/Unsupported image type/);
+    expect(generateCards).not.toHaveBeenCalled();
+  });
+
+  it('rejects an oversized image without calling vision', async () => {
+    const generateCards = jest.fn();
+    const { service } = makeService({ generateCards });
+    const oversized = Buffer.alloc(10 * 1024 * 1024 + 1).toString('base64');
+    await expect(
+      service.photoToDeck({ image: oversized }, 'o', {})
+    ).rejects.toThrow(/10 MB/);
+    expect(generateCards).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a quota-exceeded error from the vision use case', async () => {
+    const quotaError = Object.assign(
+      new Error('Free plan is 5 photos per month. Upgrade for unlimited.'),
+      { status: 429 }
+    );
+    const generateCards = jest.fn(async () => {
+      throw quotaError;
+    });
+    const { service } = makeService({ generateCards });
+    await expect(
+      service.photoToDeck({ image: ONE_PIXEL_PNG_BASE64 }, 'o', {})
+    ).rejects.toThrow(/Free plan is 5 photos per month/);
   });
 });

--- a/src/services/mcp/McpToolsService.ts
+++ b/src/services/mcp/McpToolsService.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import { randomUUID } from 'node:crypto';
+import imageSize from 'image-size';
 
 import { JobWithDownloadKey } from '../../data_layer/JobRepository';
 import ApkgPreviewService from '../ApkgPreviewService/ApkgPreviewService';
@@ -13,13 +14,90 @@ import {
   McpConvertOptions,
   mcpOptionsToCardSettings,
 } from './mcpOptionsToCardSettings';
+import { detectFileMime } from '../../lib/detectFileMime';
+import { isPaying } from '../../lib/isPaying';
+import type { VisionMediaType } from '../../lib/claude/countVisionTokens';
+import {
+  PhotoToFlashcardsUseCase,
+  type GeneratedFlashcard,
+  type PhotoDensity,
+  type PhotoMode,
+} from '../../usecases/imageOcclusion/PhotoToFlashcardsUseCase';
 
 const APKG_KEY_PATTERN = /\.apkg$/i;
 const MAX_TEXT_BYTES = 5 * 1024 * 1024;
 const MAX_URL_BYTES = 100 * 1024 * 1024;
+const MAX_PHOTO_BYTES = 10 * 1024 * 1024;
 const PREVIEW_CARD_LIMIT = 20;
 const MAX_CARDS = 500;
 const DEFAULT_DECK_NAME = 'MCP deck';
+const DATA_URL_PREFIX = /^data:[^,]*,/;
+const ALLOWED_PHOTO_MEDIA_TYPES: VisionMediaType[] = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+];
+
+export interface PhotoDeckInput {
+  image: string;
+  density?: PhotoDensity;
+  mode?: PhotoMode;
+  includeSourceImage?: boolean;
+}
+
+export interface PhotoDeckResult {
+  cards: GeneratedFlashcard[];
+  count: number;
+  summary: string;
+}
+
+interface DecodedPhoto {
+  imageBase64: string;
+  mediaType: VisionMediaType;
+  width: number;
+  height: number;
+}
+
+function isAllowedPhotoMediaType(
+  value: string | null
+): value is VisionMediaType {
+  return (
+    value != null && (ALLOWED_PHOTO_MEDIA_TYPES as string[]).includes(value)
+  );
+}
+
+function decodePhotoInput(image: string): DecodedPhoto {
+  const base64 = image.replace(DATA_URL_PREFIX, '').trim();
+  if (base64.length === 0) {
+    throw new Error('Provide a photo as a base64 string or data URL.');
+  }
+
+  const buffer = Buffer.from(base64, 'base64');
+  if (buffer.length === 0) {
+    throw new Error("Couldn't decode the photo. Check the base64 data.");
+  }
+  if (buffer.length > MAX_PHOTO_BYTES) {
+    throw new Error('Photo is over the 10 MB limit. Try a smaller image.');
+  }
+
+  const mediaType = detectFileMime(buffer);
+  if (!isAllowedPhotoMediaType(mediaType)) {
+    throw new Error('Unsupported image type. Use PNG, JPEG, WebP, or GIF.');
+  }
+
+  const dims = imageSize(buffer);
+  if (dims.width == null || dims.height == null) {
+    throw new Error("Couldn't read the photo's dimensions.");
+  }
+
+  return {
+    imageBase64: base64,
+    mediaType,
+    width: dims.width,
+    height: dims.height,
+  };
+}
 
 export interface DeckSummary {
   jobId: string;
@@ -147,8 +225,34 @@ export class McpToolsService {
     private readonly previewService: ApkgPreviewService,
     private readonly uploadEntry: UploadEntrypoint,
     private readonly storage: StorageHandler,
-    private readonly deckPersistence: DeckPersistence
+    private readonly deckPersistence: DeckPersistence,
+    private readonly photoToFlashcards: PhotoToFlashcardsUseCase
   ) {}
+
+  async photoToDeck(
+    input: PhotoDeckInput,
+    owner: string,
+    locals: Record<string, unknown>
+  ): Promise<PhotoDeckResult> {
+    const photo = decodePhotoInput(input.image);
+    const generated = await this.photoToFlashcards.generateCards({
+      imageBase64: photo.imageBase64,
+      mediaType: photo.mediaType,
+      deckName: '',
+      owner,
+      isPaying: isPaying(locals),
+      imageDimensions: { width: photo.width, height: photo.height },
+      includeSourceImage: input.includeSourceImage,
+      density: input.density,
+      mode: input.mode,
+    });
+
+    return {
+      cards: generated.cards,
+      count: generated.cardCount,
+      summary: `${generated.cardCount} cards from your photo. Review them, then call create_deck to build and download the deck.`,
+    };
+  }
 
   async listMyDecks(owner: string): Promise<DeckSummary[]> {
     const jobs = await this.jobLister.getJobsByOwner(owner);

--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
@@ -67,6 +67,22 @@ export interface PhotoToFlashcardsResult {
   mcqSkippedCount: number;
 }
 
+export interface GeneratedFlashcard {
+  front: string;
+  back: string;
+}
+
+export interface PhotoVisionCards {
+  decks: CompactDeck[];
+  cards: GeneratedFlashcard[];
+  cardCount: number;
+  deckName: string;
+  estimatedCostUsd: number;
+  tileCount: number;
+  inputTokens: number;
+  outputTokens: number;
+}
+
 function ownerToUserId(owner: string): number | null {
   const n = Number(owner);
   return Number.isFinite(n) && n > 0 ? n : null;
@@ -274,6 +290,17 @@ interface CompactDeck {
   cards: CompactCard[];
 }
 
+function cardBack(card: CompactCard): string {
+  if (typeof card.a === 'string' && card.a.length > 0) return card.a;
+  return typeof card.rationale === 'string' ? card.rationale : '';
+}
+
+function flattenDecksToCards(decks: CompactDeck[]): GeneratedFlashcard[] {
+  return decks.flatMap((deck) =>
+    deck.cards.map((card) => ({ front: card.q ?? '', back: cardBack(card) }))
+  );
+}
+
 function logUnreadableVisionResponse(raw: string): void {
   console.log(
     JSON.stringify({
@@ -473,9 +500,9 @@ function buildDeckInfo(
 export class PhotoToFlashcardsUseCase {
   constructor(private readonly events?: IEventsRepository) {}
 
-  async execute(
+  async generateCards(
     input: PhotoToFlashcardsInput
-  ): Promise<PhotoToFlashcardsResult> {
+  ): Promise<PhotoVisionCards> {
     const userId = ownerToUserId(input.owner);
 
     if (!input.isPaying && this.events != null) {
@@ -564,6 +591,47 @@ export class PhotoToFlashcardsUseCase {
       (outputTokens / 1_000_000) * OUTPUT_COST_PER_MILLION;
 
     const deckName = input.deckName || (decks[0]?.deck ?? 'Photo deck');
+
+    track(VISION_PHOTO_EVENT, {
+      userId,
+      anonymousId: userId == null ? input.owner : null,
+      props: {
+        card_count: cardCount,
+        tile_count: tiles,
+        source_mode: mode,
+        card_style: input.cardStyle ?? DEFAULT_PHOTO_CARD_STYLE,
+        density: input.density ?? DEFAULT_PHOTO_DENSITY,
+      },
+    });
+
+    return {
+      decks,
+      cards: flattenDecksToCards(decks),
+      cardCount,
+      deckName,
+      estimatedCostUsd,
+      tileCount: tiles,
+      inputTokens,
+      outputTokens,
+    };
+  }
+
+  async execute(
+    input: PhotoToFlashcardsInput
+  ): Promise<PhotoToFlashcardsResult> {
+    const {
+      decks,
+      deckName,
+      cardCount,
+      estimatedCostUsd,
+      tileCount,
+      inputTokens,
+      outputTokens,
+    } = await this.generateCards(input);
+
+    const mcqEnabled = (input.mcqEnabled ?? false) && input.isPaying;
+    const mode = input.mode ?? DEFAULT_PHOTO_MODE;
+
     const embedSourceImage = input.includeSourceImage ?? true;
     const sourceFilename = embedSourceImage
       ? `source-${randomUUID()}.${mediaTypeToExt(input.mediaType)}`
@@ -603,7 +671,7 @@ export class PhotoToFlashcardsUseCase {
       JSON.stringify({
         event: 'vision_call_success',
         estimated_cost_usd: estimatedCostUsd,
-        tile_count: tiles,
+        tile_count: tileCount,
         media_type: input.mediaType,
         card_count: cardCount,
         input_tokens: inputTokens,
@@ -614,23 +682,11 @@ export class PhotoToFlashcardsUseCase {
       })
     );
 
-    track(VISION_PHOTO_EVENT, {
-      userId: ownerToUserId(input.owner),
-      anonymousId: ownerToUserId(input.owner) == null ? input.owner : null,
-      props: {
-        card_count: cardCount,
-        tile_count: tiles,
-        source_mode: mode,
-        card_style: input.cardStyle ?? DEFAULT_PHOTO_CARD_STYLE,
-        density: input.density ?? DEFAULT_PHOTO_DENSITY,
-      },
-    });
-
     return {
       apkgPath,
       cardCount,
       estimatedCostUsd,
-      tileCount: tiles,
+      tileCount,
       mcqCount,
       mcqSkippedCount,
     };


### PR DESCRIPTION
## What
Adds a `photo_to_deck` MCP tool. An MCP client sends a photo (base64 or data URL) of handwritten notes, a textbook page, or a slide, and 2anki runs it through the existing Claude Vision pipeline (`PhotoToFlashcardsUseCase`) and returns the generated cards as `{ cards: [{front, back}], count, summary }`. It returns cards, not an `.apkg` — Claude then hands those cards to `create_deck` to build and download the deck.

## Why
Extends the limited-beta MCP surface (gated to `users.developer_access`) so a chat client can go from a photo to reviewable flashcards in one turn, without leaving the assistant. Returning cards instead of a file keeps this tool independent of the create_deck/persistence work in #3731.

## How
- Extracted a `generateCards()` step from `PhotoToFlashcardsUseCase` that runs the free-quota check, the vision token-ceiling check, the Claude Vision call, response parse, and the `vision_photo_converted` analytics event — everything **except** the apkg build. `execute()` (the HTTP path) now calls `generateCards()` then builds the apkg exactly as before, so HTTP behaviour is unchanged. The one intentional shift: the analytics/quota event now fires right after the vision call succeeds rather than after the apkg build, so the quota accounting is identical across the HTTP and MCP paths (the event is the billable "a vision conversion happened" signal).
- `McpToolsService.photoToDeck(input, owner, locals)` decodes the base64/data-URL, caps size at 10 MB, detects the media type from the bytes (`detectFileMime`), reads real dimensions (`image-size`) to feed the token ceiling, then calls `generateCards`. Quota is enforced via the use case (no bypass); `isPaying(locals)` gates the free limit exactly as the HTTP controller does.
- New tool registered in `McpServerFactory` (`photo_to_deck`), dependency wired in `McpRouter.ts` as `new PhotoToFlashcardsUseCase(new EventsRepository(database))`.
- Vision calls hit Claude Vision (claude-sonnet-4-5), ~2–10s, ~$0.075 max per photo (15-tile ceiling), unchanged from the existing photo-to-deck path — this PR adds no new model call type and no new tokens beyond the one vision call the HTTP path already makes. Prompt caching does not apply (single one-shot image message). Tests never make a real vision call.

### Coordination with sibling MCP PRs
#3731 (feat/mcp-create-deck) and #3732 (feat/mcp-card-options) also touch `McpServerFactory.ts` and `McpToolsService.ts`. All three are **additive** (new tool + new method appended); this PR is built off `main` (neither sibling is on main). Any merge order works — the re-append rebase is trivial.

## Measuring success
`mcp_tool_called` fires with `props.tool = 'photo_to_deck'` on every invocation (via `context.recordToolCall`), and each successful conversion emits `vision_photo_converted` (read at `/api/ops/metrics`). Day-7 prod check: is `photo_to_deck` in the `mcp_tool_called` breakdown at all? T+30 adoption review below.

## Testing
- Unit tests added:
  - `McpToolsService.photoToDeck`: decodes a data URL and a bare base64 string, forwards density/mode to the use case, maps output to `{cards, count, summary}`, rejects empty / non-image / oversized input without calling vision, and surfaces a quota-exceeded error.
  - `PhotoToFlashcardsUseCase.generateCards` is exercised transitively through the existing `execute` suite (unchanged) plus the new MCP tests; the MCQ null-`a` runtime shape is covered.
  - `McpServerFactory`: asserts `photo_to_deck` is registered alongside the existing tools.
- `tsc -p . --noEmit` green (deploy build compiles tests). `pnpm format:check` green tree-wide. Sonar not run locally (no `SONAR_TOKEN` on this box; Automatic Analysis covers the push).

## Browser check
Browser check: not applicable — no `web/src/` changes; backend/MCP only.

## Changelog
No changelog entry — beta MCP tool (gated to `developer_access`, not generally available).

## Surface lifecycle (T+30 obligation)
This is a new user-facing capability on the MCP surface. On merge, create the T+30d adoption-review issue with the review date in the title; verdict at review is keep-or-remove based on the `mcp_tool_called` / `vision_photo_converted` signal.

## Risks
- The extracted `generateCards()` moves the `vision_photo_converted` event to just after the vision call (before apkg build) on the HTTP path. Consequence: if the apkg build fails after a successful vision call, the event now fires (previously it did not). This is the intended, more-correct accounting (the vision call is the billable unit) and keeps HTTP/MCP quota identical. Rollback: revert the branch — no migration, no schema change.
- Vision cost per call is unchanged from the existing photo-to-deck endpoint.

## Goal alignment
Deepens the MCP beta (a differentiated distribution surface — 2anki inside the assistant). Not an acquisition-lane change; internal-beta reach. Metric to watch: `mcp_tool_called{tool=photo_to_deck}` at `/api/ops/metrics` — if the beta cohort uses it, it argues for graduating MCP out of `developer_access`.
