### PR TITLE
fix: create_deck applies the deckName instead of the first heading

### DIFF
--- a/src/services/mcp/McpToolsService.test.ts
+++ b/src/services/mcp/McpToolsService.test.ts
@@ -385,6 +385,24 @@ describe('McpToolsService.createDeck', () => {
     expect(getPresignedUrl).toHaveBeenCalled();
   });
 
+  it('passes the deck name to the pipeline settings so it wins over the first heading', async () => {
+    let capturedBody: Record<string, unknown> | undefined;
+    const entry: UploadEntrypoint = (req, res) => {
+      capturedBody = (req as unknown as { body: Record<string, unknown> }).body;
+      res.set('X-Card-Count', '1');
+      res.set('File-Name', 'deck.apkg');
+      res.status(200).send(Buffer.from('APKG-BYTES'));
+    };
+    const { service } = makeService({ uploadEntry: entry });
+    await service.createDeck(
+      [{ front: 'morning', back: '朝' }],
+      'Japanese — Greetings',
+      'owner-9',
+      {}
+    );
+    expect(capturedBody).toEqual({ deckName: 'Japanese — Greetings' });
+  });
+
   it('falls back to the card count when the pipeline reports none', async () => {
     const entry: UploadEntrypoint = (_req, res) => {
       res.set('File-Name', 'deck.apkg');

--- a/src/services/mcp/McpToolsService.ts
+++ b/src/services/mcp/McpToolsService.ts
@@ -385,7 +385,7 @@ export class McpToolsService {
       size: buffer.byteLength,
       buffer,
     };
-    const res = await this.runUpload(file, locals);
+    const res = await this.runUpload(file, locals, { deckName: title });
     const result = await this.mapUploadResult(res, owner, title);
     if (result.kind === 'deck' && result.cardCount == null) {
       return { ...result, cardCount: cards.length };


### PR DESCRIPTION
## What
Fixes `create_deck` naming the Anki deck after the first card's heading instead of the `deckName` you pass. Found dogfooding: `deckName: "Japanese::Self-Introduction"` produced a deck named `## Hello. I'm Alexander.`

## Why
`create_deck` serializes cards to `## front / back` markdown and reused the upload pipeline, passing `deckName` only as the **filename**. The pipeline names the deck via `DeckParser`: `settings.deckName ?? getTitleFromMarkdown(contents)`. Since `settings.deckName` was never set, it fell through to `getTitleFromMarkdown` = the first line = `## <first card front>` (and `getTitleFromMarkdown` only strips a single `# `, so the `##` leaked too).

## How
`runUpload` now threads `{ deckName: title }` into the settings body for `create_deck`, so `DeckParser` uses it and never touches the markdown heading. The File-Name header and the persisted `.apkg` filename follow the deck name, so the download is named correctly as well.

## Testing
New test: `create_deck` puts `{ deckName }` in the upload settings body. 98 MCP tests green; tsc + format clean.

## Follow-up (separate PR, in flight)
The /downloads page shows an MCP deck twice (a jobs row + an uploads row) and labels the source "Upload"/"From the app" instead of MCP — `toDeckRows` doesn't recognize `type='mcp'` or dedup its upload. Being fixed separately (web + i18n).

## Goal alignment
Core correctness for the `create_deck` loop — the deck is named what the user asked for.

no changelog entry — developer_access-gated beta MCP tool.

Browser check: not applicable — server-only change, no web/src.