### PR TITLE
fix: thread signup_origin through the async conversion job payload

### DIFF
--- a/src/controllers/NotionController.test.ts
+++ b/src/controllers/NotionController.test.ts
@@ -287,6 +287,29 @@ describe('NotionController', () => {
       expect(res.json).toHaveBeenCalledWith({ jobId: 77, restarted: false });
     });
 
+    it('threads signup_origin from the first_touch cookie into the runConversion payload', async () => {
+      setupConvertMocks();
+      req.cookies = {
+        first_touch: JSON.stringify({ landingPath: '/pricing' }),
+      };
+
+      await controller.convert(req as express.Request, res as express.Response);
+
+      expect(runConversion).toHaveBeenCalledWith(
+        expect.objectContaining({ signupOrigin: '/pricing' })
+      );
+    });
+
+    it('passes signupOrigin=null into the runConversion payload when no first_touch cookie is present', async () => {
+      setupConvertMocks();
+
+      await controller.convert(req as express.Request, res as express.Response);
+
+      expect(runConversion).toHaveBeenCalledWith(
+        expect.objectContaining({ signupOrigin: null })
+      );
+    });
+
     it('emits upload_started so the Notion path enters the upload→download funnel', async () => {
       setupConvertMocks();
 

--- a/src/controllers/NotionController.ts
+++ b/src/controllers/NotionController.ts
@@ -355,6 +355,7 @@ class NotionController {
         frontField: safeString(frontField),
         backField: safeString(backField),
         anonId: safeString(anonId),
+        signupOrigin: parseFirstTouch(cookies?.first_touch).signupOrigin,
       }).catch((err: unknown) => {
         console.error('notion convert worker:', err);
       });

--- a/src/lib/conversionPool.ts
+++ b/src/lib/conversionPool.ts
@@ -33,6 +33,7 @@ export interface ConversionWorkerRequest {
   frontField?: string;
   backField?: string;
   anonId?: string;
+  signupOrigin?: string | null;
 }
 
 let pool: Piscina | null = null;
@@ -226,5 +227,6 @@ export async function runConversionInWorker(
     frontField: request.frontField,
     backField: request.backField,
     anonId: request.anonId,
+    signupOrigin: request.signupOrigin,
   });
 }

--- a/src/lib/storage/jobs/helpers/performConversion.test.ts
+++ b/src/lib/storage/jobs/helpers/performConversion.test.ts
@@ -417,6 +417,113 @@ describe('performConversion — heavy pipeline', () => {
   });
 });
 
