### PR TITLE
fix: index mcp_authorization_codes FK columns

### DIFF
--- a/migrations/20260925000000_index_mcp_authorization_code_fks.js
+++ b/migrations/20260925000000_index_mcp_authorization_code_fks.js
@@ -1,0 +1,13 @@
+module.exports.up = async function (knex) {
+  await knex.schema.alterTable('mcp_authorization_codes', (table) => {
+    table.index(['user_id'], 'mcp_authorization_codes_user_id_idx');
+    table.index(['client_id'], 'mcp_authorization_codes_client_id_idx');
+  });
+};
+
+module.exports.down = async function (knex) {
+  await knex.schema.alterTable('mcp_authorization_codes', (table) => {
+    table.dropIndex(['user_id'], 'mcp_authorization_codes_user_id_idx');
+    table.dropIndex(['client_id'], 'mcp_authorization_codes_client_id_idx');
+  });
+};


### PR DESCRIPTION
Draft — carries a schema migration, so it's gated on a `migration-reviewer` pass and Alexander's OK before flipping ready.

## What

Adds two indexes on `mcp_authorization_codes`:
- `mcp_authorization_codes_user_id_idx` on `user_id`
- `mcp_authorization_codes_client_id_idx` on `client_id`

## Why

Postgres does not auto-create an index on a foreign-key column. `mcp_authorization_codes.user_id` and `.client_id` are both FKs (to `users` and `mcp_oauth_clients`) with `ON DELETE CASCADE` but no index. On a user or OAuth-client deletion, Postgres full-scans this child table once per deleted parent row to enforce the cascade. The planned expired-row reaper (see below) would scan the same way.

The sibling `mcp_access_tokens` / `mcp_refresh_tokens` tables already carry a `user_id` index from the create migration; this brings `mcp_authorization_codes` to parity.

This is the first of the two non-blocking follow-ups named in #3727's migration review.

## Scope

- Additive, non-destructive. `up` adds two indexes; `down` drops them.
- No generated-type change — indexes are not part of the Kanel row type, so `src/data_layer/public/*` is untouched (no `pnpm kanel` diff expected).
- No TS or `web/` changes, so `/check` is unaffected. Internal-only — no changelog entry.

## Decisions made overnight (please review)
- Scope: shipped only the `mcp_authorization_codes` FK indexes the review named. Deliberately did NOT build the second follow-up — the expired-row reaper for the token/code tables — because it adds a new scheduled job that DELETEs rows on the OAuth surface, which is better landed with you awake. If you want it bundled, say so and I'll add it with an `expires_at` index.
- Chose plain `CREATE INDEX` (knex `.index()`), not `CREATE INDEX CONCURRENTLY`: these are new low-volume beta tables, so the brief write lock during build is negligible. Reconsider if the tables have grown by review time (2026-08-18).
- Left #3727 open — it's the T+30 keep/remove review dated 2026-08-18, not closeable now. This PR only clears one of its pre-review follow-ups.

## migration-reviewer
Requesting a `migration-reviewer` pass on the locking/rollback shape before this leaves draft.

Refs #3727
