### PR TITLE
fix: show MCP-created decks once on My decks, labeled correctly

### DIFF
--- a/web/src/lib/i18n/locales/de/common.json
+++ b/web/src/lib/i18n/locales/de/common.json
@@ -429,7 +429,8 @@
       "upload": "Hochgeladen",
       "app": "Aus der App",
       "dropbox": "Dropbox",
-      "drive": "Drive"
+      "drive": "Drive",
+      "mcp": "Mit Claude erstellt"
     },
     "badge": {
       "writtenWithClaude": "Mit Claude geschrieben",

--- a/web/src/lib/i18n/locales/en/common.json
+++ b/web/src/lib/i18n/locales/en/common.json
@@ -429,7 +429,8 @@
       "upload": "Upload",
       "app": "From the app",
       "dropbox": "Dropbox",
-      "drive": "Drive"
+      "drive": "Drive",
+      "mcp": "Made with Claude"
     },
     "badge": {
       "writtenWithClaude": "Written with Claude",

--- a/web/src/lib/i18n/locales/es/common.json
+++ b/web/src/lib/i18n/locales/es/common.json
@@ -429,7 +429,8 @@
       "upload": "Subida",
       "app": "Desde la app",
       "dropbox": "Dropbox",
-      "drive": "Drive"
+      "drive": "Drive",
+      "mcp": "Hecho con Claude"
     },
     "badge": {
       "writtenWithClaude": "Escrito con Claude",

--- a/web/src/lib/i18n/locales/fr/common.json
+++ b/web/src/lib/i18n/locales/fr/common.json
@@ -429,7 +429,8 @@
       "upload": "Téléversement",
       "app": "Depuis l'application",
       "dropbox": "Dropbox",
-      "drive": "Drive"
+      "drive": "Drive",
+      "mcp": "Créé avec Claude"
     },
     "badge": {
       "writtenWithClaude": "Rédigé avec Claude",

--- a/web/src/lib/i18n/locales/it/common.json
+++ b/web/src/lib/i18n/locales/it/common.json
@@ -429,7 +429,8 @@
       "upload": "Caricamento",
       "app": "Dall'app",
       "dropbox": "Dropbox",
-      "drive": "Drive"
+      "drive": "Drive",
+      "mcp": "Creato con Claude"
     },
     "badge": {
       "writtenWithClaude": "Scritto con Claude",

--- a/web/src/lib/i18n/locales/ja/common.json
+++ b/web/src/lib/i18n/locales/ja/common.json
@@ -427,7 +427,8 @@
       "upload": "アップロード",
       "app": "アプリから",
       "dropbox": "Dropbox",
-      "drive": "Drive"
+      "drive": "Drive",
+      "mcp": "Claudeで作成"
     },
     "badge": {
       "writtenWithClaude": "Claude で作成",

--- a/web/src/lib/i18n/locales/nl/common.json
+++ b/web/src/lib/i18n/locales/nl/common.json
@@ -429,7 +429,8 @@
       "upload": "Upload",
       "app": "Uit de app",
       "dropbox": "Dropbox",
-      "drive": "Drive"
+      "drive": "Drive",
+      "mcp": "Gemaakt met Claude"
     },
     "badge": {
       "writtenWithClaude": "Geschreven met Claude",

--- a/web/src/lib/i18n/locales/pl/common.json
+++ b/web/src/lib/i18n/locales/pl/common.json
@@ -433,7 +433,8 @@
       "upload": "Przesłane",
       "app": "Z aplikacji",
       "dropbox": "Dropbox",
-      "drive": "Drive"
+      "drive": "Drive",
+      "mcp": "Utworzono w Claude"
     },
     "badge": {
       "writtenWithClaude": "Napisane z Claude",

--- a/web/src/lib/i18n/locales/pt/common.json
+++ b/web/src/lib/i18n/locales/pt/common.json
@@ -429,7 +429,8 @@
       "upload": "Upload",
       "app": "Do app",
       "dropbox": "Dropbox",
-      "drive": "Drive"
+      "drive": "Drive",
+      "mcp": "Feito com Claude"
     },
     "badge": {
       "writtenWithClaude": "Escrito com o Claude",

--- a/web/src/lib/i18n/locales/ru/common.json
+++ b/web/src/lib/i18n/locales/ru/common.json
@@ -433,7 +433,8 @@
       "upload": "Загрузка",
       "app": "Из приложения",
       "dropbox": "Dropbox",
-      "drive": "Drive"
+      "drive": "Drive",
+      "mcp": "Создано с помощью Claude"
     },
     "badge": {
       "writtenWithClaude": "Написано с Claude",

--- a/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
@@ -346,6 +346,34 @@ describe('DownloadsPage source labels', () => {
     renderAt('/downloads');
     expect(screen.getByText('From the app')).toBeInTheDocument();
   });
+
+  it('shows a done MCP deck once, labeled "Made with Claude"', () => {
+    mockJobs = [
+      buildJob({
+        type: 'mcp',
+        status: 'done',
+        object_id: 'mcp-deck-uuid',
+        title: 'Claude connector deck',
+        download_key: 'mcp-deck.apkg',
+        upload_id: 55,
+      }),
+    ];
+    mockUploads = [
+      {
+        id: 'u-mcp',
+        size_mb: 2,
+        owner: 1,
+        key: 'mcp-deck.apkg',
+        filename: 'Claude connector deck',
+        object_id: 'mcp-deck-uuid',
+        created_at: '2026-05-18T10:00:00Z',
+        source: null,
+      },
+    ];
+    renderAt('/downloads');
+    expect(screen.getByText('Made with Claude')).toBeInTheDocument();
+    expect(screen.getAllByText('Claude connector deck')).toHaveLength(1);
+  });
 });
 
 describe('DownloadsPage preview button on done job rows', () => {

--- a/web/src/pages/DownloadsPage/DownloadsPage.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.tsx
@@ -104,6 +104,8 @@ function getSourceLabel(source: DeckRow['source'], t: TFunction): string {
       return t('downloads.source.notion');
     case 'upload':
       return t('downloads.source.upload');
+    case 'mcp':
+      return t('downloads.source.mcp');
     case 'app':
       return t('downloads.source.app');
     case 'dropbox':
@@ -721,7 +723,8 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                             <EyeIcon width={16} height={16} />
                                           </Link>
                                         )}
-                                      {row.source === 'notion' &&
+                                      {(row.source === 'notion' ||
+                                        row.source === 'mcp') &&
                                         isDoneJob(row.job.status) &&
                                         row.job.upload_id != null && (
                                           <SendToAnkifyButton

--- a/web/src/pages/DownloadsPage/helpers/toDeckRows.test.ts
+++ b/web/src/pages/DownloadsPage/helpers/toDeckRows.test.ts
@@ -78,6 +78,11 @@ describe('toDeckRows — source mapping', () => {
     expect(rows[0].source).toBe('upload');
   });
 
+  it('maps job.type === "mcp" to source: mcp', () => {
+    const rows = toDeckRows([makeJob({ type: 'mcp' })], [], [], []);
+    expect(rows[0].source).toBe('mcp');
+  });
+
   it('maps unknown job.type to source: upload', () => {
     const rows = toDeckRows([makeJob({ type: 'apkg_import' })], [], [], []);
     expect(rows[0].source).toBe('upload');
@@ -230,6 +235,41 @@ describe('toDeckRows — Notion job dedupe', () => {
       key: 'other-deck.apkg',
     });
     const rows = toDeckRows([notionJob], [unrelatedUpload], [], []);
+    expect(rows).toHaveLength(2);
+  });
+});
+
+describe('toDeckRows — MCP job dedupe', () => {
+  it('suppresses the upload row so a done MCP deck with a download_key appears once', () => {
+    const mcpJob = makeJob({
+      id: 1 as JobsId,
+      type: 'mcp',
+      status: 'done',
+      object_id: 'mcp-deck-uuid',
+      download_key: 'deck-mcp123.apkg',
+      upload_id: 77,
+    });
+    const matchingUpload = makeUpload({
+      object_id: 'mcp-deck-uuid',
+      key: 'deck-mcp123.apkg',
+    });
+    const rows = toDeckRows([mcpJob], [matchingUpload], [], []);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe('job');
+    expect(rows[0].source).toBe('mcp');
+  });
+
+  it('keeps the upload row when the MCP job has no download_key', () => {
+    const mcpJob = makeJob({
+      id: 1 as JobsId,
+      type: 'mcp',
+      status: 'done',
+      object_id: 'mcp-deck-uuid',
+      download_key: null,
+      upload_id: null,
+    });
+    const upload = makeUpload({ object_id: 'mcp-deck-uuid' });
+    const rows = toDeckRows([mcpJob], [upload], [], []);
     expect(rows).toHaveLength(2);
   });
 });

--- a/web/src/pages/DownloadsPage/helpers/toDeckRows.ts
+++ b/web/src/pages/DownloadsPage/helpers/toDeckRows.ts
@@ -5,6 +5,7 @@ import { DropboxUpload, GoogleDriveUpload } from '../../../lib/backend';
 export type DeckRow =
   | { source: 'notion'; kind: 'job'; job: JobResponse; sortKey: Date }
   | { source: 'upload'; kind: 'job'; job: JobResponse; sortKey: Date }
+  | { source: 'mcp'; kind: 'job'; job: JobResponse; sortKey: Date }
   | {
       source: 'upload' | 'app';
       kind: 'file';
@@ -22,7 +23,10 @@ export type DeckRow =
 const NOTION_TYPES = new Set(['page', 'database', 'conversion']);
 const EPOCH = new Date(0);
 
-function jobSource(type: string | null | undefined): 'notion' | 'upload' {
+function jobSource(
+  type: string | null | undefined
+): 'notion' | 'upload' | 'mcp' {
+  if (type === 'mcp') return 'mcp';
   if (type != null && NOTION_TYPES.has(type)) return 'notion';
   return 'upload';
 }
@@ -40,11 +44,12 @@ function toSortKey(value: string | Date | null | undefined): Date {
 function buildSuppressedObjectIds(jobs: JobResponse[]): Set<string> {
   const ids = new Set<string>();
   for (const job of jobs) {
-    const isNotionDoneWithKey =
-      jobSource(job.type) === 'notion' &&
+    const source = jobSource(job.type);
+    const isGeneratedDoneWithKey =
+      (source === 'notion' || source === 'mcp') &&
       job.status === 'done' &&
       job.download_key != null;
-    if (isNotionDoneWithKey) ids.add(job.object_id);
+    if (isGeneratedDoneWithKey) ids.add(job.object_id);
   }
   return ids;
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-19-mcp-deck-source.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-19-mcp-deck-source.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-19-mcp-deck-source",
+  "date": "2026-07-19",
+  "type": "fix",
+  "title": "Decks made with the Claude connector show once on My decks, labeled Made with Claude"
+}


### PR DESCRIPTION
## What
On the My decks (`/downloads`) page, a deck created via the create_deck MCP tool appeared **twice** — once as an "Upload" job row and once as an "Upload" file row — with the wrong source label on both. It now appears **once**, labeled "Made with Claude", as the job row, with a working download, preview, and Send to Anki.

## Why
MCP deck persistence writes both a `jobs` row (`type='mcp'`) and an `uploads` row for the same `object_id`. The downloads list only recognized Notion job types as a distinct source (everything else fell through to `'upload'`) and only deduped Notion jobs' matching uploads — so the mcp job's upload row was never suppressed, and neither row carried a correct label. User-visible outcome: one clean row per Claude-connector deck, correctly attributed.

## How
- `toDeckRows.ts`: `jobSource` returns `'mcp'` for `type === 'mcp'`; the `DeckRow` job union gains an `'mcp'` source; `buildSuppressedObjectIds` now suppresses the matching upload for a **done** mcp job with a `download_key` (same dedup path as Notion). The mcp job row carries `download_key`/`upload_id` via the existing uploads join, so it serves the download and Send-to-Anki — matching the Notion job pattern.
- `DownloadsPage.tsx`: `getSourceLabel` gains a `case 'mcp'` → `downloads.source.mcp`; the Send-to-Anki button condition now includes `'mcp'` so the surviving row keeps that capability the suppressed upload row had. mcp is treated like an app/upload deck elsewhere (failure panel, image-drop), not like Notion.
- i18n: `downloads.source.mcp` added to all 10 locale `common.json` files (de/es/pt/fr/it/nl/pl/ru/ja translated, "Claude" verbatim).

## Measuring success
No new metric. Confirm in prod: create a deck via the Claude connector, open `/downloads` — exactly one row for it, badge reads "Made with Claude", the download link resolves. Query check: for an owner with an mcp deck, `jobs` (type='mcp', status='done') and its matching `uploads` row now collapse to one visible row.

## Testing
- Unit tests added (`toDeckRows.test.ts`): mcp job → source `'mcp'`; a done mcp job with a `download_key` suppresses its matching upload (one row); no `download_key` keeps both rows.
- Component test added (`DownloadsPage.test.tsx`): a done mcp deck renders once and shows the "Made with Claude" label.
- Full web suite green (2660 tests), web typecheck clean, tree-wide `pnpm format:check` clean, lint clean (only pre-existing warnings).
- Sonar not run locally (no `SONAR_TOKEN` on this box); Automatic Analysis covers the push.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: golden-path e2e not run in this worktree (no local dev server started); boxes left unticked honestly. The change is a data-mapping + label fix covered by the vitest component test.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-07-19-mcp-deck-source.json` — "Decks made with the Claude connector show once on My decks, labeled Made with Claude"

## Risks
Low, frontend-only. The mcp dedup mirrors the proven Notion dedup path; the only behavior change is one fewer duplicate row and a new label. If the mcp job row ever lacks a `download_key` (join miss), the upload row is kept (falls back to old two-row behavior), so no deck ever loses its download. Rollback: revert the branch.

## Goal alignment
Simpler/more beautiful: removes a confusing duplicate row and a wrong label from a paid-adjacent surface. No funnel/revenue metric targeted — a correctness fix on an existing surface (MCP connector, shipped 2026-07-18). None — internal correctness, not acquisition.

