### PR TITLE
fix: index uploads.owner to stop the 502 on GET /api/upload/mine

### DIFF
--- a/migrations/20260926000000_index_uploads_owner_id_concurrent.js
+++ b/migrations/20260926000000_index_uploads_owner_id_concurrent.js
@@ -1,0 +1,11 @@
+exports.config = { transaction: false };
+
+exports.up = async (knex) => {
+  await knex.schema.raw(
+    'CREATE INDEX CONCURRENTLY IF NOT EXISTS uploads_owner_id_idx ON uploads (owner, id DESC)'
+  );
+};
+
+exports.down = async (knex) => {
+  await knex.schema.raw('DROP INDEX CONCURRENTLY IF EXISTS uploads_owner_id_idx');
+};

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-19-uploads-list-loads-reliably.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-19-uploads-list-loads-reliably.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-19-uploads-list-loads-reliably",
+  "date": "2026-07-19",
+  "type": "fix",
+  "title": "Your uploads list loads reliably even with a long history"
+}


### PR DESCRIPTION
## What
Adds a concurrent btree index `uploads_owner_id_idx` on `uploads (owner, id DESC)`. No query change.

## Why
`GET /api/upload/mine` was intermittently returning `502 Proxy Error` under load. `UploadRepository.getUploadsByOwner` runs `.where({ owner }).orderBy('id','desc')`, but the only owner index on `uploads` is a PARTIAL unique index on `(owner, dedupe_key) WHERE dedupe_key IS NOT NULL` — Postgres cannot use it for an owner-only filter. So every upload-page load seq-scanned all users' rows and sorted them, and under load that crossed the nginx/pm2 read timeout, returning 502. Every other owner-scoped table (favorites, sessions, ankify_*) already has an owner index; `uploads` was missed.

## How
`(owner, id DESC)` matches the exact filter + sort, so the read becomes an index range scan with no sort node. Built with `CREATE INDEX CONCURRENTLY IF NOT EXISTS` so there is no table lock on the live `uploads` table; the migration sets `config.transaction = false` because CONCURRENTLY cannot run inside a transaction (same pattern as `20260903000001_uploads_dedupe_index_concurrent.js`). The `down` drops it `CONCURRENTLY IF EXISTS`, also lock-free.

No kanel regeneration: this adds an INDEX only, no table/column change, and kanel regenerates types from table/column schema, not indexes.

## Measuring success
- Prod: `EXPLAIN SELECT * FROM uploads WHERE owner = <id> ORDER BY id DESC` should show `Index Scan using uploads_owner_id_idx`, not `Seq Scan` + `Sort`.
- The 502 rate on `GET /api/upload/mine` in the proxy/access logs should drop to zero.

## Verified locally
Applied the migration against local Postgres via `knex.migrate.latest`, then `EXPLAIN`:
- Before: `Seq Scan on uploads` + `Sort Key: id DESC`
- After: `Index Scan using uploads_owner_id_idx (Index Cond: owner = 1)`, no sort node
- `down` cleanly dropped the index and reverted to the pre-migration index set.

## Testing
- No unit test: this is an index-only migration (plain JS, no source `.ts` touched), matching the existing concurrent index migrations which carry none. `npx tsc -p . --noEmit` is clean.

Sonar not run locally; Automatic Analysis covers the push (no SONAR_TOKEN on this box).

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-07-19-uploads-list-loads-reliably.json` — "Your uploads list loads reliably even with a long history"

Browser check: not applicable — migration + changelog only, no rendered output

## Risks
Concurrent index build takes longer than a plain build but never locks the table for writes. If it fails partway it can leave an INVALID index, which the `IF NOT EXISTS` re-run replaces; rollback is `down` (also CONCURRENTLY IF EXISTS). No query or app-code change, so nothing else is affected.

## Goal alignment
Reliability fix on a logged-in surface (the uploads list). Should move the 502 error rate on `GET /api/upload/mine` to zero — read in the proxy/access logs. Keeps the app fast for returning users with a long upload history.
