### PR TITLE
fix: cohort return-rate from events so all sources are visible, not only Notion pages

### DIFF
--- a/src/services/ops/ReturnRateMetricsService.test.ts
+++ b/src/services/ops/ReturnRateMetricsService.test.ts
@@ -1,210 +1,187 @@
 import knex, { Knex } from 'knex';
 
-import { ReturnRateMetricsService } from './ReturnRateMetricsService';
+import {
+  CohortMember,
+  ReturnRecord,
+  ReturnRateMetricsService,
+  computeReturnRates,
+} from './ReturnRateMetricsService';
 
-async function makeDb(): Promise<Knex> {
-  const db = knex({
-    client: 'better-sqlite3',
-    connection: { filename: ':memory:' },
-    useNullAsDefault: true,
-  });
-  await db.schema.createTable('jobs', (t) => {
-    t.increments('id');
-    t.string('owner').notNullable();
-    t.string('object_id').notNullable();
-    t.string('title');
-    t.string('type');
-    t.string('status');
-    t.timestamp('created_at').defaultTo(db.fn.now());
-    t.timestamp('last_edited_time');
-    t.string('job_reason_failure');
-    t.integer('card_count');
-  });
-  return db;
+const NOW = new Date('2026-07-19T00:00:00.000Z');
+const CUTOFF = new Date('2026-04-20T00:00:00.000Z');
+
+function daysBefore(anchor: Date, n: number): Date {
+  return new Date(anchor.getTime() - n * 24 * 60 * 60 * 1000);
 }
 
-function daysAgo(n: number): Date {
-  const d = new Date();
-  d.setUTCDate(d.getUTCDate() - n);
-  return d;
+function daysAfter(anchor: Date, n: number): Date {
+  return new Date(anchor.getTime() + n * 24 * 60 * 60 * 1000);
 }
 
-async function insertJob(
-  db: Knex,
-  attrs: {
-    owner: string;
-    object_id: string;
-    type: string;
-    status?: string;
-    created_at?: Date;
-  }
-) {
-  await db('jobs').insert({
-    owner: attrs.owner,
-    object_id: attrs.object_id,
-    type: attrs.type,
-    status: attrs.status ?? 'done',
-    created_at: attrs.created_at ?? new Date(),
-    last_edited_time: new Date(),
+describe('ReturnRateMetricsService — generated SQL', () => {
+  const pg = knex({ client: 'pg' });
+  const service = new ReturnRateMetricsService(pg);
+
+  afterAll(async () => {
+    await pg.destroy();
   });
-}
 
-describe('ReturnRateMetricsService — graceful failure', () => {
-  it('returns null for all windows when the db throws', async () => {
-    const failing = { raw: jest.fn() } as unknown as Knex;
-    const service = new ReturnRateMetricsService(failing);
-    const result = await service.getMetrics();
-    expect(result.by_source_type).toBeNull();
-    expect(result.overall['7d']).toBeNull();
-    expect(result.overall['14d']).toBeNull();
-    expect(result.overall['30d']).toBeNull();
+  it('builds the cohort over conversion_succeeded keyed by identity and source', () => {
+    const { sql, bindings } = service.buildCohortQuery(NOW).toSQL();
+
+    expect(sql).toBe(
+      "select COALESCE(user_id::text, anonymous_id) as owner, COALESCE(props->>'source', ?) as source_type, " +
+        'MAX(created_at) as last_success_at from "events" ' +
+        'where "name" = ? and "created_at" >= ? ' +
+        'and COALESCE(user_id::text, anonymous_id) IS NOT NULL ' +
+        "group by COALESCE(user_id::text, anonymous_id), COALESCE(props->>'source', ?)"
+    );
+    expect(bindings).toEqual([
+      'unknown',
+      'conversion_succeeded',
+      CUTOFF,
+      'unknown',
+    ]);
+  });
+
+  it('builds the returns query finding each identity/source next conversion', () => {
+    const { sql, bindings } = service.buildReturnsQuery(NOW).toSQL();
+
+    expect(sql).toBe(
+      "select COALESCE(e1.user_id::text, e1.anonymous_id) as owner, COALESCE(e1.props->>'source', ?) as source_type, " +
+        '"e1"."created_at" as "anchor_at", ' +
+        '(SELECT MIN(e2.created_at) FROM events e2 ' +
+        'WHERE COALESCE(e2.user_id::text, e2.anonymous_id) = COALESCE(e1.user_id::text, e1.anonymous_id) ' +
+        "AND COALESCE(e2.props->>'source', ?) = COALESCE(e1.props->>'source', ?) " +
+        'AND e2.name = ? AND e2.created_at > e1.created_at) as first_return_at ' +
+        'from "events" as "e1" ' +
+        'where "e1"."name" = ? and "e1"."created_at" >= ? ' +
+        'and COALESCE(e1.user_id::text, e1.anonymous_id) IS NOT NULL'
+    );
+    expect(bindings).toEqual([
+      'unknown',
+      'unknown',
+      'unknown',
+      'conversion_succeeded',
+      'conversion_succeeded',
+      CUTOFF,
+    ]);
   });
 });
 
-describe('ReturnRateMetricsService — return-rate windows', () => {
-  let db: Knex;
-  let service: ReturnRateMetricsService;
+describe('computeReturnRates — return-rate windows', () => {
+  const asOf = NOW.toISOString();
 
-  beforeEach(async () => {
-    db = await makeDb();
-    service = new ReturnRateMetricsService(db);
-  });
+  function cohortMember(
+    owner: string,
+    source_type: string,
+    last_success_at: Date
+  ): CohortMember {
+    return {
+      owner,
+      source_type,
+      last_success_at: last_success_at.toISOString(),
+    };
+  }
 
-  afterEach(async () => {
-    await db.destroy();
-  });
+  function returnRecord(
+    owner: string,
+    source_type: string,
+    anchor: Date,
+    firstReturn: Date
+  ): ReturnRecord {
+    return {
+      owner,
+      source_type,
+      anchor_at: anchor.toISOString(),
+      first_return_at: firstReturn.toISOString(),
+    };
+  }
 
-  it('counts a user who returned within 7 days as retained in all windows', async () => {
-    await insertJob(db, {
-      owner: 'u1',
-      object_id: 'j-first',
-      type: 'page',
-      status: 'done',
-      created_at: daysAgo(20),
-    });
-    await insertJob(db, {
-      owner: 'u1',
-      object_id: 'j-second',
-      type: 'page',
-      status: 'done',
-      created_at: daysAgo(15),
-    });
-
-    const result = await service.getMetrics();
+  it('counts an identity that returned within 7 days as retained in all windows', () => {
+    const anchor = daysBefore(NOW, 20);
+    const result = computeReturnRates(
+      [cohortMember('u1', 'notion', anchor)],
+      [returnRecord('u1', 'notion', anchor, daysAfter(anchor, 5))],
+      asOf
+    );
 
     expect(result.overall['7d']).toBeCloseTo(100, 5);
     expect(result.overall['14d']).toBeCloseTo(100, 5);
     expect(result.overall['30d']).toBeCloseTo(100, 5);
   });
 
-  it('counts a user who only returned after 8 days as NOT in 7d window but in 14d', async () => {
-    await insertJob(db, {
-      owner: 'u2',
-      object_id: 'j-a',
-      type: 'page',
-      status: 'done',
-      created_at: daysAgo(40),
-    });
-    await insertJob(db, {
-      owner: 'u2',
-      object_id: 'j-b',
-      type: 'page',
-      status: 'done',
-      created_at: new Date(daysAgo(40).getTime() + 8 * 24 * 60 * 60 * 1000),
-    });
-
-    const result = await service.getMetrics();
+  it('counts an identity that returned after 8 days as NOT in 7d but in 14d', () => {
+    const anchor = daysBefore(NOW, 40);
+    const result = computeReturnRates(
+      [cohortMember('u2', 'upload', anchor)],
+      [returnRecord('u2', 'upload', anchor, daysAfter(anchor, 8))],
+      asOf
+    );
 
     expect(result.overall['7d']).toBeCloseTo(0, 5);
     expect(result.overall['14d']).toBeCloseTo(100, 5);
     expect(result.overall['30d']).toBeCloseTo(100, 5);
   });
 
-  it('excludes non-conversion job types from the cohort', async () => {
-    await insertJob(db, {
-      owner: 'u3',
-      object_id: 'j-c',
-      type: 'claude',
-      status: 'done',
-      created_at: daysAgo(10),
-    });
-    await insertJob(db, {
-      owner: 'u3',
-      object_id: 'j-d',
-      type: 'claude',
-      status: 'done',
-      created_at: daysAgo(5),
-    });
+  it('breaks down return rates for every source, not just Notion', () => {
+    const anchor = daysBefore(NOW, 15);
+    const result = computeReturnRates(
+      [
+        cohortMember('u4', 'notion', anchor),
+        cohortMember('u5', 'upload', anchor),
+        cohortMember('u6', 'google_drive', anchor),
+      ],
+      [returnRecord('u4', 'notion', anchor, daysAfter(anchor, 3))],
+      asOf
+    );
 
-    const result = await service.getMetrics();
+    const bySource = new Map(
+      (result.by_source_type ?? []).map((r) => [r.source_type, r])
+    );
+    expect(bySource.get('notion')?.cohort_size).toBe(1);
+    expect(bySource.get('notion')?.returned_7d).toBe(1);
+    expect(bySource.get('upload')?.cohort_size).toBe(1);
+    expect(bySource.get('upload')?.returned_7d).toBe(0);
+    expect(bySource.get('google_drive')?.cohort_size).toBe(1);
+    expect(bySource.get('google_drive')?.returned_7d).toBe(0);
+  });
+
+  it('uses the smallest gap between conversions for an identity', () => {
+    const anchor = daysBefore(NOW, 50);
+    const result = computeReturnRates(
+      [cohortMember('u7', 'notion', anchor)],
+      [
+        returnRecord('u7', 'notion', anchor, daysAfter(anchor, 40)),
+        returnRecord('u7', 'notion', anchor, daysAfter(anchor, 4)),
+      ],
+      asOf
+    );
+
+    expect(result.overall['7d']).toBeCloseTo(100, 5);
+  });
+
+  it('returns null windows and no source breakdown for an empty cohort', () => {
+    const result = computeReturnRates([], [], asOf);
 
     expect(result.overall['7d']).toBeNull();
     expect(result.overall['14d']).toBeNull();
     expect(result.overall['30d']).toBeNull();
+    expect(result.by_source_type).toBeNull();
+    expect(result.as_of).toBe(asOf);
   });
+});
 
-  it('breaks down return rates by source_type', async () => {
-    await insertJob(db, {
-      owner: 'u4',
-      object_id: 'j-e',
-      type: 'page',
-      status: 'done',
-      created_at: daysAgo(15),
-    });
-    await insertJob(db, {
-      owner: 'u4',
-      object_id: 'j-f',
-      type: 'page',
-      status: 'done',
-      created_at: daysAgo(10),
-    });
-    await insertJob(db, {
-      owner: 'u5',
-      object_id: 'j-g',
-      type: 'conversion',
-      status: 'done',
-      created_at: daysAgo(15),
-    });
+describe('ReturnRateMetricsService — graceful failure', () => {
+  it('returns null windows when the query throws', async () => {
+    const failing = { raw: jest.fn() } as unknown as Knex;
+    const service = new ReturnRateMetricsService(failing);
 
     const result = await service.getMetrics();
 
-    const pageRow = result.by_source_type?.find(
-      (r) => r.source_type === 'page'
-    );
-    const convRow = result.by_source_type?.find(
-      (r) => r.source_type === 'conversion'
-    );
-    expect(pageRow?.cohort_size).toBe(1);
-    expect(pageRow?.returned_7d).toBe(1);
-    expect(convRow?.cohort_size).toBe(1);
-    expect(convRow?.returned_7d).toBe(0);
-  });
-
-  it('uses the last successful job as the cohort anchor, not the first', async () => {
-    await insertJob(db, {
-      owner: 'u6',
-      object_id: 'j-x1',
-      type: 'page',
-      status: 'done',
-      created_at: daysAgo(50),
-    });
-    await insertJob(db, {
-      owner: 'u6',
-      object_id: 'j-x2',
-      type: 'page',
-      status: 'done',
-      created_at: daysAgo(10),
-    });
-    await insertJob(db, {
-      owner: 'u6',
-      object_id: 'j-x3',
-      type: 'page',
-      status: 'done',
-      created_at: daysAgo(5),
-    });
-
-    const result = await service.getMetrics();
-
-    expect(result.overall['7d']).toBeCloseTo(100, 5);
+    expect(result.by_source_type).toBeNull();
+    expect(result.overall['7d']).toBeNull();
+    expect(result.overall['14d']).toBeNull();
+    expect(result.overall['30d']).toBeNull();
   });
 });

--- a/src/services/ops/ReturnRateMetricsService.ts
+++ b/src/services/ops/ReturnRateMetricsService.ts
@@ -23,17 +23,18 @@ export interface ReturnRateMetricsResponse {
   as_of: string;
 }
 
-const CONVERSION_TYPES: string[] = ['page', 'database', 'conversion'];
+const CONVERSION_EVENT = 'conversion_succeeded';
 const SECONDS_PER_DAY = 24 * 60 * 60;
 const LOOKBACK_DAYS = 90;
+const UNKNOWN_SOURCE = 'unknown';
 
-interface CohortMember {
+export interface CohortMember {
   owner: string;
   source_type: string;
   last_success_at: string;
 }
 
-interface ReturnRecord {
+export interface ReturnRecord {
   owner: string;
   source_type: string;
   anchor_at: string;
@@ -44,6 +45,84 @@ const pct = (num: number, denom: number): number | null => {
   if (denom === 0) return null;
   return (num / denom) * 100;
 };
+
+export function computeReturnRates(
+  cohort: CohortMember[],
+  returns: ReturnRecord[],
+  as_of: string
+): ReturnRateMetricsResponse {
+  const returnMap = new Map<string, { gapMs: number }>();
+  for (const r of returns) {
+    const key = `${r.owner}::${r.source_type}`;
+    const gapMs =
+      new Date(r.first_return_at).getTime() - new Date(r.anchor_at).getTime();
+    const existing = returnMap.get(key);
+    if (existing == null || gapMs < existing.gapMs) {
+      returnMap.set(key, { gapMs });
+    }
+  }
+
+  const sourceMap = new Map<
+    string,
+    { cohort: number; r7: number; r14: number; r30: number }
+  >();
+
+  let totalCohort = 0;
+  let totalR7 = 0;
+  let totalR14 = 0;
+  let totalR30 = 0;
+
+  for (const member of cohort) {
+    const key = `${member.owner}::${member.source_type}`;
+    const ret = returnMap.get(key);
+    const gapMs = ret?.gapMs ?? Infinity;
+
+    const returned7 = gapMs <= 7 * SECONDS_PER_DAY * 1000 ? 1 : 0;
+    const returned14 = gapMs <= 14 * SECONDS_PER_DAY * 1000 ? 1 : 0;
+    const returned30 = gapMs <= 30 * SECONDS_PER_DAY * 1000 ? 1 : 0;
+
+    totalCohort += 1;
+    totalR7 += returned7;
+    totalR14 += returned14;
+    totalR30 += returned30;
+
+    const existing = sourceMap.get(member.source_type) ?? {
+      cohort: 0,
+      r7: 0,
+      r14: 0,
+      r30: 0,
+    };
+    existing.cohort += 1;
+    existing.r7 += returned7;
+    existing.r14 += returned14;
+    existing.r30 += returned30;
+    sourceMap.set(member.source_type, existing);
+  }
+
+  const by_source_type: ReturnRateBySourceType[] = [];
+  for (const [source_type, counts] of sourceMap) {
+    by_source_type.push({
+      source_type,
+      cohort_size: counts.cohort,
+      returned_7d: counts.r7,
+      returned_14d: counts.r14,
+      returned_30d: counts.r30,
+      return_rate_7d_pct: pct(counts.r7, counts.cohort),
+      return_rate_14d_pct: pct(counts.r14, counts.cohort),
+      return_rate_30d_pct: pct(counts.r30, counts.cohort),
+    });
+  }
+
+  return {
+    overall: {
+      '7d': pct(totalR7, totalCohort),
+      '14d': pct(totalR14, totalCohort),
+      '30d': pct(totalR30, totalCohort),
+    },
+    by_source_type: by_source_type.length > 0 ? by_source_type : null,
+    as_of,
+  };
+}
 
 export class ReturnRateMetricsService {
   constructor(private readonly database: Knex) {}
@@ -76,48 +155,64 @@ export class ReturnRateMetricsService {
       };
     }
 
-    return this.compute(cohort, returns, as_of);
+    return computeReturnRates(cohort, returns, as_of);
+  }
+
+  private cutoff(now: Date): Date {
+    return new Date(now.getTime() - LOOKBACK_DAYS * SECONDS_PER_DAY * 1000);
+  }
+
+  buildCohortQuery(now: Date): Knex.QueryBuilder {
+    return this.database('events')
+      .where('name', CONVERSION_EVENT)
+      .where('created_at', '>=', this.cutoff(now))
+      .whereRaw('COALESCE(user_id::text, anonymous_id) IS NOT NULL')
+      .select(
+        this.database.raw('COALESCE(user_id::text, anonymous_id) as owner'),
+        this.database.raw("COALESCE(props->>'source', ?) as source_type", [
+          UNKNOWN_SOURCE,
+        ]),
+        this.database.raw('MAX(created_at) as last_success_at')
+      )
+      .groupByRaw(
+        "COALESCE(user_id::text, anonymous_id), COALESCE(props->>'source', ?)",
+        [UNKNOWN_SOURCE]
+      );
+  }
+
+  buildReturnsQuery(now: Date): Knex.QueryBuilder {
+    return this.database('events as e1')
+      .where('e1.name', CONVERSION_EVENT)
+      .where('e1.created_at', '>=', this.cutoff(now))
+      .whereRaw('COALESCE(e1.user_id::text, e1.anonymous_id) IS NOT NULL')
+      .select(
+        this.database.raw(
+          'COALESCE(e1.user_id::text, e1.anonymous_id) as owner'
+        ),
+        this.database.raw("COALESCE(e1.props->>'source', ?) as source_type", [
+          UNKNOWN_SOURCE,
+        ]),
+        'e1.created_at as anchor_at',
+        this.database.raw(
+          '(SELECT MIN(e2.created_at) FROM events e2' +
+            ' WHERE COALESCE(e2.user_id::text, e2.anonymous_id) =' +
+            ' COALESCE(e1.user_id::text, e1.anonymous_id)' +
+            " AND COALESCE(e2.props->>'source', ?) =" +
+            " COALESCE(e1.props->>'source', ?)" +
+            ' AND e2.name = ?' +
+            ' AND e2.created_at > e1.created_at' +
+            ') as first_return_at',
+          [UNKNOWN_SOURCE, UNKNOWN_SOURCE, CONVERSION_EVENT]
+        )
+      );
   }
 
   private fetchCohort(now: Date): Promise<CohortMember[]> {
-    const cutoff = new Date(
-      now.getTime() - LOOKBACK_DAYS * SECONDS_PER_DAY * 1000
-    );
-    return this.database('jobs')
-      .whereIn('type', CONVERSION_TYPES)
-      .where('status', 'done')
-      .where('created_at', '>=', cutoff)
-      .select(
-        'owner',
-        'type as source_type',
-        this.database.raw('MAX(created_at) as last_success_at')
-      )
-      .groupBy('owner', 'type') as Promise<CohortMember[]>;
+    return this.buildCohortQuery(now) as Promise<CohortMember[]>;
   }
 
   private async fetchReturns(now: Date): Promise<ReturnRecord[]> {
-    const cutoff = new Date(
-      now.getTime() - LOOKBACK_DAYS * SECONDS_PER_DAY * 1000
-    );
-
-    const rows = (await this.database('jobs as j1')
-      .whereIn('j1.type', CONVERSION_TYPES)
-      .where('j1.status', 'done')
-      .where('j1.created_at', '>=', cutoff)
-      .select(
-        'j1.owner',
-        'j1.type as source_type',
-        'j1.created_at as anchor_at',
-        this.database.raw(
-          '(SELECT MIN(j2.created_at) FROM jobs j2' +
-            ' WHERE j2.owner = j1.owner' +
-            ' AND j2.type = j1.type' +
-            ' AND j2.status = ?' +
-            ' AND j2.created_at > j1.created_at' +
-            ') as first_return_at',
-          ['done']
-        )
-      )) as Array<{
+    const rows = (await this.buildReturnsQuery(now)) as Array<{
       owner: string;
       source_type: string;
       anchor_at: string;
@@ -142,83 +237,5 @@ export class ReturnRateMetricsService {
     }
 
     return result;
-  }
-
-  private compute(
-    cohort: CohortMember[],
-    returns: ReturnRecord[],
-    as_of: string
-  ): ReturnRateMetricsResponse {
-    const returnMap = new Map<string, { gapMs: number }>();
-    for (const r of returns) {
-      const key = `${r.owner}::${r.source_type}`;
-      const gapMs =
-        new Date(r.first_return_at).getTime() - new Date(r.anchor_at).getTime();
-      const existing = returnMap.get(key);
-      if (existing == null || gapMs < existing.gapMs) {
-        returnMap.set(key, { gapMs });
-      }
-    }
-
-    const sourceMap = new Map<
-      string,
-      { cohort: number; r7: number; r14: number; r30: number }
-    >();
-
-    let totalCohort = 0;
-    let totalR7 = 0;
-    let totalR14 = 0;
-    let totalR30 = 0;
-
-    for (const member of cohort) {
-      const key = `${member.owner}::${member.source_type}`;
-      const ret = returnMap.get(key);
-      const gapMs = ret?.gapMs ?? Infinity;
-
-      const returned7 = gapMs <= 7 * SECONDS_PER_DAY * 1000 ? 1 : 0;
-      const returned14 = gapMs <= 14 * SECONDS_PER_DAY * 1000 ? 1 : 0;
-      const returned30 = gapMs <= 30 * SECONDS_PER_DAY * 1000 ? 1 : 0;
-
-      totalCohort += 1;
-      totalR7 += returned7;
-      totalR14 += returned14;
-      totalR30 += returned30;
-
-      const existing = sourceMap.get(member.source_type) ?? {
-        cohort: 0,
-        r7: 0,
-        r14: 0,
-        r30: 0,
-      };
-      existing.cohort += 1;
-      existing.r7 += returned7;
-      existing.r14 += returned14;
-      existing.r30 += returned30;
-      sourceMap.set(member.source_type, existing);
-    }
-
-    const by_source_type: ReturnRateBySourceType[] = [];
-    for (const [source_type, counts] of sourceMap) {
-      by_source_type.push({
-        source_type,
-        cohort_size: counts.cohort,
-        returned_7d: counts.r7,
-        returned_14d: counts.r14,
-        returned_30d: counts.r30,
-        return_rate_7d_pct: pct(counts.r7, counts.cohort),
-        return_rate_14d_pct: pct(counts.r14, counts.cohort),
-        return_rate_30d_pct: pct(counts.r30, counts.cohort),
-      });
-    }
-
-    return {
-      overall: {
-        '7d': pct(totalR7, totalCohort),
-        '14d': pct(totalR14, totalCohort),
-        '30d': pct(totalR30, totalCohort),
-      },
-      by_source_type: by_source_type.length > 0 ? by_source_type : null,
-      as_of,
-    };
   }
 }


### PR DESCRIPTION
## What
Repoints the ops return-rate cohort query from the `jobs` table to the `events` table so it measures return behavior across every conversion source, not just Notion pages.

## Why
The by-source-type return-rate breakdown was a measurement artifact. `fetchCohort`/`fetchReturns` filtered `jobs.type in ('page','database','conversion')`, and only the Notion import path writes those job types. The overwhelming majority of file uploads take a path that never creates a `jobs` row, and the few upload jobs that do exist use types (`claude`, `apkg_import`, `mcp`) the filter excludes. Result: `page` was the ONLY visible cohort — we were blind to return behavior for every non-Notion input.

## How
Both queries now read `events` where `name = 'conversion_succeeded'`, keyed on the same distinct-identity idiom the other events metrics use (`COALESCE(user_id::text, anonymous_id)`) and grouped by `props->>'source'` as the source dimension. The `source` prop is already emitted on every conversion path (`upload`, `notion`, `google_drive`, `dropbox`, `app`, `web`; a null source folds into `unknown`). "Returned within N days" is unchanged semantically: the same identity has a later `conversion_succeeded` within N days. The response shape (`overall` + `by_source_type` rows: cohort_size, returned_7d/14d/30d, rate pcts) is preserved, so downstream ops consumers keep working — now with N real source rows instead of one.

## Measuring success
`GET /api/ops/return-rate/metrics` `by_source_type` goes from a single `page` row to N real source rows (`notion`, `upload`, `google_drive`, …) within a 90-day window post-deploy. Confirm on the ops dashboard, or directly: `select props->>'source' as source, count(*) from events where name = 'conversion_succeeded' and created_at >= now() - interval '90 days' group by 1` should return multiple source buckets, and the endpoint should mirror them.

## Testing
- Generated-SQL assertions (pg dialect, `knex({ client: 'pg' })`, no connection) on `buildCohortQuery` and `buildReturnsQuery` — confirms `props->>'source'`, `::text`, and the correlated-subquery interval math are valid Postgres and bind in the right order. A sqlite integration test can't reproduce these PG-only operators.
- Behavior tests on the extracted pure `computeReturnRates` cover the 7/14/30-day window math, the multi-source breakdown, smallest-gap selection, and the empty cohort.
- `pnpm test src/services/ops/ReturnRateMetricsService.test.ts` green (8 tests); `tsc -p . --noEmit` clean; `pnpm format:check` clean.
- Sonar not run locally; Automatic Analysis covers the push.

## Changelog
No entry — internal ops metric, no user-visible change.

Browser check: not applicable — server-side ops metric only, no `web/src/` touched.

## Risks
Low. Query change only; the response contract is identical. Historical `jobs`-based numbers and `events`-based numbers are not directly comparable across the switch, which is the point — the old numbers were a Notion-only slice.

## Goal alignment
None — internal. This is a measurement-correctness fix for retention analysis; it unblinds return-rate by source so retention work (the stated revenue lever) can be prioritized on real data instead of a Notion-only artifact.

no changelog entry — internal ops metric (return-rate cohort source), no user-visible behavior change.
