### PR TITLE
fix: stamp signup_origin on upload and conversion funnel events

### DIFF
--- a/src/controllers/NotionController.ts
+++ b/src/controllers/NotionController.ts
@@ -46,6 +46,7 @@ import { INotionRepository } from '../data_layer/NotionRespository';
 import { IEmailService } from '../services/EmailService/EmailService';
 import UsersRepository from '../data_layer/UsersRepository';
 import { track } from '../services/events/track';
+import { parseFirstTouch } from './helpers/parseFirstTouch';
 import { classifyDevice } from '../lib/analytics/classifyDevice';
 
 const DEFAULT_PREVIEW_PAGE_SIZE = 15;
@@ -288,6 +289,7 @@ class NotionController {
       props: {
         source: conversionSourceFromType(type),
         device: classifyDevice(req.headers?.['user-agent']),
+        signup_origin: parseFirstTouch(cookies?.first_touch).signupOrigin,
       },
     });
 

--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -1927,3 +1927,121 @@ describe('UploadService.restartClaudeJob — card-limit enforcement', () => {
     expect(mockStorageUploadFile).not.toHaveBeenCalled();
   });
 });
+
+describe('UploadService.handleUpload — signup_origin attribution', () => {
+  const originalWorkspaceBase = process.env.WORKSPACE_BASE;
+
+  beforeAll(() => {
+    process.env.WORKSPACE_BASE = path.join(os.tmpdir(), 'upload-service-test');
+  });
+
+  afterAll(() => {
+    process.env.WORKSPACE_BASE = originalWorkspaceBase;
+  });
+
+  beforeEach(() => {
+    MockGeneratePackagesUseCase.mockClear();
+    trackMock.mockClear();
+    mockFirstApkg = Buffer.from('fake-apkg');
+    mockWorkspaceId = 'test-ws-id';
+  });
+
+  function mockSingleDeck(cardCount: number) {
+    MockGeneratePackagesUseCase.mockImplementation(
+      () =>
+        ({
+          execute: jest
+            .fn()
+            .mockResolvedValue({ packages: [{ name: 'deck', cardCount }] }),
+        }) as unknown as InstanceType<typeof GeneratePackagesUseCase>
+    );
+  }
+
+  function firstTouchCookie(landingPath: string) {
+    return JSON.stringify({ landingPath });
+  }
+
+  it('stamps the resolved signup_origin on upload_started and conversion_succeeded from the first_touch cookie', async () => {
+    mockSingleDeck(12);
+
+    const service = new UploadService(
+      buildRepository(),
+      {} as JobRepository,
+      buildUsersRepo()
+    );
+    const req = buildRequest({
+      cookies: { first_touch: firstTouchCookie('/pricing') },
+    } as Partial<express.Request>);
+    const { res, capturedStatus } = buildResponse();
+
+    await service.handleUpload(req, res);
+
+    expect(capturedStatus()).toBe(200);
+    expect(trackMock).toHaveBeenCalledWith(
+      'upload_started',
+      expect.objectContaining({
+        props: expect.objectContaining({ signup_origin: '/pricing' }),
+      })
+    );
+    expect(trackMock).toHaveBeenCalledWith(
+      'conversion_succeeded',
+      expect.objectContaining({
+        props: expect.objectContaining({ signup_origin: '/pricing' }),
+      })
+    );
+  });
+
+  it('stamps the resolved signup_origin on conversion_failed for an over-limit upload', async () => {
+    mockSingleDeck(30);
+    const usersRepo = buildUsersRepo({
+      getCardUsage: jest
+        .fn()
+        .mockResolvedValue({ cards_used: 80, month_started_at: new Date() }),
+    });
+
+    const service = new UploadService(
+      buildRepository(),
+      {} as JobRepository,
+      usersRepo
+    );
+    const req = buildRequest({
+      cookies: { first_touch: firstTouchCookie('/photo-to-deck') },
+    } as Partial<express.Request>);
+    const { res } = buildResponse();
+    (res.redirect as unknown as jest.Mock).mockReturnValue(res);
+    (res.locals as Record<string, unknown>).owner = 42;
+
+    await service.handleUpload(req, res);
+
+    expect(trackMock).toHaveBeenCalledWith(
+      'conversion_failed',
+      expect.objectContaining({
+        props: expect.objectContaining({
+          reason: 'monthly_limit',
+          signup_origin: '/photo-to-deck',
+        }),
+      })
+    );
+  });
+
+  it('stamps signup_origin=null when the request carries no first_touch cookie', async () => {
+    mockSingleDeck(12);
+
+    const service = new UploadService(
+      buildRepository(),
+      {} as JobRepository,
+      buildUsersRepo()
+    );
+    const req = buildRequest();
+    const { res } = buildResponse();
+
+    await service.handleUpload(req, res);
+
+    expect(trackMock).toHaveBeenCalledWith(
+      'upload_started',
+      expect.objectContaining({
+        props: expect.objectContaining({ signup_origin: null }),
+      })
+    );
+  });
+});

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -49,6 +49,7 @@ import Deck from '../lib/parser/Deck';
 import { isHTMLFile, isMarkdownFile } from '../lib/storage/checks';
 import { FileSizeInMegaBytes } from '../lib/misc/file';
 import { track } from './events/track';
