### PR TITLE
fix: key the MCP create_deck preview cache by jobId not deck name

### DIFF
--- a/src/services/mcp/McpToolsService.test.ts
+++ b/src/services/mcp/McpToolsService.test.ts
@@ -78,6 +78,7 @@ function makeService(overrides: {
     persist,
     getPresignedUrl,
     generateCards,
+    previewService,
   };
 }
 
@@ -384,6 +385,39 @@ describe('McpToolsService.createDeck', () => {
       expect.any(String),
       'deck.apkg',
       Buffer.from('APKG-BYTES')
+    );
+  });
+
+  it('keys the preview cache by the jobId, not the deck name, so a reused name does not return stale cards (regression: #3744)', async () => {
+    const { entry } = captureUpload();
+    const { service, previewService } = makeService({ uploadEntry: entry });
+    const parseMock = previewService.parse as jest.Mock;
+
+    const first = await service.createDeck(
+      [{ front: 'A-front', back: 'A-back' }],
+      'Same Name',
+      'owner-9',
+      {}
+    );
+    const second = await service.createDeck(
+      [{ front: 'B-front', back: 'B-back' }],
+      'Same Name',
+      'owner-9',
+      {}
+    );
+
+    const firstJobId = (first as { jobId?: string }).jobId;
+    const secondJobId = (second as { jobId?: string }).jobId;
+    expect(firstJobId).not.toBe(secondJobId);
+    expect(parseMock).toHaveBeenNthCalledWith(
+      1,
+      `mcp:${firstJobId}`,
+      expect.any(Buffer)
+    );
+    expect(parseMock).toHaveBeenNthCalledWith(
+      2,
+      `mcp:${secondJobId}`,
+      expect.any(Buffer)
     );
   });
 

--- a/src/services/mcp/McpToolsService.ts
+++ b/src/services/mcp/McpToolsService.ts
@@ -414,13 +414,10 @@ export class McpToolsService {
 
   private async previewFromBytes(
     buffer: Buffer,
-    filename: string | null
+    cacheKey: string
   ): Promise<Pick<DeckPreview, 'deckCount' | 'decks' | 'sampleCards'> | null> {
     try {
-      const parsed = await this.previewService.parse(
-        filename ?? 'deck.apkg',
-        buffer
-      );
+      const parsed = await this.previewService.parse(cacheKey, buffer);
       const meta = this.previewService.getMeta(parsed);
       const page = this.previewService.getCardsPage(
         parsed,
@@ -525,7 +522,7 @@ export class McpToolsService {
     const objectId = randomUUID();
     await this.deckPersistence.persist(owner, objectId, title, bytes);
     const downloadUrl = `${this.baseUrl}/api/mcp/decks/${objectId}/download`;
-    const preview = await this.previewFromBytes(bytes, filename);
+    const preview = await this.previewFromBytes(bytes, `mcp:${objectId}`);
     const summary =
       cardCount != null
         ? `${cardCount} cards. Ready to download.`


### PR DESCRIPTION
Fixes https://github.com/2anki/server/issues/3744

## Bug
`ApkgPreviewService.parse(cacheKey, bytes)` memoizes by its `cacheKey`. `persistDeckResult` passed the **filename** (the deck name) as that key, so two `create_deck` calls with the same `deckName` within the cache TTL collided — the second response returned the *first* job's `sampleCards` and internal deck `id` verbatim, even though the newly submitted (and stored) bytes were correct. `get_deck_preview` was never affected because it keys by the unique `owner:key`.

## Fix
Key the inline preview by `mcp:<objectId>` (the per-job UUID) instead of the filename, so every job parses its own bytes and can never serve a sibling job's cached parse.

One-line change in `previewFromBytes` + its call site; `filename` was used *only* as the cache key there.

## Test
`McpToolsService.test.ts` — two `create_deck` calls with the same deck name now assert `previewService.parse` is invoked with two distinct per-job keys (`mcp:<jobId1>` then `mcp:<jobId2>`). Full suite green (30).

## Changelog
No changelog entry — MCP tool-response correctness (agent-facing), not a change a user notices in the app. `Browser check: not applicable — server-only change, no web/src files.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs4pvvQ4BKVpvEtGA9GXTn

