### PR TITLE
style: restyle the MCP OAuth consent screen

### DIFF
--- a/src/services/mcp/oauth/consent.test.ts
+++ b/src/services/mcp/oauth/consent.test.ts
@@ -63,4 +63,57 @@ describe('renderConsentPage', () => {
     expect(html).not.toContain('<script>alert(1)</script>');
     expect(html).toContain('&lt;script&gt;');
   });
+
+  it('renders human-readable scope lines instead of the raw scope token', () => {
+    const html = renderConsentPage({
+      actionPath: '/authorize',
+      clientName: 'Claude',
+      scopes: ['mcp'],
+      csrf: 'x',
+      fields: {},
+    });
+    expect(html).toContain('List your decks');
+    expect(html).toContain('Preview a deck&#39;s cards');
+    expect(html).toContain('Create decks from your content');
+    expect(html).not.toContain(
+      '<li><span class="consent-check" aria-hidden="true">✓</span><span>mcp</span></li>'
+    );
+  });
+
+  it('falls back to a generic scope line for an unknown scope', () => {
+    const html = renderConsentPage({
+      actionPath: '/authorize',
+      clientName: 'Claude',
+      scopes: ['unknown-scope'],
+      csrf: 'x',
+      fields: {},
+    });
+    expect(html).toContain('Access your 2anki decks and conversions');
+  });
+
+  it('includes the mascot image and an inline style block', () => {
+    const html = renderConsentPage({
+      actionPath: '/authorize',
+      clientName: 'Claude',
+      scopes: ['mcp'],
+      csrf: 'x',
+      fields: {},
+    });
+    expect(html).toContain('src="https://2anki.net/mascot/navbar-logo.png"');
+    expect(html).toContain('<style>');
+  });
+
+  it('renders both buttons with the new labels while keeping approve/deny values', () => {
+    const html = renderConsentPage({
+      actionPath: '/authorize',
+      clientName: 'Claude',
+      scopes: ['mcp'],
+      csrf: 'x',
+      fields: {},
+    });
+    expect(html).toContain('name="consent" value="approve"');
+    expect(html).toContain('name="consent" value="deny"');
+    expect(html).toContain('>Allow access</button>');
+    expect(html).toContain('>Cancel</button>');
+  });
 });

--- a/src/services/mcp/oauth/consent.ts
+++ b/src/services/mcp/oauth/consent.ts
@@ -42,44 +42,184 @@ export interface ConsentPageInput {
   fields: Record<string, string | undefined>;
 }
 
+const SCOPE_LINES: Record<string, string[]> = {
+  mcp: [
+    'List your decks',
+    "Preview a deck's cards",
+    'Create decks from your content — these count toward your usual card limit',
+  ],
+};
+
+const FALLBACK_SCOPE_LINE = 'Access your 2anki decks and conversions';
+
+function scopeLinesFor(scopes: string[]): string[] {
+  const lines = scopes.flatMap(
+    (scope) => SCOPE_LINES[scope] ?? [FALLBACK_SCOPE_LINE]
+  );
+  return lines.length > 0 ? lines : [FALLBACK_SCOPE_LINE];
+}
+
 function hiddenInput(name: string, value: string): string {
   return `<input type="hidden" name="${escapeHtml(name)}" value="${escapeHtml(
     value
   )}" />`;
 }
 
