### PR TITLE
fix: make the billing period unmistakable on /pricing before checkout

### DIFF
--- a/web/src/lib/i18n/locales/de/common.json
+++ b/web/src/lib/i18n/locales/de/common.json
@@ -350,8 +350,8 @@
     "unlimited": {
       "mostPopular": "Am beliebtesten",
       "perMonth": "/ Monat",
-      "yearlyHint": "{{annualTotal}}/Jahr, jährlich abgerechnet · spare {{savings}} %",
-      "monthlyHint": "monatlich abgerechnet",
+      "yearlyHint": "{{annualTotal}} heute fällig, dann jährlich · spare {{savings}} %",
+      "monthlyHint": "{{monthlyTotal}} heute fällig, dann monatlich",
       "billingCycle": "Abrechnungszeitraum",
       "yearlyOption": "Jährlich · spare {{savings}} %",
       "monthlyOption": "Monatlich",
@@ -366,9 +366,10 @@
       "benefitCancel": "Jederzeit kündbar",
       "tryAgain": "Erneut versuchen",
       "startingCheckout": "Checkout wird gestartet",
-      "getUnlimited": "Unlimited holen",
-      "termsYearly": "{{annualTotal}}/Jahr, verlängert sich jährlich. Jederzeit kündbar — der Zugang bleibt bis zum Ende des bezahlten Jahres.",
-      "termsMonthly": "{{monthlyTotal}}/Monat, verlängert sich monatlich. Jederzeit kündbar.",
+      "getUnlimitedYearly": "Unlimited holen — jährliche Abrechnung",
+      "getUnlimitedMonthly": "Unlimited holen — monatliche Abrechnung",
+      "termsYearly": "{{annualTotal}} heute fällig, verlängert sich jährlich. Jederzeit kündbar — der Zugang bleibt bis zum Ende des bezahlten Jahres.",
+      "termsMonthly": "{{monthlyTotal}} heute fällig, verlängert sich monatlich. Jederzeit kündbar.",
       "checkoutError": "Der Checkout konnte nicht gestartet werden. Versuch es erneut oder schreib an support@2anki.net."
     },
     "card": {

--- a/web/src/lib/i18n/locales/en/common.json
+++ b/web/src/lib/i18n/locales/en/common.json
@@ -350,8 +350,8 @@
     "unlimited": {
       "mostPopular": "Most popular",
       "perMonth": "/ mo",
-      "yearlyHint": "{{annualTotal}}/year billed yearly · save {{savings}}%",
-      "monthlyHint": "billed monthly",
+      "yearlyHint": "{{annualTotal}} billed today, then yearly · save {{savings}}%",
+      "monthlyHint": "{{monthlyTotal}} billed today, then monthly",
       "billingCycle": "Billing cycle",
       "yearlyOption": "Yearly · save {{savings}}%",
       "monthlyOption": "Monthly",
@@ -366,9 +366,10 @@
       "benefitCancel": "Cancel anytime",
       "tryAgain": "Try again",
       "startingCheckout": "Starting checkout",
-      "getUnlimited": "Get Unlimited",
-      "termsYearly": "{{annualTotal}}/year, renews yearly. Cancel anytime — keeps access through the year you paid for.",
-      "termsMonthly": "{{monthlyTotal}}/month, renews monthly. Cancel anytime.",
+      "getUnlimitedYearly": "Get Unlimited — billed yearly",
+      "getUnlimitedMonthly": "Get Unlimited — billed monthly",
+      "termsYearly": "{{annualTotal}} billed today, renews yearly. Cancel anytime — keeps access through the year you paid for.",
+      "termsMonthly": "{{monthlyTotal}} billed today, renews monthly. Cancel anytime.",
       "checkoutError": "Couldn't start checkout. Try again, or email support@2anki.net."
     },
     "card": {

--- a/web/src/lib/i18n/locales/es/common.json
+++ b/web/src/lib/i18n/locales/es/common.json
@@ -350,8 +350,8 @@
     "unlimited": {
       "mostPopular": "El más popular",
       "perMonth": "/ mes",
-      "yearlyHint": "{{annualTotal}}/año facturado anualmente · ahorra un {{savings}} %",
-      "monthlyHint": "facturado mensualmente",
+      "yearlyHint": "{{annualTotal}} se cobra hoy, luego cada año · ahorra un {{savings}} %",
+      "monthlyHint": "{{monthlyTotal}} se cobra hoy, luego cada mes",
       "billingCycle": "Ciclo de facturación",
       "yearlyOption": "Anual · ahorra un {{savings}} %",
       "monthlyOption": "Mensual",
@@ -366,9 +366,10 @@
       "benefitCancel": "Cancela cuando quieras",
       "tryAgain": "Inténtalo de nuevo",
       "startingCheckout": "Abriendo el pago",
-      "getUnlimited": "Consigue Unlimited",
-      "termsYearly": "{{annualTotal}}/año, se renueva anualmente. Cancela cuando quieras — conservas el acceso durante el año que pagaste.",
-      "termsMonthly": "{{monthlyTotal}}/mes, se renueva mensualmente. Cancela cuando quieras.",
+      "getUnlimitedYearly": "Consigue Unlimited — facturación anual",
+      "getUnlimitedMonthly": "Consigue Unlimited — facturación mensual",
+      "termsYearly": "{{annualTotal}} se cobra hoy, se renueva anualmente. Cancela cuando quieras — conservas el acceso durante el año que pagaste.",
+      "termsMonthly": "{{monthlyTotal}} se cobra hoy, se renueva mensualmente. Cancela cuando quieras.",
       "checkoutError": "No se pudo iniciar el pago. Inténtalo de nuevo, o escribe a support@2anki.net."
     },
     "card": {

--- a/web/src/lib/i18n/locales/fr/common.json
+++ b/web/src/lib/i18n/locales/fr/common.json
@@ -350,8 +350,8 @@
     "unlimited": {
       "mostPopular": "Le plus populaire",
       "perMonth": "/ mois",
-      "yearlyHint": "{{annualTotal}}/an facturé annuellement · économise {{savings}} %",
-      "monthlyHint": "facturé mensuellement",
+      "yearlyHint": "{{annualTotal}} facturé aujourd'hui, puis chaque année · économise {{savings}} %",
+      "monthlyHint": "{{monthlyTotal}} facturé aujourd'hui, puis chaque mois",
       "billingCycle": "Cycle de facturation",
       "yearlyOption": "Annuel · économise {{savings}} %",
       "monthlyOption": "Mensuel",
@@ -366,9 +366,10 @@
       "benefitCancel": "Annulable à tout moment",
       "tryAgain": "Réessayer",
       "startingCheckout": "Ouverture du paiement",
-      "getUnlimited": "Prendre Unlimited",
-      "termsYearly": "{{annualTotal}}/an, se renouvelle chaque année. Annulable à tout moment — l'accès est conservé jusqu'à la fin de l'année payée.",
-      "termsMonthly": "{{monthlyTotal}}/mois, se renouvelle chaque mois. Annulable à tout moment.",
+      "getUnlimitedYearly": "Prendre Unlimited — facturation annuelle",
+      "getUnlimitedMonthly": "Prendre Unlimited — facturation mensuelle",
+      "termsYearly": "{{annualTotal}} facturé aujourd'hui, se renouvelle chaque année. Annulable à tout moment — l'accès est conservé jusqu'à la fin de l'année payée.",
+      "termsMonthly": "{{monthlyTotal}} facturé aujourd'hui, se renouvelle chaque mois. Annulable à tout moment.",
       "checkoutError": "Impossible de démarrer le paiement. Réessaie, ou écris à support@2anki.net."
     },
     "card": {

--- a/web/src/lib/i18n/locales/it/common.json
+++ b/web/src/lib/i18n/locales/it/common.json
@@ -350,8 +350,8 @@
     "unlimited": {
       "mostPopular": "Più scelto",
       "perMonth": "/ mese",
-      "yearlyHint": "{{annualTotal}}/anno con fatturazione annuale · risparmi {{savings}}%",
-      "monthlyHint": "fatturazione mensile",
+      "yearlyHint": "{{annualTotal}} addebitato oggi, poi ogni anno · risparmi {{savings}}%",
+      "monthlyHint": "{{monthlyTotal}} addebitato oggi, poi ogni mese",
       "billingCycle": "Ciclo di fatturazione",
       "yearlyOption": "Annuale · risparmi {{savings}}%",
       "monthlyOption": "Mensile",
@@ -366,9 +366,10 @@
       "benefitCancel": "Disdici quando vuoi",
       "tryAgain": "Riprova",
       "startingCheckout": "Avvio del pagamento",
-      "getUnlimited": "Ottieni Unlimited",
-      "termsYearly": "{{annualTotal}}/anno, si rinnova ogni anno. Disdici quando vuoi — mantieni l'accesso per l'anno che hai pagato.",
-      "termsMonthly": "{{monthlyTotal}}/mese, si rinnova ogni mese. Disdici quando vuoi.",
+      "getUnlimitedYearly": "Ottieni Unlimited — fatturazione annuale",
+      "getUnlimitedMonthly": "Ottieni Unlimited — fatturazione mensile",
+      "termsYearly": "{{annualTotal}} addebitato oggi, si rinnova ogni anno. Disdici quando vuoi — mantieni l'accesso per l'anno che hai pagato.",
+      "termsMonthly": "{{monthlyTotal}} addebitato oggi, si rinnova ogni mese. Disdici quando vuoi.",
       "checkoutError": "Non siamo riusciti ad avviare il pagamento. Riprova, oppure scrivi a support@2anki.net."
     },
     "card": {

--- a/web/src/lib/i18n/locales/ja/common.json
+++ b/web/src/lib/i18n/locales/ja/common.json
@@ -348,8 +348,8 @@
     "unlimited": {
       "mostPopular": "一番人気",
       "perMonth": "/ 月",
-      "yearlyHint": "年払いで {{annualTotal}}/年 · {{savings}}% お得",
-      "monthlyHint": "月払い",
+      "yearlyHint": "本日 {{annualTotal}} を請求、以降は年払い · {{savings}}% お得",
+      "monthlyHint": "本日 {{monthlyTotal}} を請求、以降は月払い",
       "billingCycle": "請求サイクル",
       "yearlyOption": "年払い · {{savings}}% お得",
       "monthlyOption": "月払い",
@@ -364,9 +364,10 @@
       "benefitCancel": "いつでも解約",
       "tryAgain": "再試行",
       "startingCheckout": "チェックアウトを開始しています",
-      "getUnlimited": "Get Unlimited",
-      "termsYearly": "{{annualTotal}}/年、毎年更新。いつでも解約可能 — お支払い済みの 1 年間はご利用いただけます。",
-      "termsMonthly": "{{monthlyTotal}}/月、毎月更新。いつでも解約可能。",
+      "getUnlimitedYearly": "Get Unlimited — 年払い",
+      "getUnlimitedMonthly": "Get Unlimited — 月払い",
+      "termsYearly": "本日 {{annualTotal}} を請求、毎年更新。いつでも解約可能 — お支払い済みの 1 年間はご利用いただけます。",
+      "termsMonthly": "本日 {{monthlyTotal}} を請求、毎月更新。いつでも解約可能。",
       "checkoutError": "チェックアウトを開始できませんでした。もう一度お試しいただくか、support@2anki.net までご連絡ください。"
     },
     "card": {

--- a/web/src/lib/i18n/locales/nl/common.json
+++ b/web/src/lib/i18n/locales/nl/common.json
@@ -350,8 +350,8 @@
     "unlimited": {
       "mostPopular": "Meest gekozen",
       "perMonth": "/ mnd",
-      "yearlyHint": "{{annualTotal}}/jaar jaarlijks gefactureerd · bespaar {{savings}}%",
-      "monthlyHint": "maandelijks gefactureerd",
+      "yearlyHint": "{{annualTotal}} vandaag afgeschreven, daarna jaarlijks · bespaar {{savings}}%",
+      "monthlyHint": "{{monthlyTotal}} vandaag afgeschreven, daarna maandelijks",
       "billingCycle": "Facturatiecyclus",
       "yearlyOption": "Jaarlijks · bespaar {{savings}}%",
       "monthlyOption": "Maandelijks",
@@ -366,9 +366,10 @@
       "benefitCancel": "Altijd opzegbaar",
       "tryAgain": "Opnieuw proberen",
       "startingCheckout": "Afrekenen starten",
-      "getUnlimited": "Unlimited kopen",
-      "termsYearly": "{{annualTotal}}/jaar, wordt jaarlijks verlengd. Altijd opzegbaar — je houdt toegang gedurende het jaar waarvoor je betaalde.",
-      "termsMonthly": "{{monthlyTotal}}/maand, wordt maandelijks verlengd. Altijd opzegbaar.",
+      "getUnlimitedYearly": "Unlimited kopen — jaarlijkse facturering",
+      "getUnlimitedMonthly": "Unlimited kopen — maandelijkse facturering",
+      "termsYearly": "{{annualTotal}} vandaag afgeschreven, wordt jaarlijks verlengd. Altijd opzegbaar — je houdt toegang gedurende het jaar waarvoor je betaalde.",
+      "termsMonthly": "{{monthlyTotal}} vandaag afgeschreven, wordt maandelijks verlengd. Altijd opzegbaar.",
       "checkoutError": "Kon het afrekenen niet starten. Probeer het opnieuw, of mail support@2anki.net."
     },
     "card": {

--- a/web/src/lib/i18n/locales/nl/nl.test.ts
+++ b/web/src/lib/i18n/locales/nl/nl.test.ts
@@ -92,7 +92,9 @@ describe('Dutch (nl) locale parity', () => {
     const common = flatten(nlCommon);
     expect(common['pricing.pass.getDayPass']).toBe('Day Pass kopen');
     expect(common['pricing.pass.getWeekPass']).toBe('Week Pass kopen');
-    expect(common['pricing.unlimited.getUnlimited']).toBe('Unlimited kopen');
+    expect(common['pricing.unlimited.getUnlimitedYearly']).toBe(
+      'Unlimited kopen — jaarlijkse facturering'
+    );
     expect(common['pricing.contextBanner']).toContain('100 kaarten per maand');
   });
 });

--- a/web/src/lib/i18n/locales/pl/common.json
+++ b/web/src/lib/i18n/locales/pl/common.json
@@ -354,8 +354,8 @@
     "unlimited": {
       "mostPopular": "Najpopularniejszy",
       "perMonth": "/ mies.",
-      "yearlyHint": "{{annualTotal}}/rok przy płatności rocznej · oszczędzasz {{savings}}%",
-      "monthlyHint": "rozliczane miesięcznie",
+      "yearlyHint": "{{annualTotal}} pobierane dziś, potem co roku · oszczędzasz {{savings}}%",
+      "monthlyHint": "{{monthlyTotal}} pobierane dziś, potem co miesiąc",
       "billingCycle": "Cykl rozliczeniowy",
       "yearlyOption": "Rocznie · oszczędzasz {{savings}}%",
       "monthlyOption": "Miesięcznie",
@@ -370,9 +370,10 @@
       "benefitCancel": "Anuluj w każdej chwili",
       "tryAgain": "Spróbuj ponownie",
       "startingCheckout": "Rozpoczynanie płatności",
-      "getUnlimited": "Kup Unlimited",
-      "termsYearly": "{{annualTotal}}/rok, odnawia się co roku. Anuluj w każdej chwili — zachowujesz dostęp przez opłacony rok.",
-      "termsMonthly": "{{monthlyTotal}}/miesiąc, odnawia się co miesiąc. Anuluj w każdej chwili.",
+      "getUnlimitedYearly": "Kup Unlimited — płatność roczna",
+      "getUnlimitedMonthly": "Kup Unlimited — płatność miesięczna",
+      "termsYearly": "{{annualTotal}} pobierane dziś, odnawia się co roku. Anuluj w każdej chwili — zachowujesz dostęp przez opłacony rok.",
+      "termsMonthly": "{{monthlyTotal}} pobierane dziś, odnawia się co miesiąc. Anuluj w każdej chwili.",
       "checkoutError": "Nie udało się rozpocząć płatności. Spróbuj ponownie albo napisz na support@2anki.net."
     },
     "card": {

--- a/web/src/lib/i18n/locales/pt/common.json
+++ b/web/src/lib/i18n/locales/pt/common.json
@@ -350,8 +350,8 @@
     "unlimited": {
       "mostPopular": "Mais popular",
       "perMonth": "/ mês",
-      "yearlyHint": "{{annualTotal}}/ano na cobrança anual · economize {{savings}}%",
-      "monthlyHint": "cobrança mensal",
+      "yearlyHint": "{{annualTotal}} cobrado hoje, depois anualmente · economize {{savings}}%",
+      "monthlyHint": "{{monthlyTotal}} cobrado hoje, depois mensalmente",
       "billingCycle": "Ciclo de cobrança",
       "yearlyOption": "Anual · economize {{savings}}%",
       "monthlyOption": "Mensal",
@@ -366,9 +366,10 @@
       "benefitCancel": "Cancele quando quiser",
       "tryAgain": "Tentar de novo",
       "startingCheckout": "Iniciando o checkout",
-      "getUnlimited": "Obter Unlimited",
-      "termsYearly": "{{annualTotal}}/ano, renova anualmente. Cancele quando quiser — o acesso continua até o fim do ano pago.",
-      "termsMonthly": "{{monthlyTotal}}/mês, renova mensalmente. Cancele quando quiser.",
+      "getUnlimitedYearly": "Obter Unlimited — cobrança anual",
+      "getUnlimitedMonthly": "Obter Unlimited — cobrança mensal",
+      "termsYearly": "{{annualTotal}} cobrado hoje, renova anualmente. Cancele quando quiser — o acesso continua até o fim do ano pago.",
+      "termsMonthly": "{{monthlyTotal}} cobrado hoje, renova mensalmente. Cancele quando quiser.",
       "checkoutError": "Não foi possível iniciar o checkout. Tente de novo, ou envie um e-mail para support@2anki.net."
     },
     "card": {

--- a/web/src/lib/i18n/locales/ru/common.json
+++ b/web/src/lib/i18n/locales/ru/common.json
@@ -354,8 +354,8 @@
     "unlimited": {
       "mostPopular": "Самый популярный",
       "perMonth": "/ мес",
-      "yearlyHint": "{{annualTotal}}/год при годовой оплате · экономия {{savings}}%",
-      "monthlyHint": "оплата помесячно",
+      "yearlyHint": "{{annualTotal}} спишется сегодня, далее ежегодно · экономия {{savings}}%",
+      "monthlyHint": "{{monthlyTotal}} спишется сегодня, далее ежемесячно",
       "billingCycle": "Цикл оплаты",
       "yearlyOption": "Годовой · экономия {{savings}}%",
       "monthlyOption": "Помесячно",
@@ -370,9 +370,10 @@
       "benefitCancel": "Отмена в любой момент",
       "tryAgain": "Попробовать снова",
       "startingCheckout": "Открываем оплату",
-      "getUnlimited": "Купить Unlimited",
-      "termsYearly": "{{annualTotal}}/год, продлевается ежегодно. Отмена в любой момент — доступ сохраняется до конца оплаченного года.",
-      "termsMonthly": "{{monthlyTotal}}/месяц, продлевается ежемесячно. Отмена в любой момент.",
+      "getUnlimitedYearly": "Купить Unlimited — годовая оплата",
+      "getUnlimitedMonthly": "Купить Unlimited — помесячная оплата",
+      "termsYearly": "{{annualTotal}} спишется сегодня, продлевается ежегодно. Отмена в любой момент — доступ сохраняется до конца оплаченного года.",
+      "termsMonthly": "{{monthlyTotal}} спишется сегодня, продлевается ежемесячно. Отмена в любой момент.",
       "checkoutError": "Не удалось открыть оплату. Попробуй ещё раз или напиши на support@2anki.net."
     },
     "card": {

--- a/web/src/pages/PricingPage/PricingPage.module.css
+++ b/web/src/pages/PricingPage/PricingPage.module.css
@@ -666,8 +666,8 @@
    BILLING TOGGLE — in-card cycle selector on Unlimited card
    ===================================================================== */
 .billingToggle {
-  display: inline-flex;
-  align-self: flex-start;
+  display: flex;
+  align-self: stretch;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-full);
   overflow: hidden;
@@ -680,7 +680,7 @@
   flex: 1;
   padding: 0.3rem 0.85rem;
   font-family: var(--font-sans);
-  font-size: var(--text-xs);
+  font-size: var(--text-sm);
   font-weight: var(--font-medium);
   border: none;
   background: transparent;
@@ -688,13 +688,14 @@
   transition:
     background var(--transition-fast),
     color var(--transition-fast);
-  color: var(--color-text-secondary);
+  color: var(--color-text-tertiary);
   white-space: nowrap;
 }
 
 .billingToggleOptionActive {
   background: var(--color-primary);
   color: var(--color-bg-primary);
+  font-weight: var(--font-semibold);
 }
 
 .billingToggleOption:hover {

--- a/web/src/pages/PricingPage/PricingPage.test.tsx
+++ b/web/src/pages/PricingPage/PricingPage.test.tsx
@@ -400,7 +400,9 @@ describe('PricingPage internal event tracking', () => {
     });
 
     renderAt('/pricing', { isLoggedIn: true });
-    fireEvent.click(screen.getByRole('button', { name: 'Get Unlimited' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Get Unlimited — billed yearly' })
+    );
 
     await waitFor(() => {
       expect(trackMock).toHaveBeenCalledWith('paywall_upgrade_clicked', {
@@ -494,7 +496,9 @@ describe('PricingPage anonymous upgrade-click tracking', () => {
     });
 
     renderAt('/pricing', { isLoggedIn: false });
-    fireEvent.click(screen.getByRole('button', { name: 'Get Unlimited' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Get Unlimited — billed yearly' })
+    );
 
     expect(trackMock).toHaveBeenCalledWith('paywall_upgrade_clicked', {
       surface: 'pricing_page',
@@ -602,7 +606,7 @@ describe('PricingPage Unlimited billing toggle', () => {
     ).toHaveAttribute('aria-checked', 'true');
     expect(screen.getByText('$5.00')).toBeInTheDocument();
     expect(
-      screen.getByText('$60/year billed yearly · save 17%')
+      screen.getByText('$60 billed today, then yearly · save 17%')
     ).toBeInTheDocument();
   });
 
@@ -610,9 +614,11 @@ describe('PricingPage Unlimited billing toggle', () => {
     renderAt('/pricing');
     fireEvent.click(screen.getByRole('radio', { name: 'Monthly' }));
     expect(screen.getByText('$6')).toBeInTheDocument();
-    expect(screen.getByText('billed monthly')).toBeInTheDocument();
     expect(
-      screen.getByText('$6/month, renews monthly. Cancel anytime.')
+      screen.getByText('$6 billed today, then monthly')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('$6 billed today, renews monthly. Cancel anytime.')
     ).toBeInTheDocument();
   });
 
@@ -627,7 +633,9 @@ describe('PricingPage Unlimited billing toggle', () => {
 
     renderAt('/pricing', { isLoggedIn: true });
     fireEvent.click(screen.getByRole('radio', { name: 'Monthly' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Get Unlimited' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Get Unlimited — billed monthly' })
+    );
 
     await waitFor(() => {
       expect(mockStartUnlimitedCheckout).toHaveBeenCalledWith(
@@ -648,7 +656,9 @@ describe('PricingPage Unlimited billing toggle', () => {
     });
 
     renderAt('/pricing', { isLoggedIn: true });
-    fireEvent.click(screen.getByRole('button', { name: 'Get Unlimited' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Get Unlimited — billed yearly' })
+    );
 
     await waitFor(() => {
       expect(mockStartUnlimitedCheckout).toHaveBeenCalledWith(
@@ -665,7 +675,9 @@ describe('PricingPage Unlimited billing toggle', () => {
       value: { href: '' },
     });
     renderAt('/pricing', { isLoggedIn: false });
-    fireEvent.click(screen.getByRole('button', { name: 'Get Unlimited' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Get Unlimited — billed yearly' })
+    );
     expect(globalThis.location.href).toBe('/login?redirect=/pricing');
   });
 

--- a/web/src/pages/PricingPage/components/UnlimitedCard.tsx
+++ b/web/src/pages/PricingPage/components/UnlimitedCard.tsx
@@ -76,7 +76,9 @@ export function UnlimitedCard({
   function getButtonLabel(): string {
     if (error) return t('pricing.unlimited.tryAgain');
     if (pending) return t('pricing.unlimited.startingCheckout');
-    return t('pricing.unlimited.getUnlimited');
+    return isYearly
+      ? t('pricing.unlimited.getUnlimitedYearly')
+      : t('pricing.unlimited.getUnlimitedMonthly');
   }
 
   return (
@@ -98,7 +100,7 @@ export function UnlimitedCard({
           </p>
         ) : (
           <p className={styles.yearlyHint}>
-            {t('pricing.unlimited.monthlyHint')}
+            {t('pricing.unlimited.monthlyHint', { monthlyTotal })}
           </p>
         )}
         {yearlyAvailable && (

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-19-pricing-billing-period.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-19-pricing-billing-period.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-19-pricing-billing-period",
+  "date": "2026-07-19",
+  "type": "fix",
+  "title": "Pricing shows the full amount billed today and the billing period on the button before checkout"
+}

--- a/web/tests/checkout.spec.ts
+++ b/web/tests/checkout.spec.ts
@@ -60,7 +60,7 @@ test.describe('Unlimited checkout', () => {
 
     await expect(page.getByText('$5.00').first()).toBeVisible();
     await expect(
-      page.getByText('$60/year billed yearly · save 17%')
+      page.getByText('$60 billed today, then yearly · save 17%')
     ).toBeVisible();
     await expect(page.getByText('$5.33')).toBeHidden();
   });
@@ -73,7 +73,7 @@ test.describe('Unlimited checkout', () => {
 
     await expect(page.getByText('$5.33')).toBeVisible();
     await expect(
-      page.getByText('$64/year billed yearly · save 33%')
+      page.getByText('$64 billed today, then yearly · save 33%')
     ).toBeVisible();
   });
 
@@ -92,7 +92,9 @@ test.describe('Unlimited checkout', () => {
     });
 
     await page.goto('/pricing');
-    await page.getByRole('button', { name: 'Get Unlimited' }).click();
+    await page
+      .getByRole('button', { name: 'Get Unlimited — billed yearly' })
+      .click();
 
     await expect.poll(() => checkoutBody.interval).toBe('year');
   });


### PR DESCRIPTION
Fixes https://github.com/2anki/server/issues/3738

## Problem
Pricing v2 made **annual the default** (an intentional ARPU lever). But the "Get Unlimited" CTA proceeded to Stripe at the yearly plan without the billing period being obvious at the decision point, so a user intending the $7.99/mo monthly plan could pay a full year by accident — this produced a cancel + full refund. The annual default is correct; the user couldn't *see* it.

## Change (annual stays the default — clarity only)
- **CTA echoes the period** — "Get Unlimited — billed yearly" vs "— billed monthly".
- **Price hint leads with the amount charged today** — "$64 billed today, then yearly · save 33%" (and a symmetric monthly hint), so the muted per-month figure isn't misread as the charge.
- **Terms line aligned** — "$64 billed today, renews yearly. Cancel anytime …".
- **Toggle is now a full-width segmented control** with a clear selected-state weight delta, so which period is on reads at a glance.
- Copy updated across **all 10 locales**; `de`/`pt`/`es` (traffic-bearing) worth a native pass on the "billed today" idiom + em-dash CTA.

Not building a custom Stripe confirm step — Stripe Checkout already shows the interval and total before the card is charged; adding a click there would be friction on the one path that moves acquisition.

## Trio
pm + designer + engineer reviewed in parallel; agreed, no conflict. pm: minimal high-impact fix = show total + echo period, don't touch the default. designer: keep $5.33 hero, three reinforcements of the real charge, loud toggle.

## Metric
Should lower the **accidental-annual refund / cancel-within-7-days rate**; guardrail **checkout→paid ≥50%** so added clarity doesn't scare buyers off annual. Read at `/api/ops/metrics`, cross-checked against ARPU at `/api/ops/business/metrics`. Verify ~2 weeks post-ship.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: PricingPage vitest (incl. billing-toggle + CTA assertions) and nl locale-parity test green; web typecheck + tree-wide format:check clean; golden-path spec run as attestation evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs4pvvQ4BKVpvEtGA9GXTn
