### PR TITLE
fix: serve MCP deck downloads via a branded 2anki.net link

### DIFF
--- a/src/controllers/McpDeckDownloadController.ts
+++ b/src/controllers/McpDeckDownloadController.ts
@@ -1,0 +1,23 @@
+import { Request, Response } from 'express';
+
+import { ResolveMcpDeckDownloadUseCase } from '../usecases/mcp/ResolveMcpDeckDownloadUseCase';
+import { track } from '../services/events/track';
+
+class McpDeckDownloadController {
+  constructor(private readonly useCase: ResolveMcpDeckDownloadUseCase) {}
+
+  async download(req: Request, res: Response): Promise<void> {
+    const result = await this.useCase.resolve(req.params.objectId);
+    if (result.kind === 'not_found') {
+      res.status(404).send();
+      return;
+    }
+    track('mcp_deck_download', {
+      userId: result.owner,
+      props: { source: 'mcp_single' },
+    });
+    res.redirect(302, result.url);
+  }
+}
+
+export default McpDeckDownloadController;

--- a/src/controllers/Upload/DropboxController.test.ts
+++ b/src/controllers/Upload/DropboxController.test.ts
@@ -32,6 +32,7 @@ function makeController(
     deleteUpload: jest.fn().mockResolvedValue(1),
     getUploadsByOwner: jest.fn().mockResolvedValue([]),
     findByIdAndOwner: jest.fn().mockResolvedValue(null),
+    findByObjectId: jest.fn().mockResolvedValue(null),
     findByKey: jest.fn().mockResolvedValue(null),
     findAllByObjectIdAndOwner: jest.fn().mockResolvedValue([]),
     update: jest.fn().mockResolvedValue([]),

--- a/src/controllers/Upload/GoogleDriveController.test.ts
+++ b/src/controllers/Upload/GoogleDriveController.test.ts
@@ -31,6 +31,7 @@ function makeController(
     deleteUpload: jest.fn().mockResolvedValue(1),
     getUploadsByOwner: jest.fn().mockResolvedValue([]),
     findByIdAndOwner: jest.fn().mockResolvedValue(null),
+    findByObjectId: jest.fn().mockResolvedValue(null),
     findByKey: jest.fn().mockResolvedValue(null),
     findAllByObjectIdAndOwner: jest.fn().mockResolvedValue([]),
     update: jest.fn().mockResolvedValue([]),

--- a/src/controllers/Upload/UploadController.test.ts
+++ b/src/controllers/Upload/UploadController.test.ts
@@ -51,6 +51,9 @@ describe('Upload file', () => {
       ): Promise<Uploads | null> {
         return Promise.resolve(null);
       },
+      findByObjectId: function (_objectId: string): Promise<Uploads | null> {
+        return Promise.resolve(null);
+      },
       findByKey: function (
         _owner: number,
         _key: string
@@ -169,6 +172,7 @@ describe('Upload file — multer error handling', () => {
       deleteUpload: jest.fn(),
       getUploadsByOwner: jest.fn().mockResolvedValue([]),
       findByIdAndOwner: jest.fn().mockResolvedValue(null),
+      findByObjectId: jest.fn().mockResolvedValue(null),
       findByKey: jest.fn().mockResolvedValue(null),
       findAllByObjectIdAndOwner: jest.fn().mockResolvedValue([]),
       update: jest.fn().mockResolvedValue([]),
@@ -229,6 +233,7 @@ describe('UploadController.retryPdfWithCredential rate limit', () => {
       deleteUpload: jest.fn(),
       getUploadsByOwner: jest.fn().mockResolvedValue([]),
       findByIdAndOwner: jest.fn().mockResolvedValue(null),
+      findByObjectId: jest.fn().mockResolvedValue(null),
       findByKey: jest.fn().mockResolvedValue(null),
       findAllByObjectIdAndOwner: jest.fn().mockResolvedValue([]),
       update: jest.fn().mockResolvedValue([]),
@@ -310,6 +315,7 @@ describe('UploadController.retryPdfWithCredential rate limit', () => {
       deleteUpload: jest.fn(),
       getUploadsByOwner: jest.fn().mockResolvedValue([]),
       findByIdAndOwner: jest.fn().mockResolvedValue(null),
+      findByObjectId: jest.fn().mockResolvedValue(null),
       findByKey: jest.fn().mockResolvedValue(null),
       findAllByObjectIdAndOwner: jest.fn().mockResolvedValue([]),
       update: jest.fn().mockResolvedValue([]),

--- a/src/data_layer/UploadRespository.sql.test.ts
+++ b/src/data_layer/UploadRespository.sql.test.ts
@@ -33,6 +33,25 @@ describe('UploadRepository.update generated SQL', () => {
   });
 });
 
+describe('UploadRepository.findByObjectId generated SQL', () => {
+  it('scopes the lookup to the object_id and rows with a non-null key', () => {
+    const pg = knex({ client: 'pg' });
+
+    const sql = pg('uploads')
+      .select('*')
+      .where({ object_id: 'abc-123' })
+      .whereNotNull('object_id')
+      .whereNotNull('key')
+      .first()
+      .toString();
+
+    expect(sql).toBe(
+      'select * from "uploads" where "object_id" = \'abc-123\' ' +
+        'and "object_id" is not null and "key" is not null limit 1'
+    );
+  });
+});
+
 describe('UploadRepository.getLastReconvertibleUpload generated SQL', () => {
   it('filters apkg keys with a bound parameter and orders by created_at desc', () => {
     const pg = knex({ client: 'pg' });

--- a/src/data_layer/UploadRespository.test.ts
+++ b/src/data_layer/UploadRespository.test.ts
@@ -40,3 +40,17 @@ describe('UploadRepository owner guards', () => {
     expect(warn).toHaveBeenCalled();
   });
 });
+
+describe('UploadRepository.findByObjectId', () => {
+  it('returns null and skips the query when the object id is null', async () => {
+    let queried = false;
+    const db = () => {
+      queried = true;
+      return {} as never;
+    };
+    const repo = new UploadRepository(db as unknown as never);
+    const result = await repo.findByObjectId(null as unknown as string);
+    expect(result).toBeNull();
+    expect(queried).toBe(false);
+  });
+});

--- a/src/data_layer/UploadRespository.ts
+++ b/src/data_layer/UploadRespository.ts
@@ -33,6 +33,7 @@ export interface IUploadRepository {
   deleteUpload(owner: number, key: string): Promise<number>;
   getUploadsByOwner(owner: number): Promise<Uploads[]>;
   findByIdAndOwner(id: number, owner: number): Promise<Uploads | null>;
+  findByObjectId(objectId: string): Promise<Uploads | null>;
   findByKey(owner: number, key: string): Promise<Uploads | null>;
   findAllByObjectIdAndOwner(
     objectId: string,
@@ -88,6 +89,19 @@ class UploadRepository implements IUploadRepository {
       .select('*')
       .where('id', id)
       .andWhere('owner', owner)
+      .first();
+    return row ?? null;
+  }
+
+  async findByObjectId(objectId: string): Promise<Uploads | null> {
+    if (objectId == null) {
+      return null;
+    }
+    const row = await this.database<Uploads>(this.table)
+      .select('*')
+      .where({ object_id: objectId })
+      .whereNotNull('object_id')
+      .whereNotNull('key')
       .first();
     return row ?? null;
   }

--- a/src/lib/storage/StorageHandler.test.ts
+++ b/src/lib/storage/StorageHandler.test.ts
@@ -1,3 +1,6 @@
+import { GetObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+
 import StorageHandler from './StorageHandler';
 
 const mockSend = jest.fn();
@@ -45,5 +48,54 @@ describe('StorageHandler.getFileContents', () => {
     const result = await handler.getFileContents('some/key.apkg');
 
     expect(result.Body).toBeUndefined();
+  });
+});
+
+describe('StorageHandler.getPresignedUrl', () => {
+  const signedUrlMock = getSignedUrl as jest.MockedFunction<
+    typeof getSignedUrl
+  >;
+
+  beforeEach(() => {
+    signedUrlMock.mockClear();
+    process.env.SPACES_DEFAULT_BUCKET_NAME = 'test-bucket';
+    process.env.SPACES_ENDPOINT = 'https://test.spaces.example.com';
+  });
+
+  function lastCall() {
+    const { calls } = signedUrlMock.mock;
+    return calls[calls.length - 1];
+  }
+
+  function lastCommandInput(): GetObjectCommand['input'] {
+    const command = lastCall()[1] as GetObjectCommand;
+    return command.input;
+  }
+
+  it('sets a download disposition and octet-stream type when a filename is given', async () => {
+    const handler = new StorageHandler();
+    await handler.getPresignedUrl(
+      'owner-1-deck.apkg',
+      300,
+      'Biochemistry.apkg'
+    );
+
+    const input = lastCommandInput();
+    expect(input.ResponseContentDisposition).toBe(
+      'attachment; filename="Biochemistry.apkg"; ' +
+        "filename*=UTF-8''Biochemistry.apkg"
+    );
+    expect(input.ResponseContentType).toBe('application/octet-stream');
+    expect(lastCall()[2]).toEqual({ expiresIn: 300 });
+  });
+
+  it('omits the disposition and type headers when no filename is given', async () => {
+    const handler = new StorageHandler();
+    await handler.getPresignedUrl('owner-1-deck.apkg');
+
+    const input = lastCommandInput();
+    expect(input.ResponseContentDisposition).toBeUndefined();
+    expect(input.ResponseContentType).toBeUndefined();
+    expect(lastCall()[2]).toEqual({ expiresIn: 3600 });
   });
 });

--- a/src/lib/storage/StorageHandler.ts
+++ b/src/lib/storage/StorageHandler.ts
@@ -11,6 +11,8 @@ import {
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 
 import { normalizeS3Endpoint } from './normalizeS3Endpoint';
+import { buildContentDisposition } from '../buildContentDisposition';
+import { getSafeFilename } from '../getSafeFilename';
 
 export interface StoredObject {
   Body: Buffer | undefined;
@@ -125,15 +127,26 @@ class StorageHandler {
     }
   }
 
-  getPresignedUrl(key: string, expiresSeconds = 3600): Promise<string> {
-    return getSignedUrl(
-      this.s3,
-      new GetObjectCommand({
-        Bucket: StorageHandler.DefaultBucketName(),
-        Key: key,
-      }),
-      { expiresIn: expiresSeconds }
-    );
+  getPresignedUrl(
+    key: string,
+    expiresSeconds = 3600,
+    filename?: string
+  ): Promise<string> {
+    const command =
+      filename != null
+        ? new GetObjectCommand({
+            Bucket: StorageHandler.DefaultBucketName(),
+            Key: key,
+            ResponseContentDisposition: buildContentDisposition(
+              getSafeFilename(filename)
+            ),
+            ResponseContentType: 'application/octet-stream',
+          })
+        : new GetObjectCommand({
+            Bucket: StorageHandler.DefaultBucketName(),
+            Key: key,
+          });
+    return getSignedUrl(this.s3, command, { expiresIn: expiresSeconds });
   }
 
   async objectExists(key: string): Promise<boolean> {

--- a/src/routes/McpDeckDownloadRouter.test.ts
+++ b/src/routes/McpDeckDownloadRouter.test.ts
@@ -1,0 +1,125 @@
+import express from 'express';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { createMcpDeckDownloadRouter } from './McpDeckDownloadRouter';
+import McpDeckDownloadController from '../controllers/McpDeckDownloadController';
+import {
+  ResolveMcpDeckDownloadUseCase,
+  DeckPresigner,
+} from '../usecases/mcp/ResolveMcpDeckDownloadUseCase';
+import { IUploadRepository } from '../data_layer/UploadRespository';
+import Uploads, { UploadsId } from '../data_layer/public/Uploads';
+
+const VALID_OBJECT_ID = '11111111-1111-1111-1111-111111111111';
+const PRESIGNED_URL = 'https://spaces.example/signed/deck.apkg?sig=abc';
+
+function makeRow(overrides: Partial<Uploads> = {}): Uploads {
+  return {
+    id: 1 as UploadsId,
+    owner: 42,
+    key: 'owner-42-deck.apkg',
+    filename: 'Pharmacology.apkg',
+    object_id: VALID_OBJECT_ID,
+    size_mb: 2,
+    created_at: new Date('2026-07-19T00:00:00Z'),
+    source: 'app',
+    dedupe_key: null,
+    ...overrides,
+  };
+}
+
+async function buildServer(opts: {
+  findByObjectId: jest.Mock;
+  getPresignedUrl?: DeckPresigner['getPresignedUrl'];
+}) {
+  const uploads = {
+    findByObjectId: opts.findByObjectId,
+  } as unknown as IUploadRepository;
+  const storage: DeckPresigner = {
+    getPresignedUrl: opts.getPresignedUrl ?? jest.fn(async () => PRESIGNED_URL),
+  };
+  const useCase = new ResolveMcpDeckDownloadUseCase(uploads, storage);
+  const controller = new McpDeckDownloadController(useCase);
+  const app = express();
+  app.use(createMcpDeckDownloadRouter(controller));
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const { port } = server.address() as AddressInfo;
+  return { server, url: `http://127.0.0.1:${port}` };
+}
+
+describe('GET /api/mcp/decks/:objectId/download', () => {
+  it('302-redirects a known deck to the presigned URL', async () => {
+    const findByObjectId = jest.fn(async () => makeRow());
+    const getPresignedUrl = jest.fn(async () => PRESIGNED_URL);
+    const { server, url } = await buildServer({
+      findByObjectId,
+      getPresignedUrl,
+    });
+    try {
+      const res = await fetch(
+        `${url}/api/mcp/decks/${VALID_OBJECT_ID}/download`,
+        { redirect: 'manual' }
+      );
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe(PRESIGNED_URL);
+      expect(getPresignedUrl).toHaveBeenCalledWith(
+        'owner-42-deck.apkg',
+        300,
+        'Pharmacology.apkg'
+      );
+    } finally {
+      server.close();
+    }
+  });
+
+  it('returns 404 when the deck is unknown', async () => {
+    const findByObjectId = jest.fn(async () => null);
+    const { server, url } = await buildServer({ findByObjectId });
+    try {
+      const res = await fetch(
+        `${url}/api/mcp/decks/${VALID_OBJECT_ID}/download`,
+        { redirect: 'manual' }
+      );
+      expect(res.status).toBe(404);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('returns 404 without touching the database for a malformed object id', async () => {
+    const findByObjectId = jest.fn(async () => makeRow());
+    const { server, url } = await buildServer({ findByObjectId });
+    try {
+      const res = await fetch(`${url}/api/mcp/decks/not-a-real-id/download`, {
+        redirect: 'manual',
+      });
+      expect(res.status).toBe(404);
+      expect(findByObjectId).not.toHaveBeenCalled();
+    } finally {
+      server.close();
+    }
+  });
+
+  it('returns 404 when the row has no storage key', async () => {
+    const findByObjectId = jest.fn(async () =>
+      makeRow({ key: null as unknown as string })
+    );
+    const getPresignedUrl = jest.fn(async () => PRESIGNED_URL);
+    const { server, url } = await buildServer({
+      findByObjectId,
+      getPresignedUrl,
+    });
+    try {
+      const res = await fetch(
+        `${url}/api/mcp/decks/${VALID_OBJECT_ID}/download`,
+        { redirect: 'manual' }
+      );
+      expect(res.status).toBe(404);
+      expect(getPresignedUrl).not.toHaveBeenCalled();
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/src/routes/McpDeckDownloadRouter.ts
+++ b/src/routes/McpDeckDownloadRouter.ts
@@ -1,0 +1,32 @@
+import express from 'express';
+
+import { getDatabase } from '../data_layer';
+import UploadRepository from '../data_layer/UploadRespository';
+import StorageHandler from '../lib/storage/StorageHandler';
+import McpDeckDownloadController from '../controllers/McpDeckDownloadController';
+import { ResolveMcpDeckDownloadUseCase } from '../usecases/mcp/ResolveMcpDeckDownloadUseCase';
+
+const OBJECT_ID_PATTERN = /^[0-9a-f-]{36}$/i;
+
+export function createMcpDeckDownloadRouter(
+  controller: McpDeckDownloadController
+): express.Router {
+  const router = express.Router();
+  router.get('/api/mcp/decks/:objectId/download', (req, res) => {
+    if (!OBJECT_ID_PATTERN.test(req.params.objectId ?? '')) {
+      res.status(404).send();
+      return;
+    }
+    void controller.download(req, res);
+  });
+  return router;
+}
+
+export default function mcpDeckDownloadRouter(): express.Router {
+  const database = getDatabase();
+  const useCase = new ResolveMcpDeckDownloadUseCase(
+    new UploadRepository(database),
+    new StorageHandler()
+  );
+  return createMcpDeckDownloadRouter(new McpDeckDownloadController(useCase));
+}

--- a/src/routes/McpDeckDownloadRouter.ts
+++ b/src/routes/McpDeckDownloadRouter.ts
@@ -12,6 +12,30 @@ export function createMcpDeckDownloadRouter(
   controller: McpDeckDownloadController
 ): express.Router {
   const router = express.Router();
+  /**
+   * @swagger
+   * /api/mcp/decks/{objectId}/download:
+   *   get:
+   *     summary: Download an MCP-generated deck
+   *     description: >
+   *       Public capability URL for a deck created via the hosted MCP server.
+   *       The objectId is an unguessable UUID that acts as the bearer token;
+   *       resolves the deck, presigns the stored file, and 302-redirects to it.
+   *       Returns 404 for unknown, malformed, or keyless ids.
+   *     tags: [MCP]
+   *     parameters:
+   *       - in: path
+   *         name: objectId
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: The deck's capability UUID
+   *     responses:
+   *       302:
+   *         description: Redirect to the presigned deck file
+   *       404:
+   *         description: Deck not found
+   */
   router.get('/api/mcp/decks/:objectId/download', (req, res) => {
     if (!OBJECT_ID_PATTERN.test(req.params.objectId ?? '')) {
       res.status(404).send();

--- a/src/server.ts
+++ b/src/server.ts
@@ -68,6 +68,7 @@ import mindmapRouter from './routes/MindmapRouter';
 import pitchRouter from './routes/PitchRouter';
 import iapRouter from './routes/IapRouter';
 import mcpRouter from './routes/McpRouter';
+import mcpDeckDownloadRouter from './routes/McpDeckDownloadRouter';
 import wellKnownRouter from './routes/WellKnownRouter';
 import healthRouter from './routes/HealthRouter';
 import requestLoggingMiddleware from './routes/middleware/requestLoggingMiddleware';
@@ -200,6 +201,7 @@ const serve = async () => {
   app.use(pitchRouter());
   app.use(iapRouter());
   app.use(mcpRouter());
+  app.use(mcpDeckDownloadRouter());
 
   const database = getDatabase();
   app.use(healthRouter(database));

--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -93,6 +93,7 @@ function buildRepository(): IUploadRepository {
     deleteUpload: (_owner: number, _key: string) => Promise.resolve(1),
     getUploadsByOwner: (_owner: number) => Promise.resolve([] as Uploads[]),
     findByIdAndOwner: (_id: number, _owner: number) => Promise.resolve(null),
+    findByObjectId: (_objectId: string) => Promise.resolve(null),
     findByKey: (_owner: number, _key: string) => Promise.resolve(null),
     findAllByObjectIdAndOwner: (_objectId: string, _owner: number) =>
       Promise.resolve([] as Uploads[]),

--- a/src/services/mcp/McpToolsService.test.ts
+++ b/src/services/mcp/McpToolsService.test.ts
@@ -23,6 +23,7 @@ function makeService(overrides: {
   persist?: DeckPersistence['persist'];
   getPresignedUrl?: StorageHandler['getPresignedUrl'];
   generateCards?: jest.Mock;
+  baseUrl?: string;
 }) {
   const jobLister = {
     getJobsByOwner: jest.fn(async () => overrides.jobs ?? []),
@@ -67,7 +68,8 @@ function makeService(overrides: {
     uploadEntry,
     storage,
     deckPersistence,
-    photoToFlashcards
+    photoToFlashcards,
+    overrides.baseUrl ?? 'https://mcp.test'
   );
   return {
     service,
@@ -236,25 +238,25 @@ describe('McpToolsService.convertToDeck', () => {
       res.set('File-Name', 'deck.apkg');
       res.status(200).send(Buffer.from('APKG-BYTES'));
     };
-    const { service, persist, getPresignedUrl } = makeService({ uploadEntry });
+    const { service, persist } = makeService({ uploadEntry });
     const result = await service.convertToDeck({ text: 'x' }, 'owner-9', {});
+    const jobId = (result as { jobId?: string }).jobId;
     expect(result).toMatchObject({
       kind: 'deck',
       cardCount: 42,
       filename: 'deck.apkg',
-      downloadUrl: 'https://s3.example/presigned',
+      downloadUrl: `https://mcp.test/api/mcp/decks/${jobId}/download`,
       deckCount: 1,
       decks: [{ id: 1, name: 'Bio', cardCount: 3 }],
       sampleCards: [{ front: 'Q', back: 'A' }],
     });
-    expect((result as { jobId?: string }).jobId).toEqual(expect.any(String));
+    expect(jobId).toEqual(expect.any(String));
     expect(persist).toHaveBeenCalledWith(
       'owner-9',
       expect.any(String),
       'deck.apkg',
       Buffer.from('APKG-BYTES')
     );
-    expect(getPresignedUrl).toHaveBeenCalledWith('owner-9-123-deck.apkg');
   });
 
   it('still returns the deck when inline preview parsing fails', async () => {
@@ -354,7 +356,7 @@ describe('McpToolsService.createDeck', () => {
 
   it('serializes cards to heading markdown, persists, and returns a download URL', async () => {
     const { entry, markdown } = captureUpload();
-    const { service, persist, getPresignedUrl } = makeService({
+    const { service, persist } = makeService({
       uploadEntry: entry,
     });
     const result = await service.createDeck(
@@ -370,19 +372,19 @@ describe('McpToolsService.createDeck', () => {
       '## What is ATP?\n\nEnergy currency.\n\n' +
         '## What is DNA?\n\nHeredity molecule.\n\n'
     );
+    const jobId = (result as { jobId?: string }).jobId;
     expect(result).toMatchObject({
       kind: 'deck',
       cardCount: 2,
-      downloadUrl: 'https://s3.example/presigned',
+      downloadUrl: `https://mcp.test/api/mcp/decks/${jobId}/download`,
     });
-    expect((result as { jobId?: string }).jobId).toEqual(expect.any(String));
+    expect(jobId).toEqual(expect.any(String));
     expect(persist).toHaveBeenCalledWith(
       'owner-9',
       expect.any(String),
       'deck.apkg',
       Buffer.from('APKG-BYTES')
     );
-    expect(getPresignedUrl).toHaveBeenCalled();
   });
 
   it('passes the deck name to the pipeline settings so it wins over the first heading', async () => {

--- a/src/services/mcp/McpToolsService.ts
+++ b/src/services/mcp/McpToolsService.ts
@@ -15,6 +15,7 @@ import {
   mcpOptionsToCardSettings,
 } from './mcpOptionsToCardSettings';
 import { detectFileMime } from '../../lib/detectFileMime';
+import { mcpBaseUrl } from './mcpBaseUrl';
 import { isPaying } from '../../lib/isPaying';
 import type { VisionMediaType } from '../../lib/claude/countVisionTokens';
 import {
@@ -226,7 +227,8 @@ export class McpToolsService {
     private readonly uploadEntry: UploadEntrypoint,
     private readonly storage: StorageHandler,
     private readonly deckPersistence: DeckPersistence,
-    private readonly photoToFlashcards: PhotoToFlashcardsUseCase
+    private readonly photoToFlashcards: PhotoToFlashcardsUseCase,
+    private readonly baseUrl: string = mcpBaseUrl()
   ) {}
 
   async photoToDeck(
@@ -521,13 +523,8 @@ export class McpToolsService {
     const filename = res.get('File-Name') ?? null;
     const title = filename ?? fallbackTitle;
     const objectId = randomUUID();
-    const key = await this.deckPersistence.persist(
-      owner,
-      objectId,
-      title,
-      bytes
-    );
-    const downloadUrl = await this.storage.getPresignedUrl(key);
+    await this.deckPersistence.persist(owner, objectId, title, bytes);
+    const downloadUrl = `${this.baseUrl}/api/mcp/decks/${objectId}/download`;
     const preview = await this.previewFromBytes(bytes, filename);
     const summary =
       cardCount != null

--- a/src/services/mcp/mcpBaseUrl.ts
+++ b/src/services/mcp/mcpBaseUrl.ts
@@ -1,0 +1,3 @@
+export function mcpBaseUrl(): string {
+  return (process.env.MCP_ISSUER_URL ?? 'https://2anki.net').replace(/\/$/, '');
+}

--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -98,6 +98,7 @@ export const KNOWN_EVENTS = new Set([
   'subscription_pause_offer_declined',
   'subscription_cancelled',
   'language_changed',
+  'mcp_deck_download',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/src/usecases/jobs/BuildDeckForJobUseCase.test.ts
+++ b/src/usecases/jobs/BuildDeckForJobUseCase.test.ts
@@ -31,6 +31,7 @@ function buildUploadRepository(): jest.Mocked<IUploadRepository> {
     deleteUpload: jest.fn().mockResolvedValue(1),
     getUploadsByOwner: jest.fn().mockResolvedValue([]),
     findByIdAndOwner: jest.fn().mockResolvedValue(null),
+    findByObjectId: jest.fn().mockResolvedValue(null),
     findByKey: jest.fn().mockResolvedValue(null),
     findAllByObjectIdAndOwner: jest.fn().mockResolvedValue([]),
     update: jest.fn().mockResolvedValue([]),

--- a/src/usecases/mcp/ResolveMcpDeckDownloadUseCase.test.ts
+++ b/src/usecases/mcp/ResolveMcpDeckDownloadUseCase.test.ts
@@ -1,0 +1,88 @@
+import {
+  ResolveMcpDeckDownloadUseCase,
+  DeckPresigner,
+} from './ResolveMcpDeckDownloadUseCase';
+import { IUploadRepository } from '../../data_layer/UploadRespository';
+import Uploads, { UploadsId } from '../../data_layer/public/Uploads';
+
+function makeRow(overrides: Partial<Uploads> = {}): Uploads {
+  return {
+    id: 1 as UploadsId,
+    owner: 42,
+    key: 'owner-42-deck.apkg',
+    filename: 'Pharmacology.apkg',
+    object_id: 'obj-1',
+    size_mb: 2,
+    created_at: new Date('2026-07-19T00:00:00Z'),
+    source: 'app',
+    dedupe_key: null,
+    ...overrides,
+  };
+}
+
+function makeUseCase(overrides: {
+  findByObjectId?: jest.Mock;
+  getPresignedUrl?: DeckPresigner['getPresignedUrl'];
+}) {
+  const findByObjectId =
+    overrides.findByObjectId ?? jest.fn(async () => makeRow());
+  const uploads = { findByObjectId } as unknown as IUploadRepository;
+  const getPresignedUrl =
+    overrides.getPresignedUrl ??
+    jest.fn(async () => 'https://spaces.example/signed');
+  const storage: DeckPresigner = { getPresignedUrl };
+  return {
+    useCase: new ResolveMcpDeckDownloadUseCase(uploads, storage),
+    findByObjectId,
+    getPresignedUrl,
+  };
+}
+
+describe('ResolveMcpDeckDownloadUseCase', () => {
+  it('presigns the row key with a 300s TTL and the filename disposition', async () => {
+    const { useCase, getPresignedUrl } = makeUseCase({});
+    const result = await useCase.resolve('obj-1');
+    expect(result).toEqual({
+      kind: 'redirect',
+      url: 'https://spaces.example/signed',
+      owner: 42,
+    });
+    expect(getPresignedUrl).toHaveBeenCalledWith(
+      'owner-42-deck.apkg',
+      300,
+      'Pharmacology.apkg'
+    );
+  });
+
+  it('falls back to deck.apkg for the disposition when the filename is null', async () => {
+    const { useCase, getPresignedUrl } = makeUseCase({
+      findByObjectId: jest.fn(async () => makeRow({ filename: null })),
+    });
+    await useCase.resolve('obj-1');
+    expect(getPresignedUrl).toHaveBeenCalledWith(
+      'owner-42-deck.apkg',
+      300,
+      'deck.apkg'
+    );
+  });
+
+  it('returns not_found when the row is missing', async () => {
+    const { useCase, getPresignedUrl } = makeUseCase({
+      findByObjectId: jest.fn(async () => null),
+    });
+    const result = await useCase.resolve('obj-1');
+    expect(result).toEqual({ kind: 'not_found' });
+    expect(getPresignedUrl).not.toHaveBeenCalled();
+  });
+
+  it('returns not_found without presigning when the key is null', async () => {
+    const { useCase, getPresignedUrl } = makeUseCase({
+      findByObjectId: jest.fn(async () =>
+        makeRow({ key: null as unknown as string })
+      ),
+    });
+    const result = await useCase.resolve('obj-1');
+    expect(result).toEqual({ kind: 'not_found' });
+    expect(getPresignedUrl).not.toHaveBeenCalled();
+  });
+});

--- a/src/usecases/mcp/ResolveMcpDeckDownloadUseCase.ts
+++ b/src/usecases/mcp/ResolveMcpDeckDownloadUseCase.ts
@@ -1,0 +1,36 @@
+import { IUploadRepository } from '../../data_layer/UploadRespository';
+
+export const MCP_DECK_PRESIGN_TTL_SECONDS = 300;
+
+export interface DeckPresigner {
+  getPresignedUrl(
+    key: string,
+    expiresSeconds?: number,
+    filename?: string
+  ): Promise<string>;
+}
+
+export type ResolveMcpDeckDownloadResult =
+  | { kind: 'redirect'; url: string; owner: number }
+  | { kind: 'not_found' };
+
+export class ResolveMcpDeckDownloadUseCase {
+  constructor(
+    private readonly uploads: IUploadRepository,
+    private readonly storage: DeckPresigner
+  ) {}
+
+  async resolve(objectId: string): Promise<ResolveMcpDeckDownloadResult> {
+    const upload = await this.uploads.findByObjectId(objectId);
+    if (upload == null || upload.key == null) {
+      return { kind: 'not_found' };
+    }
+    const filename = upload.filename ?? 'deck.apkg';
+    const url = await this.storage.getPresignedUrl(
+      upload.key,
+      MCP_DECK_PRESIGN_TTL_SECONDS,
+      filename
+    );
+    return { kind: 'redirect', url, owner: upload.owner };
+  }
+}

--- a/src/usecases/ops/SendInactivityWarningsUseCase.test.ts
+++ b/src/usecases/ops/SendInactivityWarningsUseCase.test.ts
@@ -40,6 +40,7 @@ function makeUploadRepo(
     deleteUpload: jest.fn(),
     getUploadsByOwner: jest.fn(),
     findByIdAndOwner: jest.fn(),
+    findByObjectId: jest.fn(),
     findByKey: jest.fn(),
     findAllByObjectIdAndOwner: jest.fn().mockResolvedValue([]),
     update: jest.fn(),

--- a/src/usecases/ops/SendInactivityWarningsUseCase.ts
+++ b/src/usecases/ops/SendInactivityWarningsUseCase.ts
@@ -18,6 +18,9 @@ class NoOpUploadRepository implements IUploadRepository {
   findByIdAndOwner(): Promise<null> {
     return Promise.resolve(null);
   }
+  findByObjectId(): Promise<null> {
+    return Promise.resolve(null);
+  }
   findByKey(): Promise<null> {
     return Promise.resolve(null);
   }

--- a/src/usecases/uploads/SaveNativeDeckUseCase.test.ts
+++ b/src/usecases/uploads/SaveNativeDeckUseCase.test.ts
@@ -8,6 +8,7 @@ function makeRepository(): jest.Mocked<IUploadRepository> {
     deleteUpload: jest.fn(),
     getUploadsByOwner: jest.fn(),
     findByIdAndOwner: jest.fn(),
+    findByObjectId: jest.fn(),
     findByKey: jest.fn(),
     findAllByObjectIdAndOwner: jest.fn(),
     update: jest.fn(),

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-19-mcp-download-link.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-19-mcp-download-link.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-19-mcp-download-link",
+  "date": "2026-07-19",
+  "type": "fix",
+  "title": "Deck downloads from the Claude connector open as a clean 2anki.net link"
+}


### PR DESCRIPTION
## What
The hosted MCP server returned each single deck's download as the raw presigned DigitalOcean Spaces URL. In claude.ai that surfaced an "Open external link" dialog exposing storage credentials, and the signature expired in about an hour. This replaces that field with an unauthenticated branded capability URL — `GET /api/mcp/decks/:objectId/download` — that 302-redirects to a freshly-presigned file. Only the single-deck path (`persistDeckResult`) changes; `list_my_decks` / batch are untouched.

## Why
The download link the connector hands back was a raw `*.digitaloceanspaces.com` URL with AWS query params. It looked untrustworthy, tripped claude.ai's external-link warning, and 403'd within the hour. The new link is a clean `2anki.net` URL that stays valid because the redirect re-signs on demand.

## How
- New unauthenticated router `McpDeckDownloadRouter` mounted next to the MCP router, under `/api` (no SPA/knownRoutes change). Validates `:objectId` against `/^[0-9a-f-]{36}$/i` before any DB call — malformed → 404.
- `McpDeckDownloadController` → `ResolveMcpDeckDownloadUseCase(IUploadRepository, StorageHandler)`. Row missing or `key` null → not-found → bare 404 (no body, no existence oracle). Otherwise presign with a 300s TTL + download disposition, then `res.redirect(302, url)`.
- New repo method `findByObjectId(objectId)` — scoped to rows with a non-null `object_id` AND non-null `key`, so it can never become a generic "download any upload by object_id" hole. Added the method to every `IUploadRepository` implementer (checked all test object literals + `NoOpUploadRepository`); `tsc -p . --noEmit` clean.
- `StorageHandler.getPresignedUrl` gains an optional 3rd `filename` param — when passed, sets `ResponseContentDisposition` (via `buildContentDisposition(getSafeFilename(filename))`) + `ResponseContentType: application/octet-stream`. Default behavior unchanged when omitted; existing callers untouched. TTL was already a param.
- `persistDeckResult` now builds `downloadUrl = ${baseUrl}/api/mcp/decks/${objectId}/download` via `mcpBaseUrl()` (injected into `McpToolsService` as a defaulted constructor param so tests pass a fixed base). It no longer presigns inline.

## Measuring success
Server-side `mcp_deck_download` event (registered in `AnalyticsEvents`, `source: 'mcp_single'`, attributed to the deck owner) fires on each successful resolve — read via `/api/ops/metrics`. Confirms real usage of the branded link post-deploy. Assumption made: there is no bespoke server-side "track" subsystem beyond the events sink; I used the same `track()` / `getEventsSink()` mechanism that `DownloadController` (`deck_downloaded`) and the other MCP tools use.

## Testing
- `McpDeckDownloadRouter` (outside-in, real `http.createServer` + native `fetch` — the repo's router-test pattern, no supertest dependency): valid id → 302 with the mocked presigned `Location`; unknown → 404; malformed id → 404 with the DB never queried; null-key row → 404 with no presign.
- `ResolveMcpDeckDownloadUseCase`: presigns with `(key, 300, filename)`, `deck.apkg` disposition fallback on null filename, `not_found` on missing/null-key.
- `UploadRepository.findByObjectId`: generated-SQL test (pg-dialect knex `.toString()`) asserting the `object_id` filter AND the non-null-key scope; plus the `== null` guard.
- `StorageHandler.getPresignedUrl`: asserts the `GetObjectCommand` input carries `ResponseContentDisposition` + `ResponseContentType` (and TTL) when a filename is passed, and omits them otherwise.
- `McpToolsService`: deck-result assertions updated from the raw presigned string to the branded `/api/mcp/decks/<jobId>/download` URL via the injected fixed base.
- The controller is covered end-to-end by the router suite (302/404 paths + the `track` call).

## Browser check
Browser check: not applicable — server-only change; the only web/src file is a changelog entry.

## Changelog
`Deck downloads from the Claude connector open as a clean 2anki.net link` (type `fix`).

## Security
- **Capability-URL model.** The endpoint is intentionally unauthenticated: the object id is a 122-bit random UUID (`randomUUID()`), so the URL itself is the capability. Not guessable, not enumerable.
- **404, never 403.** Missing row, null key, or malformed id all return a bare 404 with no body — no existence oracle, nothing echoed back.
- **Scope-narrowed lookup.** `findByObjectId` filters to rows with a non-null `object_id` AND non-null `key`, so it can only ever resolve a real converted deck — never a generic "any upload by object_id".
- **Short TTL.** The redirect target is presigned for 300s (down from the 3600 default), so a leaked redirect URL is short-lived.
- **No SSRF surface.** The presign key is server-stored, never user-supplied; no user input reaches an HTTP client. Object-id input is regex-validated before the DB call.
- `/security-review` is warranted before merge (new public unauthenticated endpoint + a storage-presign change).

## Risks
Low. The change is additive (new route + optional param) and behind a random-UUID capability. Rollback = revert; `list_my_decks`/batch paths were deliberately left as-is. Note: Sonar not run locally (no `SONAR_TOKEN` on this box); Automatic Analysis covers the push.

## Goal alignment
Removes friction and a trust-scare from the MCP/Claude-connector download step — the connector is an acquisition and activation surface for the "drop something in, get a clean deck back" mission. The `mcp_deck_download` event (read at `/api/ops/metrics`) is the usage signal for this surface; watch it post-deploy to confirm the branded link is used.
