### PR TITLE
fix: accept jobId or key in MCP get_deck_preview and surface errors

### DIFF
--- a/src/services/mcp/McpServerFactory.test.ts
+++ b/src/services/mcp/McpServerFactory.test.ts
@@ -1,12 +1,29 @@
 import { buildMcpServer, type McpRequestContext } from './McpServerFactory';
 import type { McpToolsService } from './McpToolsService';
 
-const buildContext = (): McpRequestContext => ({
+const buildContext = (
+  overrides: Partial<McpRequestContext> = {}
+): McpRequestContext => ({
   owner: 'user-1',
   locals: {},
   toolsService: {} as McpToolsService,
   recordToolCall: () => {},
+  ...overrides,
 });
+
+type ToolHandler = (
+  args: Record<string, unknown>
+) => Promise<{ content: { type: string; text: string }[]; isError?: boolean }>;
+
+const getHandler = (context: McpRequestContext, name: string): ToolHandler => {
+  const server = buildMcpServer(context);
+  const registered = (
+    server as unknown as {
+      _registeredTools: Record<string, { handler: ToolHandler }>;
+    }
+  )._registeredTools;
+  return registered[name].handler;
+};
 
 describe('buildMcpServer', () => {
   it('builds a server without throwing', () => {
@@ -66,5 +83,80 @@ describe('buildMcpServer', () => {
         'tts',
       ])
     );
+  });
+});
+
+describe('get_deck_preview handler', () => {
+  it('passes a jobId through to getDeckPreview and returns the preview', async () => {
+    const getDeckPreview = jest.fn(async () => ({
+      cardCount: 3,
+      deckCount: 1,
+      decks: [],
+      sampleCards: [],
+    }));
+    const handler = getHandler(
+      buildContext({
+        owner: 'user-1',
+        toolsService: { getDeckPreview } as unknown as McpToolsService,
+      }),
+      'get_deck_preview'
+    );
+    const result = await handler({ jobId: 'job-1' });
+    expect(getDeckPreview).toHaveBeenCalledWith('user-1', 'job-1');
+    expect(result.isError).toBeUndefined();
+  });
+
+  it('falls back to the key param when jobId is absent', async () => {
+    const getDeckPreview = jest.fn(async () => ({
+      cardCount: 1,
+      deckCount: 1,
+      decks: [],
+      sampleCards: [],
+    }));
+    const handler = getHandler(
+      buildContext({
+        owner: 'user-1',
+        toolsService: { getDeckPreview } as unknown as McpToolsService,
+      }),
+      'get_deck_preview'
+    );
+    await handler({ key: 'deck.apkg' });
+    expect(getDeckPreview).toHaveBeenCalledWith('user-1', 'deck.apkg');
+  });
+
+  it('returns a clean error when neither jobId nor key is given', async () => {
+    const getDeckPreview = jest.fn();
+    const handler = getHandler(
+      buildContext({
+        toolsService: { getDeckPreview } as unknown as McpToolsService,
+      }),
+      'get_deck_preview'
+    );
+    const result = await handler({});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe(
+      'Provide a jobId (from list_my_decks) or a deck key.'
+    );
+    expect(getDeckPreview).not.toHaveBeenCalled();
+  });
+
+  it('logs and surfaces the real error message on failure', async () => {
+    const getDeckPreview = jest.fn(async () => {
+      throw new Error('Deck not found.');
+    });
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const handler = getHandler(
+      buildContext({
+        toolsService: { getDeckPreview } as unknown as McpToolsService,
+      }),
+      'get_deck_preview'
+    );
+    const result = await handler({ jobId: 'missing' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe('Deck not found.');
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[mcp] get_deck_preview failed for missing: Deck not found.'
+    );
+    errorSpy.mockRestore();
   });
 });

--- a/src/services/mcp/McpServerFactory.ts
+++ b/src/services/mcp/McpServerFactory.ts
@@ -89,31 +89,45 @@ export function buildMcpServer(context: McpRequestContext): McpServer {
     }
   );
 
-  registerTool<{ jobId: string }>(
+  registerTool<{ jobId?: string; key?: string }>(
     server,
     'get_deck_preview',
     {
       title: 'Get deck preview',
       description:
-        'Preview an .apkg deck you own — total cards, decks, and a sample of cards.',
+        'Preview an .apkg deck you own — total cards, decks, and a sample of cards. Pass a jobId (preferred, from list_my_decks) or an .apkg deck key.',
       inputSchema: {
         jobId: z
           .string()
+          .optional()
           .describe('The jobId of the deck, as returned by list_my_decks.'),
+        key: z
+          .string()
+          .optional()
+          .describe('The .apkg storage key of the deck.'),
       },
     },
-    async ({ jobId }) => {
+    async ({ jobId, key }) => {
       context.recordToolCall('get_deck_preview');
+      const identifier = jobId ?? key;
+      if (identifier == null) {
+        return errorResult(
+          'Provide a jobId (from list_my_decks) or a deck key.'
+        );
+      }
       try {
         const preview = await context.toolsService.getDeckPreview(
           context.owner,
-          jobId
+          identifier
         );
         return textResult(preview);
       } catch (error) {
-        return errorResult(
-          error instanceof Error ? error.message : 'Could not load the deck.'
+        const message =
+          error instanceof Error ? error.message : 'Could not load the deck.';
+        console.error(
+          `[mcp] get_deck_preview failed for ${identifier}: ${message}`
         );
+        return errorResult(message);
       }
     }
   );

--- a/src/services/mcp/McpToolsService.test.ts
+++ b/src/services/mcp/McpToolsService.test.ts
@@ -162,6 +162,31 @@ describe('McpToolsService.getDeckPreview', () => {
     expect(preview.sampleCards).toEqual([{ front: 'Q', back: 'A' }]);
   });
 
+  it('resolves a raw .apkg key directly when no job matches, owner-scoped', async () => {
+    const getFileBody = jest.fn(async () => Buffer.from('apkg'));
+    const { service } = makeService({
+      jobs: [jobFixture({ object_id: 'job-1' })],
+      getFileBody,
+    });
+    const preview = await service.getDeckPreview('owner', 'legacy-deck.apkg');
+    expect(getFileBody).toHaveBeenCalledWith(
+      'owner',
+      'legacy-deck.apkg',
+      expect.anything()
+    );
+    expect(preview.cardCount).toBe(3);
+  });
+
+  it('rejects an unknown identifier that is not an .apkg key', async () => {
+    const { service, downloadService } = makeService({
+      jobs: [jobFixture({ object_id: 'job-1' })],
+    });
+    await expect(service.getDeckPreview('owner', 'not-a-key')).rejects.toThrow(
+      /Deck not found/
+    );
+    expect(downloadService.getFileBody).not.toHaveBeenCalled();
+  });
+
   it('reports when the resolved file is missing from storage', async () => {
     const { service } = makeService({
       jobs: [jobFixture({ object_id: 'job-1', download_key: 'deck.apkg' })],

--- a/src/services/mcp/McpToolsService.ts
+++ b/src/services/mcp/McpToolsService.ts
@@ -268,16 +268,11 @@ export class McpToolsService {
     }));
   }
 
-  async getDeckPreview(owner: string, jobId: string): Promise<DeckPreview> {
-    const jobs = await this.jobLister.getJobsByOwner(owner);
-    const job = jobs.find((entry) => entry.object_id === jobId);
-    if (!job) {
-      throw new Error('Deck not found.');
-    }
-    const key = job.download_key;
-    if (key == null || !APKG_KEY_PATTERN.test(key)) {
-      throw new Error('This deck has no .apkg to preview yet.');
-    }
+  async getDeckPreview(
+    owner: string,
+    identifier: string
+  ): Promise<DeckPreview> {
+    const key = await this.resolveDeckKey(owner, identifier);
     const body = await this.downloadService.getFileBody(
       owner,
       key,
@@ -311,6 +306,25 @@ export class McpToolsService {
         back: card.back,
       })),
     };
+  }
+
+  private async resolveDeckKey(
+    owner: string,
+    identifier: string
+  ): Promise<string> {
+    const jobs = await this.jobLister.getJobsByOwner(owner);
+    const job = jobs.find((entry) => entry.object_id === identifier);
+    if (job) {
+      const key = job.download_key;
+      if (key == null || !APKG_KEY_PATTERN.test(key)) {
+        throw new Error('This deck has no .apkg to preview yet.');
+      }
+      return key;
+    }
+    if (APKG_KEY_PATTERN.test(identifier)) {
+      return identifier;
+    }
+    throw new Error('Deck not found.');
   }
 
   async convertToDeck(


### PR DESCRIPTION
## What
Hardens the MCP `get_deck_preview` tool so it accepts either a `jobId` (preferred, from `list_my_decks`) or a raw `.apkg` deck key, and surfaces the real failure reason instead of swallowing it.

## Why
Two issues surfaced in the beta smoke test:
1. **Schema caching** — claude.ai caches the tool's input schema. After the param was renamed `key` → `jobId`, a stale client keeps sending `{key}`, and the new zod validator rejects it with a bare `UnknownError` at the SDK level, before our handler runs. Reconnecting the connector also refreshes the cached schema, but this makes the server tolerant either way.
2. **Errors were undiagnosable** — the handler's catch returned a generic message and logged nothing, so a real failure (missing deck, storage miss) was indistinguishable from an SDK-validation reject.

## How
- Tool input is now `{ jobId?: string, key?: string }`. The handler computes `identifier = jobId ?? key`; if neither is given it returns a clean `errorResult`.
- `getDeckPreview(owner, identifier)` resolves via a new `resolveDeckKey`: match a job by `object_id` and use its `download_key`; else if the identifier matches `APKG_KEY_PATTERN` treat it as a storage key directly (still passed to the owner-scoped `getFileBody(owner, key)` — no IDOR, `DownloadRepository.getFile` scopes on `{key, owner}`); else throw `Deck not found.`. The existing null-`download_key` and file-missing errors are preserved.
- The tool catch now `console.error`s `[mcp] get_deck_preview failed for <identifier>: <message>` (identifier + error message are not secrets — consistent with the repo's `[ankify-sync]`/`[PrepareDeck]` operational logs) and returns the real message, so SDK-validation vs handler-error is diagnosable.
- Owner-scoping is preserved on both resolution paths (both key on `context.owner`).

## Measuring success
A previously-`UnknownError` preview from a stale client now returns cards; failures print a `[mcp] get_deck_preview failed for …` line in the server log naming the identifier and the real reason. Grep prod logs for that prefix to see which decks/identifiers fail and why.

## Testing
- `McpToolsService.test.ts`: jobId resolves via its job; a raw `.apkg` key with no matching job resolves directly (owner-scoped `getFileBody` called with that key); an unknown non-key identifier throws `Deck not found`; existing null-`download_key` and storage-miss cases unchanged.
- `McpServerFactory.test.ts`: handler passes `jobId` through; falls back to `key` when `jobId` absent; returns the clean "provide a jobId or a deck key" error when neither is given; logs `[mcp] …` and surfaces the real message on failure.
- `pnpm test src/services/mcp/` — 50 passed. `tsc -p . --noEmit` clean (deploy build typechecks tests). `pnpm format:check` (tree-wide) clean.

Browser check: not applicable — server-only change, no `web/src/` files touched.

## Changelog
No changelog entry — beta MCP tool, not a user-visible product surface.

## Risks
Low. Localized to `getDeckPreview` and its tool registration; both resolution paths remain owner-scoped. The raw-key path only reaches storage through the same owner-scoped `getFileBody` the jobId path already used.

## Coordination
#3731 / #3732 / #3733 also touch `McpToolsService.ts` / `McpServerFactory.ts` additively (all off main). This edit is localized to `getDeckPreview` + the `get_deck_preview` tool registration; expect trivial additive merges, no logical conflict.

## Goal alignment
None — internal beta tooling. Removes friction for beta MCP users hitting a stale cached schema and makes failures diagnosable; no funnel/MRR metric attached yet.