+const CONSENT_STYLES = `
+    :root { color-scheme: light dark; }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px 16px;
+      background-color: #f5f5f5;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      color: #374151;
+      -webkit-font-smoothing: antialiased;
+    }
+    .consent-card {
+      width: 100%;
+      max-width: 420px;
+      background-color: #ffffff;
+      border: 1px solid #e5e7eb;
+      border-radius: 12px;
+      padding: 32px 28px;
+    }
+    .consent-logo {
+      display: block;
+      margin: 0 auto 20px;
+      height: auto;
+    }
+    .consent-title {
+      margin: 0 0 12px;
+      font-size: 20px;
+      font-weight: 600;
+      text-align: center;
+      color: #374151;
+    }
+    .consent-ask {
+      margin: 0 0 20px;
+      font-size: 15px;
+      line-height: 1.5;
+      text-align: center;
+      color: #374151;
+    }
+    .consent-scopes {
+      list-style: none;
+      margin: 0 0 28px;
+      padding: 0;
+    }
+    .consent-scopes li {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      margin: 0 0 12px;
+      font-size: 15px;
+      line-height: 1.45;
+      color: #374151;
+    }
+    .consent-scopes li:last-child { margin-bottom: 0; }
+    .consent-check {
+      flex: 0 0 auto;
+      color: #3b82f6;
+      font-weight: 700;
+    }
+    .consent-actions {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .consent-btn {
+      width: 100%;
+      padding: 12px 16px;
+      font-size: 15px;
+      font-weight: 600;
+      font-family: inherit;
+      border-radius: 8px;
+      cursor: pointer;
+    }
+    .consent-btn-primary {
+      background-color: #2563eb;
+      color: #ffffff;
+      border: 1px solid #2563eb;
+    }
+    .consent-btn-secondary {
+      background-color: transparent;
+      color: #374151;
+      border: 1px solid #e5e7eb;
+    }
+    .consent-btn:focus-visible {
+      outline: 2px solid #3b82f6;
+      outline-offset: 2px;
+    }
+    .consent-reassure {
+      margin: 20px 0 0;
+      font-size: 13px;
+      line-height: 1.5;
+      text-align: center;
+      color: #6b7280;
+    }
+    .consent-footer {
+      margin: 24px 0 0;
+      font-size: 12px;
+      text-align: center;
+      color: #6b7280;
+    }
+    @media (prefers-color-scheme: dark) {
+      body { background-color: #1a1a1a; color: #e5e7eb; }
+      .consent-card { background-color: #111827; border-color: #374151; }
+      .consent-title, .consent-ask, .consent-scopes li { color: #e5e7eb; }
+      .consent-check { color: #60a5fa; }
+      .consent-btn-secondary { color: #e5e7eb; border-color: #374151; }
+      .consent-reassure, .consent-footer { color: #9ca3af; }
+    }`;
+
 export function renderConsentPage(input: ConsentPageInput): string {
   const hidden = Object.entries(input.fields)
     .filter(([, value]) => value != null && value !== '')
     .map(([name, value]) => hiddenInput(name, value as string))
     .join('\n      ');
-  const scopeList =
-    input.scopes.length > 0
-      ? input.scopes.map((scope) => `<li>${escapeHtml(scope)}</li>`).join('')
-      : '<li>Access your 2anki decks and conversions</li>';
+  const scopeList = scopeLinesFor(input.scopes)
+    .map(
+      (line) =>
+        `<li><span class="consent-check" aria-hidden="true">✓</span><span>${escapeHtml(
+          line
+        )}</span></li>`
+    )
+    .join('\n        ');
+  const clientName = escapeHtml(input.clientName);
   return `<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
     <title>Connect to 2anki</title>
+    <style>${CONSENT_STYLES}
+    </style>
   </head>
-  <body style="font-family: system-ui, sans-serif; max-width: 480px; margin: 48px auto; padding: 0 16px;">
-    <h1 style="font-size: 20px;">Connect ${escapeHtml(
-      input.clientName
-    )} to 2anki?</h1>
-    <p>${escapeHtml(
-      input.clientName
-    )} is asking to access your 2anki account:</p>
-    <ul>${scopeList}</ul>
-    <form method="post" action="${escapeHtml(input.actionPath)}">
-      ${hidden}
-      ${hiddenInput('csrf', input.csrf)}
-      <div style="display: flex; gap: 12px; margin-top: 24px;">
-        <button type="submit" name="consent" value="approve" style="padding: 10px 16px;">Approve</button>
-        <button type="submit" name="consent" value="deny" style="padding: 10px 16px;">Deny</button>
-      </div>
-    </form>
+  <body>
+    <main class="consent-card">
+      <img class="consent-logo" src="https://2anki.net/mascot/navbar-logo.png" alt="2anki" width="96" />
+      <h1 class="consent-title">Connect ${clientName} to 2anki</h1>
+      <p class="consent-ask">${clientName} wants access to your 2anki account. It will be able to:</p>
+      <ul class="consent-scopes">
+        ${scopeList}
+      </ul>
+      <form method="post" action="${escapeHtml(input.actionPath)}">
+        ${hidden}
+        ${hiddenInput('csrf', input.csrf)}
+        <div class="consent-actions">
+          <button type="submit" name="consent" value="approve" class="consent-btn consent-btn-primary">Allow access</button>
+          <button type="submit" name="consent" value="deny" class="consent-btn consent-btn-secondary">Cancel</button>
+        </div>
+      </form>
+      <p class="consent-reassure">You can disconnect ${clientName} anytime in your account settings.</p>
+      <p class="consent-footer">2anki.net — Turn what you study into Anki flashcards</p>
+    </main>
   </body>
 </html>`;
 }