+import { parseFirstTouch } from '../controllers/helpers/parseFirstTouch';
 import { classifyDevice } from '../lib/analytics/classifyDevice';
 import {
   validateUploadSource,
@@ -433,6 +434,7 @@ class UploadService {
         props: {
           source: this.resolveUploadSource(req),
           device: classifyDevice(req.headers?.['user-agent']),
+          signup_origin: this.resolveSignupOrigin(req),
         },
       });
 
@@ -457,7 +459,11 @@ class UploadService {
         track('conversion_failed', {
           userId,
           anonymousId,
-          props: { source, reason: 'monthly_limit' },
+          props: {
+            source,
+            reason: 'monthly_limit',
+            signup_origin: this.resolveSignupOrigin(req),
+          },
         });
         track('paywall_shown', {
           userId,
@@ -473,7 +479,11 @@ class UploadService {
         track('conversion_failed', {
           userId,
           anonymousId,
-          props: { source, reason: 'anonymous_cap' },
+          props: {
+            source,
+            reason: 'anonymous_cap',
+            signup_origin: this.resolveSignupOrigin(req),
+          },
         });
         track('paywall_shown', {
           userId,
@@ -531,6 +541,7 @@ class UploadService {
           props: {
             source: this.resolveUploadSource(req),
             reason: 'upload_incomplete',
+            signup_origin: this.resolveSignupOrigin(req),
           },
         });
         return res.status(400).json({
@@ -624,6 +635,7 @@ class UploadService {
             props: {
               source: this.resolveUploadSource(req),
               card_count_bucket: this.toCardCountBucket(totalCards),
+              signup_origin: this.resolveSignupOrigin(req),
             },
           });
         } else {
@@ -699,7 +711,11 @@ class UploadService {
       track('conversion_failed', {
         userId: owner != null ? Number(owner) : null,
         anonymousId: this.resolveAnonId(req),
-        props: { source: this.resolveUploadSource(req), reason: 'empty_deck' },
+        props: {
+          source: this.resolveUploadSource(req),
+          reason: 'empty_deck',
+          signup_origin: this.resolveSignupOrigin(req),
+        },
       });
       throw new EmptyDeckError();
     }
@@ -780,7 +796,11 @@ class UploadService {
       track('conversion_succeeded', {
         userId: owner != null ? Number(owner) : null,
         anonymousId: this.resolveAnonId(req),
-        props: { source: uploadSource, card_count_bucket: bucket },
+        props: {
+          source: uploadSource,
+          card_count_bucket: bucket,
+          signup_origin: this.resolveSignupOrigin(req),
+        },
       });
       if (owner != null) {
         await this.usersRepository.incrementCardUsage(owner, totalCards);
@@ -794,6 +814,7 @@ class UploadService {
       props: {
         source: this.resolveUploadSource(req),
         card_count_bucket: this.toCardCountBucket(totalCards),
+        signup_origin: this.resolveSignupOrigin(req),
       },
     });
     if (owner != null) {
@@ -838,6 +859,11 @@ class UploadService {
     const cookies = req.cookies as Record<string, unknown> | undefined;
     const anonId = cookies?.anon_id;
     return typeof anonId === 'string' && anonId.length > 0 ? anonId : null;
+  }
+
+  private resolveSignupOrigin(req: express.Request): string | null {
+    const cookies = req.cookies as Record<string, unknown> | undefined;
+    return parseFirstTouch(cookies?.first_touch).signupOrigin;
   }
 
   private resolvePersistedSource(req: express.Request): UploadSource | null {


### PR DESCRIPTION
## What
Stamp `signup_origin` onto the `upload_started`, `conversion_succeeded`, and `conversion_failed` funnel events at the request-scoped `track(...)` call sites in `UploadService.handleUpload` and `NotionController`.

## Why
These three events fired via the raw `src/services/events/track.ts` helper without ever reading the `first_touch` cookie, so `props.signup_origin` was null. `EventsRepository.groupUploadFunnelByOrigin` groups on `props->>'signup_origin'`, so all three top funnel stages landed under `origin: null` — uploads could not be attributed to any entry path. No user-visible behavior changes; this is ops instrumentation.

## How
At each request-scoped site, resolve the origin from `req.cookies?.first_touch` via `parseFirstTouch(...).signupOrigin` — the same pattern already used in `UsersControllers.ts:234`. In `UploadService` this is a small private `resolveSignupOrigin(req)` helper alongside the existing `resolveAnonId`/`resolveUploadSource` resolvers; edits are confined to the `track()` props objects. In `NotionController` it is inlined into the single `upload_started` props object. `req` is genuinely in scope at every touched site (confirmed all 8 UploadService funnel-event props objects + the 1 NotionController `upload_started`).

Out of scope, called out as follow-up: `src/lib/storage/jobs/helpers/performConversion.ts` emits conversion events from a **background job** with no `req`/cookies. Stamping origin there requires threading the origin through the job payload at creation time — a separate change.

## Measuring success
`GET` the upload-funnel ops endpoint backed by `groupUploadFunnelByOrigin` (`by_origin[].stages`): after deploy, the `upload_started` / `conversion_succeeded` / `conversion_failed` stages stop collapsing entirely under the `null` origin bucket and begin distributing across real entry paths (e.g. `/pricing`, `/photo-to-deck`). Query events directly: `select props->>'signup_origin', name, count(*) from events where name in ('upload_started','conversion_succeeded','conversion_failed') and created_at > <deploy> group by 1,2`.

## Testing
- Unit tests added (`UploadService.test.ts`): a `first_touch` cookie yields `signup_origin` in `upload_started` and `conversion_succeeded` props (success sync path); `conversion_failed` on the over-limit path carries `signup_origin`; no cookie yields `signup_origin: null`. Drives the real `handleUpload`, observing the analytics edge (the existing `track` mock in that file). All 46 pass; `tsc -p . --noEmit` clean.

## Browser check
Browser check: not applicable — server-side instrumentation only

## Changelog
No changelog entry — internal instrumentation, no user-visible behavior change.

## Risks
Low. Additive prop on existing events; a null/absent `first_touch` cookie resolves to `null` (the prior effective value), so nothing degrades. Sonar not run locally; Automatic Analysis covers the push.

## Goal alignment
Unblocks upload-funnel attribution by entry path (acquisition lane) — lets the funnel read which landing paths actually produce uploads/conversions instead of everything reading `null`. Metric: `by_origin[].stages` on the upload-funnel ops endpoint. Internal analytics enablement, no direct user-facing surface.
