### PR TITLE
fix: show the empty-deck reason by default on the Downloads page

### DIFF
--- a/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
@@ -615,7 +615,7 @@ describe('DownloadsPage failure reason panel', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('renders the toggle teaching copy and docs CTA for empty deck errors', () => {
+  it('shows the toggle teaching copy and docs CTA for empty deck errors without a click', () => {
     mockJobs = [
       buildJob({
         status: 'failed',
@@ -625,11 +625,6 @@ describe('DownloadsPage failure reason panel', () => {
     ];
     renderAt('/downloads');
 
-    const statusButton = screen.getByRole('button', {
-      name: /Show failure reason/i,
-    });
-    fireEvent.click(statusButton);
-
     expect(
       screen.getByText(/makes a card from every Notion toggle/i)
     ).toBeInTheDocument();
@@ -637,6 +632,24 @@ describe('DownloadsPage failure reason panel', () => {
       name: 'See how toggles become cards',
     });
     expect(cta).toHaveAttribute('href', '/documentation/cards/notion-blocks');
+  });
+
+  it('does not render a show/collapse toggle for empty deck errors', () => {
+    mockJobs = [
+      buildJob({
+        status: 'failed',
+        job_reason_failure:
+          "No cards in this deck yet. 2anki makes a card from every Notion toggle — the toggle title becomes the question, what's inside becomes the answer. Wrap your key terms in toggles, then convert again.",
+      }),
+    ];
+    renderAt('/downloads');
+
+    expect(
+      screen.queryByRole('button', { name: /Show failure reason/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Collapse failure reason/i })
+    ).not.toBeInTheDocument();
   });
 
   it('does not show the toggles docs CTA for non-empty-deck errors', () => {

--- a/web/src/pages/DownloadsPage/DownloadsPage.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.tsx
@@ -77,7 +77,12 @@ const VALID_FILTERS = new Set<FilterValue>([
   'drive',
 ]);
 const APKG_PATTERN = /\.apkg$/i;
+const EMPTY_DECK_REASON_PREFIX = 'No cards in this deck yet.';
 const ACTIVE_STATUSES = new Set(['done', 'failed', 'cancelled', 'interrupted']);
+
+function isEmptyDeckReason(reason: string | null): boolean {
+  return reason != null && reason.startsWith(EMPTY_DECK_REASON_PREFIX);
+}
 
 function isActiveJob(status: string): boolean {
   return !ACTIVE_STATUSES.has(status);
@@ -219,6 +224,9 @@ function renderJobStatusWithToggle(
   t: TFunction
 ) {
   if (isFailedJob(job.status)) {
+    if (isEmptyDeckReason(job.job_reason_failure)) {
+      return <StatusTag status={job.status as JobStatus} />;
+    }
     const isMonthlyLimit =
       parseMonthlyLimitPayload(job.job_reason_failure) != null;
     return (
@@ -786,7 +794,10 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                 </td>
                               </tr>
                               {isFailed &&
-                                isExpanded &&
+                                (isExpanded ||
+                                  isEmptyDeckReason(
+                                    row.job.job_reason_failure
+                                  )) &&
                                 row.job.job_reason_failure != null && (
                                   <tr key={`job-${row.job.id}-panel`}>
                                     <td

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-19-empty-deck-reason-shown.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-19-empty-deck-reason-shown.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-19-empty-deck-reason-shown",
+  "date": "2026-07-19",
+  "type": "fix",
+  "title": "An empty deck now shows why and how to fix it without an extra click"
+}


### PR DESCRIPTION
## What
When a conversion produces zero cards the job fails with the empty-deck reason, which carries a specific, actionable message ("2anki makes a card from every Notion toggle … wrap your key terms in toggles, then convert again"). That message previously rendered only after the user clicked the failed row's chevron to expand it — on the Downloads page the row showed just a red "Failed" tag. This makes the empty-deck reason and its "See how toggles become cards" docs CTA render inline for failed rows, with no click, and drops the now-redundant show/collapse toggle for that case.

## Why
`empty_deck` is the largest named conversion-failure leak (~13/wk). The fix already existed but was hidden behind click-to-expand, so users saw no reason and dropped off instead of re-converting. Surfacing the reason inline should keep more of them in the loop back to a successful conversion.

## How
Added an `isEmptyDeckReason(reason)` prefix check in `DownloadsPage.tsx`. For failed rows whose reason is the empty-deck message, the failure panel now renders unconditionally (not gated on `isExpanded`), and `renderJobStatusWithToggle` returns a plain `StatusTag` (no chevron) since there is nothing left to collapse. All other failure types keep the existing expand/collapse behaviour. Reuses the existing `ConversionResult` `variant="failed"` panel — no restyle.

## Measuring success
`upload_to_download_rate_7d`, read at `/api/ops/conversion/metrics` via `topFailureReasons7d`; watch the `empty_deck` share week-over-week — it should fall as more users re-convert instead of abandoning after the first empty result.

## Testing
- Unit tests updated/added in `DownloadsPage.test.tsx`: empty-deck teaching copy + docs CTA now assert visibility without a click; a new test asserts no show/collapse toggle is rendered for empty-deck errors. Full file: 49 passed.
- Web typecheck clean; tree-wide `pnpm format:check` clean.
- Sonar not run locally; Automatic Analysis covers the push.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: `pnpm --filter 2anki-web test:golden-path` — 2 passed (landing + signed-in dashboard at 375px, no console errors).

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-07-19-empty-deck-reason-shown.json` — "An empty deck now shows why and how to fix it without an extra click"

## Risks
Low. Scoped to the empty-deck failed-row rendering on Downloads; other failure types (monthly limit, notion_token_expired, generic) keep their existing toggle behaviour. Rollback is a straight revert.

## Goal alignment
Directly targets the biggest named conversion leak; moving `upload_to_download_rate_7d` grows both successful conversions (the core promise) and the top-of-funnel that feeds paid conversion toward the 300K-user and MRR goals.