+describe('performConversion — signup_origin attribution', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    jest.spyOn(console, 'info').mockImplementation(() => undefined);
+    (SetJobFailedUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue(undefined),
+    }));
+    (NotionRepository as jest.Mock).mockImplementation(() => ({
+      markTokenInvalid: jest.fn().mockResolvedValue(undefined),
+      setReconnectEmailSent: jest.fn().mockResolvedValue(false),
+    }));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function mockSuccessfulPipeline(): void {
+    (CreateJobWorkSpaceUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue({
+        ws: {},
+        exporter: {},
+        settings: {},
+        bl: {},
+        rules: {},
+      }),
+    }));
+    (CreateFlashcardsForJobUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue([{ cards: [1, 2, 3] }]),
+    }));
+    (CheckMonthlyCardLimitUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue(undefined),
+    }));
+    (BuildDeckForJobUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest
+        .fn()
+        .mockResolvedValue({ size: 1, key: 'k', apkg: Buffer.from('') }),
+    }));
+    (NotifyUserUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue(undefined),
+    }));
+    (CompleteJobUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue(undefined),
+    }));
+  }
+
+  it('stamps signup_origin on conversion_succeeded from the job payload', async () => {
+    mockSuccessfulPipeline();
+
+    await performConversion(mockDatabase, {
+      ...baseRequest,
+      signupOrigin: '/pricing',
+    });
+
+    expect(track).toHaveBeenCalledWith(
+      'conversion_succeeded',
+      expect.objectContaining({
+        props: expect.objectContaining({ signup_origin: '/pricing' }),
+      })
+    );
+  });
+
+  it('stamps signup_origin on conversion_failed from the job payload', async () => {
+    (CreateJobWorkSpaceUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue({
+        ws: {},
+        exporter: {},
+        settings: {},
+        bl: {},
+        rules: {},
+      }),
+    }));
+    (CreateFlashcardsForJobUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue([{ cards: [] }]),
+    }));
+
+    await performConversion(mockDatabase, {
+      ...baseRequest,
+      signupOrigin: '/photo-to-deck',
+    });
+
+    expect(track).toHaveBeenCalledWith(
+      'conversion_failed',
+      expect.objectContaining({
+        props: expect.objectContaining({
+          reason: 'empty_deck',
+          signup_origin: '/photo-to-deck',
+        }),
+      })
+    );
+  });
+
+  it('emits signup_origin=null when the job payload carries no origin', async () => {
+    mockSuccessfulPipeline();
+
+    await performConversion(mockDatabase, baseRequest);
+
+    expect(track).toHaveBeenCalledWith(
+      'conversion_succeeded',
+      expect.objectContaining({
+        props: expect.objectContaining({ signup_origin: null }),
+      })
+    );
+  });
+});
+
 describe('performConversion — workspace cleanup', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/src/lib/storage/jobs/helpers/performConversion.ts
+++ b/src/lib/storage/jobs/helpers/performConversion.ts
@@ -59,6 +59,7 @@ interface ConversionRequest {
   frontField?: string;
   backField?: string;
   anonId?: string;
+  signupOrigin?: string | null;
 }
 
 function toAnonymousId(anonId?: string): string | null {
@@ -111,12 +112,17 @@ function trackConversionFailed(
   owner: string,
   anonId: string | undefined,
   type: string | undefined,
+  signupOrigin: string | null,
   reasonProps: Record<string, unknown>
 ): void {
   track('conversion_failed', {
     userId: Number.isFinite(Number(owner)) ? Number(owner) : null,
     anonymousId: toAnonymousId(anonId),
-    props: { source: toConversionSource(type), ...reasonProps },
+    props: {
+      source: toConversionSource(type),
+      signup_origin: signupOrigin,
+      ...reasonProps,
+    },
   });
 }
 
@@ -133,9 +139,11 @@ export default async function performConversion(
     frontField,
     backField,
     anonId,
+    signupOrigin,
   }: ConversionRequest
 ) {
   console.info(`Performing conversion for ${id}`);
+  const resolvedSignupOrigin = signupOrigin ?? null;
 
   const storage = new StorageHandler();
   const jobRepository = new JobRepository(database);
@@ -177,7 +185,7 @@ export default async function performConversion(
           '.' +
           String(jobDbId)
       );
-      trackConversionFailed(owner, anonId, type, {
+      trackConversionFailed(owner, anonId, type, resolvedSignupOrigin, {
         reason: 'no_decks_created',
       });
       return;
@@ -187,7 +195,9 @@ export default async function performConversion(
     if (cardCount === 0) {
       const setJobFailed = new SetJobFailedUseCase(jobRepository);
       await setJobFailed.execute(id, owner, EMPTY_DECK_FAILURE_REASON);
-      trackConversionFailed(owner, anonId, type, { reason: 'empty_deck' });
+      trackConversionFailed(owner, anonId, type, resolvedSignupOrigin, {
+        reason: 'empty_deck',
+      });
       return;
     }
 
@@ -208,7 +218,7 @@ export default async function performConversion(
           reset_on: error.reset_on,
         });
         await setJobFailed.execute(id, owner, payload);
-        trackConversionFailed(owner, anonId, type, {
+        trackConversionFailed(owner, anonId, type, resolvedSignupOrigin, {
           reason: 'monthly_limit',
           cards_used: error.cards_used,
           limit: error.limit,
@@ -271,6 +281,7 @@ export default async function performConversion(
       props: {
         source: toConversionSource(type),
         card_count_bucket: toCardCountBucket(cardCount),
+        signup_origin: resolvedSignupOrigin,
       },
     });
   } catch (error) {
@@ -295,7 +306,7 @@ export default async function performConversion(
     }
     const failedJob = new SetJobFailedUseCase(jobRepository);
     await failedJob.execute(id, owner, jobFailureReasonFromError(error, id));
-    trackConversionFailed(owner, anonId, type, {
+    trackConversionFailed(owner, anonId, type, resolvedSignupOrigin, {
       reason: jobFailureReasonCode(error),
     });
     const isExpectedUserState =


### PR DESCRIPTION
## What
Threads the first-touch `signup_origin` through the async conversion job payload so the background conversion worker stamps it on `conversion_succeeded` / `conversion_failed` funnel events.

## Why
Closes #3761. PR #3756 stamped `signup_origin` on the funnel events at the **request-scoped** call sites (`UploadService`, `NotionController`). The async Notion conversion path — `src/lib/storage/jobs/helpers/performConversion.ts` — runs in a Piscina worker with no `req`/cookies, so its `conversion_succeeded` / `conversion_failed` events still landed under `origin: null`. Per-origin attribution for async Notion conversions was still partial. This was called out as explicit out-of-scope follow-up in #3756.

## How
The origin is resolved where `req` is genuinely in scope — at enqueue time in `NotionController.convert`, via the same `parseFirstTouch(req.cookies?.first_touch).signupOrigin` pattern #3756 used. It is added as a new optional `signupOrigin` field on `ConversionWorkerRequest` (conversionPool), forwarded through `runConversionInWorker` into `ConversionRequest` (performConversion), and read there when emitting the two track events. No cookie is resolved inside the worker — there is none.

The `signupOrigin` field is **optional and null-safe**: a job enqueued before this change (or any path that doesn't set it) resolves to `signup_origin: null`, the prior effective value, so nothing degrades and in-flight jobs keep working.

`UploadService` was NOT touched. Its async path (`handleAsyncUpload`) uses `GeneratePackagesUseCase`, not `performConversion`, and #3756 already stamped `signup_origin` on that path — so there is no overlap with #3762 (`chore/post-merge-nits`, which dedupes an `emptyBackCount` sum in UploadService). No collision.

## Measuring success
Query events after deploy: `select props->>'signup_origin', name, count(*) from events where name in ('conversion_succeeded','conversion_failed') and created_at > <deploy> group by 1,2`. Async Notion conversions (`props->>'source' = 'notion'`) begin distributing across real entry paths instead of collapsing entirely under the `null` origin bucket. Same `by_origin[].stages` reading on the upload-funnel ops endpoint used to verify #3756.

## Testing
- Unit tests added:
  - `performConversion.test.ts`: a job payload with `signupOrigin` stamps `signup_origin` on `conversion_succeeded` and on `conversion_failed`; a payload with no origin emits `signup_origin: null`.
  - `NotionController.test.ts`: a `first_touch` cookie threads `signupOrigin` into the `runConversion` payload; no cookie yields `signupOrigin: null`.
- `tsc -p . --noEmit` clean (the deploy build typechecks tests; the new optional field does not break any mock typed as the payload interface).
- Sonar not run locally; Automatic Analysis covers the push.

## Browser check
Browser check: not applicable — server-side instrumentation only

## Changelog
No changelog entry — internal instrumentation, no user-visible change.

## Risks
Low. Additive optional field on an existing job payload; unset resolves to `null` (the prior effective value). No schema change, no migration.

## Goal alignment
Completes upload-funnel attribution by entry path for the async Notion/batch conversion path (acquisition lane) — the funnel can now read which landing paths produce async conversions instead of reading `null`. Metric: `by_origin[].stages` on the upload-funnel ops endpoint. Internal analytics enablement, no direct user-facing surface.
