### PR TITLE
fix: render safe inline HTML tags in card text instead of escaping

### DIFF
--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -185,4 +185,44 @@ describe('markdownToHTML', () => {
       expect(result).toContain('&lt;rubyish&gt;');
     });
   });
+
+  describe('inline HTML formatting tags (regression: #3743)', () => {
+    it('passes br and bold tags through instead of escaping them', () => {
+      const result = markdownToHTML('foo<br><b>bar</b>');
+      expect(result).toContain('foo<br><b>bar</b>');
+      expect(result).not.toContain('&lt;br&gt;');
+      expect(result).not.toContain('&lt;b&gt;');
+    });
+
+    it('passes the common inline set through (em, u, s, code, sub, sup, mark, small)', () => {
+      const result = markdownToHTML(
+        '<em>a</em><u>b</u><s>c</s><code>d</code><sub>e</sub><sup>f</sup><mark>g</mark><small>h</small>'
+      );
+      for (const tag of [
+        'em',
+        'u',
+        's',
+        'code',
+        'sub',
+        'sup',
+        'mark',
+        'small',
+      ]) {
+        expect(result).toContain(`<${tag}>`);
+        expect(result).not.toContain(`&lt;${tag}&gt;`);
+      }
+    });
+
+    it('renders inline formatting in an inline (front) render too', () => {
+      const result = markdownToInlineHTML('term<br><strong>x</strong>');
+      expect(result).toContain('<br>');
+      expect(result).toContain('<strong>x</strong>');
+    });
+
+    it('does not un-escape blockquote just because it starts with b', () => {
+      const result = markdownToHTML('<blockquote>x</blockquote>');
+      expect(result).not.toContain('<blockquote>');
+      expect(result).toContain('&lt;blockquote&gt;');
+    });
+  });
 });

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -13,7 +13,8 @@ const md = new MarkdownIt({
 
 const ASIDE_TAG_RE = /^<\/?aside[^>]*>\s*$/gim;
 
-const CARD_SAFE_TAGS = 'ruby|rt|rp|rb|details|summary';
+const CARD_SAFE_TAGS =
+  'ruby|rt|rp|rb|details|summary|br|b|strong|i|em|u|s|code|sub|sup|mark|small';
 const ESCAPED_CARD_SAFE_TAG_RE = new RegExp(
   `&lt;(/?(?:${CARD_SAFE_TAGS}))&gt;`,
   'gi'

--- a/src/services/mcp/serializeCardsToMarkdown.test.ts
+++ b/src/services/mcp/serializeCardsToMarkdown.test.ts
@@ -86,6 +86,16 @@ describe('serializeCardsToMarkdown', () => {
     expect(notes[0].back).toContain('<summary>Hint</summary>');
   });
 
+  it('renders inline HTML like <br> and <b> in the card back (regression: #3743)', () => {
+    const markdown = serializeCardsToMarkdown([
+      { front: 'Formatting', back: 'foo<br><b>bar</b>' },
+    ]);
+    const { notes } = parseCards(markdown);
+    expect(notes).toHaveLength(1);
+    expect(notes[0].back).toContain('foo<br><b>bar</b>');
+    expect(notes[0].back).not.toContain('&lt;br&gt;');
+  });
+
   it('escapes a markdown heading inside the body so it does not split the card', () => {
     const markdown = serializeCardsToMarkdown([
       { front: 'Outline', back: '## Overview\nSome detail' },

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-19-inline-html-cards.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-19-inline-html-cards.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-19-inline-html-cards",
+  "date": "2026-07-19",
+  "type": "fix",
+  "title": "Cards keep inline formatting like bold, line breaks, and highlights when your notes use HTML tags"
+}


### PR DESCRIPTION
Fixes https://github.com/2anki/server/issues/3743

## Bug
The card markdown renderer runs `markdown-it` with `html: false`, which HTML-escapes raw tags. The `<ruby>` fix (#3739) added a post-render allowlist that restores a fixed set of safe tags, but common inline formatting — `<br>`, `<b>`, `<strong>`, etc. — was still escaped, so `create_deck` cards containing `foo<br><b>bar</b>` rendered literal `foo&lt;br&gt;&lt;b&gt;bar&lt;/b&gt;`. Markdown (`**bold**`) worked throughout.

## Fix (option a — allowlist safe inline HTML)
Extend `CARD_SAFE_TAGS` to: `br, b, strong, i, em, u, s, code, sub, sup, mark, small`. All are attribute-free presentational tags, all already in the preview sanitizer allowlist, and the restore regex captures no attributes — so nothing dangerous is un-escaped (verified: `<script>` still escaped; `<blockquote>` not un-escaped just because it starts with `b`). `html: false` is unchanged.

This lives in `src/lib/markdown.ts`, shared by the whole conversion pipeline, so the fix applies to uploads and Notion too, not just MCP.

## Tests
- `markdown.test.ts` — `<br>`/`<b>` and the full inline set pass through; inline (front) render; `<script>` stays escaped; `<blockquote>` stays escaped.
- `serializeCardsToMarkdown.test.ts` — the reporter's exact `create_deck` shape (`foo<br><b>bar</b>`) renders through the heading-markdown path.
- Full markdown/serialize/sanitize suites green.

## Security
No new raw-HTML surface: `html: false` stays, only attribute-free presentational tags are restored, and the web preview re-sanitizes at render time.

`Browser check: not applicable — server-only change; the only web/src file is a changelog entry.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs4pvvQ4BKVpvEtGA9GXTn