### PR DESCRIPTION
## What
Restyles the MCP OAuth consent screen (`src/services/mcp/oauth/consent.ts`) — the page a user sees when adding the 2anki connector in claude.ai. It was bare unstyled HTML: a raw `mcp` scope token and two identical blue buttons. Now it's a centered card with the 2anki mascot, human-readable scope lines, a clear primary/secondary button pair, a disconnect reassurance line, light + dark mode, and WCAG AA focus/contrast — all self-contained inline styles.

## Why
This is the first-touch trust moment for the whole MCP connector: the screen where a user decides whether to grant Claude access to their 2anki account. A raw `mcp` scope and undifferentiated buttons read as sketchy and don't tell the user what they're actually granting. The redesign makes the ask legible (what Claude can do, in plain language) and the choice unambiguous.

## How
- Added a `SCOPE_LINES` map: `mcp` → `['List your decks', "Preview a deck's cards", 'Create decks from your content — these count toward your usual card limit']`; unknown scopes fall back to a generic line.
- Moved all styling into one inline `<style>` block with class names — no external CSS/JS/fonts, no inline `style=` attrs. One allowed https image: the mascot (same asset the email templates use).
- Light + dark palette mirrors the email templates via `@media (prefers-color-scheme: dark)` + `<meta name="color-scheme">`.
- Primary `Allow access` uses `#2563eb` (AA on 15px text); the `#3b82f6` accent is used only for the check glyph and focus ring (3:1 bar).
- Real `<ul>/<li>` scopes, `<button type="submit">`, `aria-hidden` check glyph, `alt` on the mascot, `:focus-visible` ring on both buttons.

## Security invariants preserved (unchanged)
- All hidden fields still emitted from `input.fields` via `hiddenInput`, plus the `csrf` hidden field.
- `name="consent" value="approve"` and `name="consent" value="deny"` kept byte-identical and contiguous.
- Every interpolated value (clientName, scope lines, actionPath, all hidden names+values) stays wrapped in `escapeHtml`; no new unescaped sink. The `escapeHtml` helper is untouched.
- Button values remain `approve`/`deny`; only visible labels changed.

## Measuring success
No new metric wired in this PR (server-rendered, beta connector). Success is qualitative: the connector-add flow in claude.ai renders a branded, legible consent card. If we later want a number, the authorize-path POST (`consent=approve` vs `deny`) is the approve-rate signal.

## Testing
`consent.test.ts` — all existing assertions kept unchanged and passing:
- csrf field present (`name="csrf" value="..."`)
- hidden field present (`name="client_id" value="abc"`)
- `name="consent" value="approve"` and `...value="deny"` present
- correct `action="/authorize"`
- empty fields filtered (`name="empty"` absent)
- malicious client name escaped (`<script>` → `&lt;script&gt;`)

Added:
- scope map renders human lines, not the raw `mcp` token
- unknown scope falls back to the generic line
- mascot img + inline `<style>` present
- both buttons render `Allow access` / `Cancel` while keeping approve/deny values

`/check`: server tsc clean, `pnpm format:check` (tree-wide) clean, 9/9 tests pass. Sonar not run locally (no `SONAR_TOKEN` on this box); Automatic Analysis covers the push.

## Browser check
Not applicable — no `web/src/` files. `consent.ts` is server-rendered HTML in `src/services/`, so the browser-attestation gate does not fire.

## Changelog
No changelog entry — beta MCP consent screen, developer_access-gated.

## Risks
Low. Pure presentational change to one server-rendered string; the security-relevant markup (hidden fields, csrf/consent name-value pairs, escaping) is byte-identical and covered by the unchanged test assertions. Rollback is a straight revert of the single commit.

## Goal alignment
First-touch trust for the MCP connector: a world-class consent screen lowers the drop-off at the moment a user decides whether to connect Claude to 2anki, which is the entry point for MCP-driven deck creation. No direct MRR line — this is connector-adoption plumbing, not a paid surface.
