### PR TITLE
fix: make contact-form support notification reliable and observable

### DIFF
--- a/src/controllers/IndexController/IndexController.ts
+++ b/src/controllers/IndexController/IndexController.ts
@@ -18,18 +18,33 @@ class IndexController {
     const attachments = Array.isArray(req.files) ? req.files : [];
     const database = getDatabase();
 
-    await database('feedback').insert({
-      name,
-      email,
-      message,
-      attachments: JSON.stringify(attachments.map((a) => a.originalname)),
-    });
+    const inserted = await database('feedback')
+      .insert({
+        name,
+        email,
+        message,
+        attachments: JSON.stringify(attachments.map((a) => a.originalname)),
+      })
+      .returning('id');
+    const feedbackId =
+      typeof inserted?.[0] === 'object' ? inserted[0]?.id : inserted?.[0];
 
     const emailService = getDefaultEmailService();
-    emailService
+    void emailService
       .sendContactEmail(name, email, message, attachments)
+      .then((result) => {
+        if (!result.didSend) {
+          console.error(
+            `Contact email notification failed for feedback row ${feedbackId}; the message is saved in the ops inbox`,
+            result.error
+          );
+        }
+      })
       .catch((err) => {
-        console.error('Failed to send contact email notification', err);
+        console.error(
+          `Contact email notification threw for feedback row ${feedbackId}; the message is saved in the ops inbox`,
+          err
+        );
       });
 
     return res.status(200).send();

--- a/src/services/EmailService/EmailService.ts
+++ b/src/services/EmailService/EmailService.ts
@@ -28,6 +28,7 @@ import { ClientResponse } from '@sendgrid/mail';
 import { SUPPORT_EMAIL_ADDRESS } from '../../lib/constants';
 import { emailHash } from '../../lib/emailHash';
 import { getDatabase } from '../../data_layer';
+import { sendWithRetry } from './sendWithRetry';
 import SuppressionEventsRepository from '../../data_layer/SuppressionEventsRepository';
 import UsersRepository from '../../data_layer/UsersRepository';
 import { DeckReadyStrings, getEmailStrings } from './i18n';
@@ -336,7 +337,7 @@ export class EmailService implements IEmailService {
       })),
     };
     try {
-      await sgMail.send(msg);
+      await sendWithRetry(() => sgMail.send(msg));
       return { didSend: true };
     } catch (e) {
       console.error('Error sending email', e);

--- a/src/services/EmailService/sendWithRetry.test.ts
+++ b/src/services/EmailService/sendWithRetry.test.ts
@@ -1,0 +1,78 @@
+import { sendWithRetry, isTransientSendError } from './sendWithRetry';
+
+const noSleep = () => Promise.resolve();
+
+function sendError(code: number | string): Error {
+  return Object.assign(new Error(`send failed ${code}`), { code });
+}
+
+describe('isTransientSendError', () => {
+  it.each([429, 500, 502, 503, 504])('treats HTTP %s as transient', (code) => {
+    expect(isTransientSendError(sendError(code))).toBe(true);
+  });
+
+  it.each([400, 401, 403, 413])('treats HTTP %s as permanent', (code) => {
+    expect(isTransientSendError(sendError(code))).toBe(false);
+  });
+
+  it.each(['ECONNRESET', 'ETIMEDOUT', 'EAI_AGAIN'])(
+    'treats network code %s as transient',
+    (code) => {
+      expect(isTransientSendError(sendError(code))).toBe(true);
+    }
+  );
+
+  it('treats an error without a code as permanent', () => {
+    expect(isTransientSendError(new Error('nope'))).toBe(false);
+    expect(isTransientSendError(null)).toBe(false);
+  });
+});
+
+describe('sendWithRetry', () => {
+  it('returns the result on first success without retrying', async () => {
+    const send = jest.fn().mockResolvedValue('ok');
+    await expect(sendWithRetry(send, { sleepFn: noSleep })).resolves.toBe('ok');
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a transient failure then succeeds', async () => {
+    const send = jest
+      .fn()
+      .mockRejectedValueOnce(sendError(503))
+      .mockResolvedValue('ok');
+    await expect(sendWithRetry(send, { sleepFn: noSleep })).resolves.toBe('ok');
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it('rethrows after exhausting attempts on persistent transient failure', async () => {
+    const send = jest.fn().mockRejectedValue(sendError(500));
+    await expect(
+      sendWithRetry(send, { maxAttempts: 3, sleepFn: noSleep })
+    ).rejects.toMatchObject({ code: 500 });
+    expect(send).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry a permanent failure', async () => {
+    const send = jest.fn().mockRejectedValue(sendError(400));
+    await expect(
+      sendWithRetry(send, { sleepFn: noSleep })
+    ).rejects.toMatchObject({ code: 400 });
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('backs off exponentially between attempts', async () => {
+    const delays: number[] = [];
+    const send = jest.fn().mockRejectedValue(sendError(429));
+    await expect(
+      sendWithRetry(send, {
+        maxAttempts: 3,
+        baseDelayMs: 500,
+        sleepFn: (ms) => {
+          delays.push(ms);
+          return Promise.resolve();
+        },
+      })
+    ).rejects.toBeDefined();
+    expect(delays).toEqual([500, 1000]);
+  });
+});

--- a/src/services/EmailService/sendWithRetry.ts
+++ b/src/services/EmailService/sendWithRetry.ts
@@ -1,0 +1,59 @@
+export interface SendRetryOptions {
+  maxAttempts?: number;
+  baseDelayMs?: number;
+  sleepFn?: (ms: number) => Promise<void>;
+}
+
+const RETRYABLE_NETWORK_CODES = new Set<string>([
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ETIMEDOUT',
+  'EAI_AGAIN',
+  'ENOTFOUND',
+  'EPIPE',
+]);
+
+// SendGrid surfaces HTTP failures as an error whose `code` is the numeric
+// status (429 rate-limit, 5xx upstream); transport failures surface with a
+// string `code` (ECONNRESET, …) and no HTTP response. Both are worth another
+// attempt; a 4xx other than 429 is a permanent reject and must not retry.
+export function isTransientSendError(error: unknown): boolean {
+  const code = (error as { code?: unknown } | null | undefined)?.code;
+  if (typeof code === 'number') {
+    return code === 429 || code >= 500;
+  }
+  if (typeof code === 'string') {
+    return RETRYABLE_NETWORK_CODES.has(code);
+  }
+  return false;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Retry a single email send across transient SendGrid/transport failures with
+// exponential backoff. Rethrows the last error when attempts are exhausted or
+// the failure is permanent, so the caller still learns the send did not happen.
+export async function sendWithRetry<T>(
+  send: () => Promise<T>,
+  options: SendRetryOptions = {}
+): Promise<T> {
+  const maxAttempts = options.maxAttempts ?? 3;
+  const baseDelayMs = options.baseDelayMs ?? 500;
+  const doSleep = options.sleepFn ?? sleep;
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await send();
+    } catch (error) {
+      lastError = error;
+      if (attempt === maxAttempts || !isTransientSendError(error)) {
+        throw error;
+      }
+      await doSleep(baseDelayMs * 2 ** (attempt - 1));
+    }
+  }
+  throw lastError;
+}


### PR DESCRIPTION
## Problem

A contact-form submission reliably appears in the Ops Messages inbox but its support@2anki.net notification can silently never arrive.

`contactUs` (`IndexController.ts`) does two things:
1. Insert into `feedback` — **awaited**, so the message always lands in the Ops inbox.
2. `sendContactEmail(...)` — **fire-and-forget**. And `sendContactEmail` catches its own SendGrid error and resolves `{ didSend: false }` rather than throwing, so the controller's `.catch` was dead code. A failed send left only one `console.error` deep in EmailService.

Net: a single transient SendGrid failure (429/5xx/network blip) drops the notification with no retry and no visible signal, while the message still shows in Ops. That is the reported "it's in the inbox but never reached support@ like the others."

## Fix

- New `sendWithRetry` helper (SendGrid-aware): retries transient HTTP `429`/`5xx` and network codes (`ECONNRESET`, `ETIMEDOUT`, …) up to 3 attempts with exponential backoff; rethrows on permanent (`4xx` other than 429) or exhaustion. The Notion `withRetry` could not be reused — its predicate only recognizes Notion API errors.
- `sendContactEmail` sends through it.
- `contactUs` now observes the send result and, on failure, logs the **feedback row id** (not the submitter's email) so a genuine failure is traceable while the ops inbox stays the durable record.

## Scope / notes

- Backend reliability only. The submitter's experience is unchanged (still an instant 200; retries run in the background), so **no changelog entry** and no `web/src/` changes.
- Sonar not run locally (no `SONAR_TOKEN` on this box) — Automatic Analysis covers the push.
- Tests: `sendWithRetry.test.ts` (18 cases: transient vs permanent classification, retry-then-succeed, exhaustion, no-retry-on-permanent, backoff schedule). Existing `EmailService.test.ts` stays green.

## Follow-up (not built)

The fully durable fix is to persist send status on the `feedback` row and surface an "not notified" badge in the Ops Messages tab — that needs a migration + web change + a UX call, so it's out of scope here. This PR closes the silent-loss gap; say the word and I'll spec the badge.
