### PR TITLE
fix: decode the percent-encoded File-Name header in MCP deck results

### DIFF
--- a/src/services/mcp/McpToolsService.test.ts
+++ b/src/services/mcp/McpToolsService.test.ts
@@ -260,6 +260,24 @@ describe('McpToolsService.convertToDeck', () => {
     );
   });
 
+  it('decodes a percent-encoded File-Name header into a readable filename (regression: #3748)', async () => {
+    const japanese = '日本語レッスン：まるごと１・旅行ロールプレイ.apkg';
+    const uploadEntry: UploadEntrypoint = (_req, res) => {
+      res.set('X-Card-Count', '40');
+      res.set('File-Name', encodeURIComponent(japanese));
+      res.status(200).send(Buffer.from('APKG-BYTES'));
+    };
+    const { service, persist } = makeService({ uploadEntry });
+    const result = await service.convertToDeck({ text: 'x' }, 'owner-9', {});
+    expect(result).toMatchObject({ kind: 'deck', filename: japanese });
+    expect(persist).toHaveBeenCalledWith(
+      'owner-9',
+      expect.any(String),
+      japanese,
+      Buffer.from('APKG-BYTES')
+    );
+  });
+
   it('still returns the deck when inline preview parsing fails', async () => {
     const uploadEntry: UploadEntrypoint = (_req, res) => {
       res.set('X-Card-Count', '7');

--- a/src/services/mcp/McpToolsService.ts
+++ b/src/services/mcp/McpToolsService.ts
@@ -100,6 +100,17 @@ function decodePhotoInput(image: string): DecodedPhoto {
   };
 }
 
+function decodeFileNameHeader(raw: string | null): string | null {
+  if (raw == null) {
+    return null;
+  }
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}
+
 export interface DeckSummary {
   jobId: string;
   title: string;
@@ -517,7 +528,7 @@ export class McpToolsService {
   ): Promise<ConvertResult> {
     const cardCountHeader = res.get('X-Card-Count');
     const cardCount = cardCountHeader != null ? Number(cardCountHeader) : null;
-    const filename = res.get('File-Name') ?? null;
+    const filename = decodeFileNameHeader(res.get('File-Name') ?? null);
     const title = filename ?? fallbackTitle;
     const objectId = randomUUID();
     await this.deckPersistence.persist(owner, objectId, title, bytes);


### PR DESCRIPTION
Fixes https://github.com/2anki/server/issues/3748

## Bug
HTTP headers can't carry raw UTF-8, so the upload pipeline sets `File-Name: encodeURIComponent(deckName)` (`UploadController.ts:320`, `UploadService.ts:772`). The web client decodes it before saving, but the MCP path (`McpToolsService.persistDeckResult`) read `res.get('File-Name')` **verbatim**. So a non-ASCII deck name was stored as `uploads.filename`, used as the deck title, returned in the `create_deck` response `filename` field, and fed into the download `Content-Disposition` — surfacing as `%E6%97%A5%E6%9C%AC%E8%AA%9E…` instead of `日本語…`.

## Fix
Decode the header once when MCP reads it, guarded against a malformed `%` sequence (falls back to the raw value). One helper + one call site.

## Test
`McpToolsService.test.ts` — a `create_deck` whose `File-Name` header is `encodeURIComponent('日本語レッスン：…apkg')` now returns `filename: '日本語レッスン：…apkg'` and persists under the decoded title. Suite green (31).

## Changelog
No changelog entry — MCP connector filename correctness; the web download path already decoded, so nothing changes for in-app users.

`Browser check: not applicable — server-only change, no web/src files.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs4pvvQ4BKVpvEtGA9GXTn
