### PR TITLE
feat: split upload-funnel conversion_failed by reason (paywall/empty/technical)

### DIFF
--- a/src/controllers/EventsController.test.ts
+++ b/src/controllers/EventsController.test.ts
@@ -17,6 +17,11 @@ function makeFakeRepository(): IEventsRepository {
     groupPaywallClicksByVariant: jest.fn(async () => []),
     groupUploadFunnel: jest.fn(async () => []),
     groupUploadFunnelByOrigin: jest.fn(async () => []),
+    groupConversionFailedByReason: jest.fn(async () => ({
+      paywall: 0,
+      empty: 0,
+      technical: 0,
+    })),
   };
 }
 

--- a/src/data_layer/EventsRepository.test.ts
+++ b/src/data_layer/EventsRepository.test.ts
@@ -1,5 +1,9 @@
 import knexLib, { Knex } from 'knex';
-import { EventsRepository, EventRow } from './EventsRepository';
+import {
+  EventsRepository,
+  EventRow,
+  buildConversionFailedByReasonQuery,
+} from './EventsRepository';
 
 interface FakeStore {
   rows: Record<string, unknown>[];
@@ -80,6 +84,17 @@ function makeFakeKnex() {
 
   const fn = (() => tableHandler()) as never;
   return { db: fn, store };
+}
+
+function makeFakeKnexReturning(row: Record<string, unknown>): { db: Knex } {
+  const builder: Record<string, unknown> = {};
+  const chain = () => builder;
+  builder.where = chain;
+  builder.select = chain;
+  builder.first = () => Promise.resolve(row);
+  const db = (() => builder) as unknown as Knex;
+  (db as unknown as { raw: (s: string) => string }).raw = (s: string) => s;
+  return { db };
 }
 
 const baseEvent: EventRow = {
@@ -234,6 +249,40 @@ describe('EventsRepository SQL generation', () => {
     );
     expect(sql).toContain("group by props->>'signup_origin', name");
     expect(sql).not.toContain('anonymous_id) as distinct_identities)');
+  });
+
+  it('groupConversionFailedByReason buckets reasons with valid PG LIKE classification', () => {
+    const pg = knexLib({ client: 'pg' });
+    const sql = buildConversionFailedByReasonQuery(
+      pg,
+      new Date('2026-05-01')
+    ).toString();
+
+    expect(sql).toContain('"name" = \'conversion_failed\'');
+    expect(sql).toContain(
+      "count(distinct case when (props->>'reason' LIKE 'monthly_limit' OR props->>'reason' LIKE 'anonymous_cap' OR props->>'reason' LIKE '%\"code\":\"monthly_limit\"%') then COALESCE(user_id::text, anonymous_id) end) as paywall"
+    );
+    expect(sql).toContain(
+      "count(distinct case when (props->>'reason' LIKE 'empty_deck' OR props->>'reason' LIKE 'no_decks_created' OR props->>'reason' LIKE 'No cards in this deck yet.%') then COALESCE(user_id::text, anonymous_id) end) as empty"
+    );
+    expect(sql).toContain(
+      "count(distinct case when (props->>'reason' IS NULL OR (NOT (props->>'reason' LIKE 'monthly_limit' OR props->>'reason' LIKE 'anonymous_cap' OR props->>'reason' LIKE '%\"code\":\"monthly_limit\"%') AND NOT (props->>'reason' LIKE 'empty_deck' OR props->>'reason' LIKE 'no_decks_created' OR props->>'reason' LIKE 'No cards in this deck yet.%'))) then COALESCE(user_id::text, anonymous_id) end) as technical"
+    );
+  });
+
+  it('groupConversionFailedByReason resolves counts through the repository', async () => {
+    const { db } = makeFakeKnexReturning({
+      paywall: '25',
+      empty: '12',
+      technical: '5',
+    });
+    const repo = new EventsRepository(db);
+
+    const result = await repo.groupConversionFailedByReason(
+      new Date('2026-05-01')
+    );
+
+    expect(result).toEqual({ paywall: 25, empty: 12, technical: 5 });
   });
 
   it('lastEventAt selects the max created_at filtered by name', async () => {

--- a/src/data_layer/EventsRepository.ts
+++ b/src/data_layer/EventsRepository.ts
@@ -1,5 +1,11 @@
 import type { Knex } from 'knex';
 
+import {
+  EMPTY_REASON_PATTERNS,
+  PAYWALL_REASON_PATTERNS,
+  REASON_PROP_EXPRESSION,
+} from './classifyFailureReason';
+
 export interface EventRow {
   name: string;
   user_id?: number | null;
@@ -34,6 +40,12 @@ export interface UploadFunnelStageByOriginRow {
   distinct_identities: number;
 }
 
+export interface ConversionFailedByReasonRow {
+  paywall: number;
+  empty: number;
+  technical: number;
+}
+
 const UPLOAD_FUNNEL_STAGES = [
   'upload_started',
   'conversion_succeeded',
@@ -65,6 +77,9 @@ export interface IEventsRepository {
   groupUploadFunnelByOrigin(
     since: Date
   ): Promise<UploadFunnelStageByOriginRow[]>;
+  groupConversionFailedByReason(
+    since: Date
+  ): Promise<ConversionFailedByReasonRow>;
 }
 
 export class EventsRepository implements IEventsRepository {
@@ -217,6 +232,62 @@ export class EventsRepository implements IEventsRepository {
       distinct_identities: Number(r.distinct_identities),
     }));
   }
+
+  async groupConversionFailedByReason(
+    since: Date
+  ): Promise<ConversionFailedByReasonRow> {
+    const row = (await buildConversionFailedByReasonQuery(
+      this.database,
+      since
+    ).first()) as
+      | {
+          paywall: string | number | null;
+          empty: string | number | null;
+          technical: string | number | null;
+        }
+      | undefined;
+
+    return {
+      paywall: Number(row?.paywall ?? 0),
+      empty: Number(row?.empty ?? 0),
+      technical: Number(row?.technical ?? 0),
+    };
+  }
+}
+
+function likeAnyCondition(patterns: string[]): string {
+  return `(${patterns
+    .map(() => `${REASON_PROP_EXPRESSION} LIKE ?`)
+    .join(' OR ')})`;
+}
+
+function distinctIdentityWhen(condition: string): string {
+  return `count(distinct case when ${condition} then COALESCE(user_id::text, anonymous_id) end)`;
+}
+
+export function buildConversionFailedByReasonQuery(
+  database: Knex,
+  since: Date
+): Knex.QueryBuilder {
+  const paywall = likeAnyCondition(PAYWALL_REASON_PATTERNS);
+  const empty = likeAnyCondition(EMPTY_REASON_PATTERNS);
+  const technical = `(${REASON_PROP_EXPRESSION} IS NULL OR (NOT ${paywall} AND NOT ${empty}))`;
+
+  return database('events')
+    .where('name', 'conversion_failed')
+    .where('created_at', '>=', since)
+    .select(
+      database.raw(`${distinctIdentityWhen(paywall)} as paywall`, [
+        ...PAYWALL_REASON_PATTERNS,
+      ]),
+      database.raw(`${distinctIdentityWhen(empty)} as empty`, [
+        ...EMPTY_REASON_PATTERNS,
+      ]),
+      database.raw(`${distinctIdentityWhen(technical)} as technical`, [
+        ...PAYWALL_REASON_PATTERNS,
+        ...EMPTY_REASON_PATTERNS,
+      ])
+    );
 }
 
 export function buildUploadFunnelByOriginQuery(

--- a/src/data_layer/classifyFailureReason.test.ts
+++ b/src/data_layer/classifyFailureReason.test.ts
@@ -1,0 +1,26 @@
+import { classifyFailureReason } from './classifyFailureReason';
+
+describe('classifyFailureReason', () => {
+  it.each([
+    ['monthly_limit', 'paywall'],
+    ['anonymous_cap', 'paywall'],
+    ['{"code":"monthly_limit","cards_used":120,"limit":100}', 'paywall'],
+    ['empty_deck', 'empty'],
+    ['no_decks_created', 'empty'],
+    ['No cards in this deck yet. Wrap your terms in toggles.', 'empty'],
+    ['python_crash', 'technical'],
+    ['pdf_password', 'technical'],
+    ['upload_incomplete', 'technical'],
+    ['some unmapped error string from the engine', 'technical'],
+  ])('classifies %s as %s', (reason, bucket) => {
+    expect(classifyFailureReason(reason)).toBe(bucket);
+  });
+
+  it('treats a null reason as technical', () => {
+    expect(classifyFailureReason(null)).toBe('technical');
+  });
+
+  it('treats an undefined reason as technical', () => {
+    expect(classifyFailureReason(undefined)).toBe('technical');
+  });
+});

--- a/src/data_layer/classifyFailureReason.ts
+++ b/src/data_layer/classifyFailureReason.ts
@@ -1,0 +1,34 @@
+export type FailureReasonBucket = 'paywall' | 'empty' | 'technical';
+
+export const REASON_PROP_EXPRESSION = "props->>'reason'";
+
+export const PAYWALL_REASON_PATTERNS = [
+  'monthly_limit',
+  'anonymous_cap',
+  '%"code":"monthly_limit"%',
+];
+
+export const EMPTY_REASON_PATTERNS = [
+  'empty_deck',
+  'no_decks_created',
+  'No cards in this deck yet.%',
+];
+
+function likeToRegExp(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const body = escaped.replace(/%/g, '.*').replace(/_/g, '.');
+  return new RegExp(`^${body}$`, 's');
+}
+
+function matchesAny(reason: string, patterns: string[]): boolean {
+  return patterns.some((pattern) => likeToRegExp(pattern).test(reason));
+}
+
+export function classifyFailureReason(
+  reason: string | null | undefined
+): FailureReasonBucket {
+  if (reason == null) return 'technical';
+  if (matchesAny(reason, PAYWALL_REASON_PATTERNS)) return 'paywall';
+  if (matchesAny(reason, EMPTY_REASON_PATTERNS)) return 'empty';
+  return 'technical';
+}

--- a/src/routes/OpsRouter.test.ts
+++ b/src/routes/OpsRouter.test.ts
@@ -232,6 +232,9 @@ jest.mock('../data_layer/EventsRepository', () => {
       groupPaywallClicksByVariant() {
         return Promise.resolve([]);
       }
+      groupConversionFailedByReason() {
+        return Promise.resolve({ paywall: 8, empty: 5, technical: 7 });
+      }
     },
   };
 });
@@ -406,6 +409,11 @@ describe('OpsRouter /api/ops/upload-funnel', () => {
             deck_downloaded: 60,
           }),
           upload_to_download_rate_pct: 60,
+          conversion_failed_by_reason: {
+            paywall: 8,
+            empty: 5,
+            technical: 7,
+          },
           by_origin: [
             expect.objectContaining({
               origin: '/nclex',

--- a/src/services/events/EventsSink.test.ts
+++ b/src/services/events/EventsSink.test.ts
@@ -15,6 +15,11 @@ function makeFakeRepository() {
     groupPaywallClicksByVariant: jest.fn(async () => []),
     groupUploadFunnel: jest.fn(async () => []),
     groupUploadFunnelByOrigin: jest.fn(async () => []),
+    groupConversionFailedByReason: jest.fn(async () => ({
+      paywall: 0,
+      empty: 0,
+      technical: 0,
+    })),
   };
   return { repo, inserted };
 }
@@ -91,6 +96,11 @@ describe('EventsSink', () => {
       groupPaywallClicksByVariant: jest.fn(async () => []),
       groupUploadFunnel: jest.fn(async () => []),
       groupUploadFunnelByOrigin: jest.fn(async () => []),
+      groupConversionFailedByReason: jest.fn(async () => ({
+        paywall: 0,
+        empty: 0,
+        technical: 0,
+      })),
     };
     const sink = new EventsSink(repo, { flushThreshold: 1 });
     sink.record(baseRow);

--- a/src/services/ops/UploadFunnelService.test.ts
+++ b/src/services/ops/UploadFunnelService.test.ts
@@ -3,11 +3,19 @@ import type {
   IEventsRepository,
   UploadFunnelStageRow,
   UploadFunnelStageByOriginRow,
+  ConversionFailedByReasonRow,
 } from '../../data_layer/EventsRepository';
+
+const NO_FAILURES: ConversionFailedByReasonRow = {
+  paywall: 0,
+  empty: 0,
+  technical: 0,
+};
 
 function makeRepo(
   rows: UploadFunnelStageRow[],
-  originRows: UploadFunnelStageByOriginRow[] = []
+  originRows: UploadFunnelStageByOriginRow[] = [],
+  failedByReason: ConversionFailedByReasonRow = NO_FAILURES
 ): IEventsRepository {
   return {
     insertEvents: jest.fn(),
@@ -19,6 +27,7 @@ function makeRepo(
     groupPaywallClicksByVariant: jest.fn(),
     groupUploadFunnel: jest.fn().mockResolvedValue(rows),
     groupUploadFunnelByOrigin: jest.fn().mockResolvedValue(originRows),
+    groupConversionFailedByReason: jest.fn().mockResolvedValue(failedByReason),
   };
 }
 
@@ -186,6 +195,40 @@ describe('UploadFunnelService', () => {
     const result = await service.getMetrics(since);
 
     expect(result.by_origin).toEqual([]);
+  });
+
+  it('splits conversion_failed into paywall, empty, and technical buckets', async () => {
+    const repo = makeRepo(
+      [{ stage: 'conversion_failed', distinct_identities: 42 }],
+      [],
+      { paywall: 25, empty: 12, technical: 5 }
+    );
+    const service = new UploadFunnelService({ eventsRepo: repo });
+
+    const result = await service.getMetrics(since);
+
+    expect(result.conversion_failed_by_reason).toEqual({
+      paywall: 25,
+      empty: 12,
+      technical: 5,
+    });
+  });
+
+  it('reports zeroed reason buckets on a repository error', async () => {
+    const repo = makeRepo([]);
+    (repo.groupConversionFailedByReason as jest.Mock).mockRejectedValueOnce(
+      new Error('db down')
+    );
+    const service = new UploadFunnelService({ eventsRepo: repo });
+
+    const result = await service.getMetrics(since);
+
+    expect(result.conversion_failed_by_reason).toEqual({
+      paywall: 0,
+      empty: 0,
+      technical: 0,
+    });
+    expect(result.error).toBe('db down');
   });
 
   it('surfaces a repository error without throwing', async () => {

--- a/src/services/ops/UploadFunnelService.ts
+++ b/src/services/ops/UploadFunnelService.ts
@@ -2,6 +2,7 @@ import type {
   IEventsRepository,
   UploadFunnelStageRow,
   UploadFunnelStageByOriginRow,
+  ConversionFailedByReasonRow,
 } from '../../data_layer/EventsRepository';
 
 export interface UploadFunnelStages {
@@ -25,9 +26,16 @@ export interface UploadFunnelOriginBreakdown extends UploadFunnelRates {
   stages: UploadFunnelStages;
 }
 
+export interface ConversionFailedByReason {
+  paywall: number;
+  empty: number;
+  technical: number;
+}
+
 export interface UploadFunnelResponse extends UploadFunnelRates {
   stages: UploadFunnelStages | null;
   by_origin: UploadFunnelOriginBreakdown[];
+  conversion_failed_by_reason: ConversionFailedByReason;
   since: string;
   as_of: string;
   error?: string;
@@ -50,15 +58,18 @@ export class UploadFunnelService {
 
     let rows: UploadFunnelStageRow[];
     let originRows: UploadFunnelStageByOriginRow[];
+    let failedByReason: ConversionFailedByReasonRow;
     try {
-      [rows, originRows] = await Promise.all([
+      [rows, originRows, failedByReason] = await Promise.all([
         this.eventsRepo.groupUploadFunnel(since),
         this.eventsRepo.groupUploadFunnelByOrigin(since),
+        this.eventsRepo.groupConversionFailedByReason(since),
       ]);
     } catch (err) {
       return {
         stages: null,
         by_origin: [],
+        conversion_failed_by_reason: { paywall: 0, empty: 0, technical: 0 },
         upload_to_download_rate_pct: 0,
         download_to_signup_rate_pct: 0,
         download_to_paid_rate_pct: 0,
@@ -73,6 +84,11 @@ export class UploadFunnelService {
     return {
       stages,
       by_origin: this.toOriginBreakdowns(originRows),
+      conversion_failed_by_reason: {
+        paywall: failedByReason.paywall,
+        empty: failedByReason.empty,
+        technical: failedByReason.technical,
+      },
       ...computeRates(stages),
       since: sinceStr,
       as_of,

--- a/src/usecases/events/TrackEventUseCase.test.ts
+++ b/src/usecases/events/TrackEventUseCase.test.ts
@@ -16,6 +16,11 @@ function makeFakeRepository() {
     groupPaywallClicksByVariant: jest.fn(async () => []),
     groupUploadFunnel: jest.fn(async () => []),
     groupUploadFunnelByOrigin: jest.fn(async () => []),
+    groupConversionFailedByReason: jest.fn(async () => ({
+      paywall: 0,
+      empty: 0,
+      technical: 0,
+    })),
   };
   return { repo, inserted };
 }

--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
@@ -66,6 +66,9 @@ function makeEventsStub(usedThisMonth = 0): IEventsRepository {
     groupPaywallClicksByVariant: jest.fn().mockResolvedValue([]),
     groupUploadFunnel: jest.fn().mockResolvedValue([]),
     groupUploadFunnelByOrigin: jest.fn().mockResolvedValue([]),
+    groupConversionFailedByReason: jest
+      .fn()
+      .mockResolvedValue({ paywall: 0, empty: 0, technical: 0 }),
   };
 }
 


### PR DESCRIPTION
## What
Adds a `conversion_failed_by_reason: { paywall, empty, technical }` field to the `/api/ops/upload-funnel` response. Existing response fields are unchanged — this is purely additive.

## Why
Closes #3760. The upload-funnel `conversion_failed` count (~2129 over 30d in the 2026-07-19 review) collapses three very different outcomes under one event name with no reason dimension at this layer:
- paywall hits (`monthly_limit` / `anonymous_cap`) — the paywall working
- empty-content outcomes (`empty_deck` / `no_decks_created`) — user content shape
- genuine technical/engine failures — the only bucket that is an actual leak

Only the last is a real leak, so any product fix prioritized against the raw aggregate mostly chases paywall-and-empty noise. Splitting the count makes the technical bucket the number to prioritize against.

## How
- `classifyFailureReason.ts` — pure classifier plus the `PAYWALL_REASON_PATTERNS` / `EMPTY_REASON_PATTERNS` LIKE-pattern lists, the single source of truth. Technical = a reason that is NULL or matches neither pattern set, mirroring `JobsMetricsRepository.computeSuccessRate7d`'s exclusion of the plan-limit and empty-deck patterns.
- `EventsRepository.groupConversionFailedByReason` — a grouped-by-reason query building `count(distinct COALESCE(user_id::text, anonymous_id))` per bucket via `case when <LIKE conditions>`, distinct-identity semantics matching the rest of the funnel. Extracted as `buildConversionFailedByReasonQuery` so the generated SQL is testable.
- `UploadFunnelService` gains `conversion_failed_by_reason` on the response; `GetUploadFunnelUseCase` and the controller pass it through unchanged.

The events `props->>'reason'` is a plain code string (`monthly_limit`, `empty_deck`, `python_crash`, …); the classifier's LIKE patterns also cover the JSON-blob (`%"code":"monthly_limit"%`) and prose (`No cards in this deck yet.%`) shapes so it stays aligned with the jobs-table classification it mirrors.

## Measuring success
`GET /api/ops/upload-funnel` now returns `conversion_failed_by_reason.technical` — the real leak signal — alongside `.paywall` and `.empty`. Compare `.technical` against the raw `stages.conversion_failed` to confirm the split lands (technical should be a fraction of the total).

## Testing
- `classifyFailureReason.test.ts` — `monthly_limit` to paywall, `{"code":"monthly_limit",…}` to paywall, `No cards in this deck yet.…` to empty, `no_decks_created` to empty, `python_crash`/arbitrary string/null to technical.
- `EventsRepository.test.ts` — asserts on the **generated PG SQL** (`knex({client:'pg'}).toString()`) for `buildConversionFailedByReasonQuery`: valid `count(distinct case when … LIKE … end) as paywall/empty/technical` with the correct patterns, plus a repo-level test resolving the counts.
- `UploadFunnelService.test.ts` — the three buckets flow through to the response, and the error branch returns zeroed buckets.
- Updated the four other `IEventsRepository` mock literals so the deploy `tsc -p .` (which typechecks tests) stays green.
- `npx tsc -p . --noEmit` clean; touched suites green (229 tests). Sonar not run locally; Automatic Analysis covers the push.

Browser check: not applicable — server-side ops metric only

## Changelog
no changelog entry — internal ops funnel metric, no user-visible change

## Risks
Additive field only; existing consumers unaffected. Distinct-identity buckets may overlap slightly (a user with both a paywall and a technical failure counts in both), so buckets are not guaranteed to sum to `stages.conversion_failed` — intentional, matching the funnel's distinct-identity semantics.

## Goal alignment
None on the user funnel directly — internal ops instrumentation. It sharpens the leak signal ops reads at `/api/ops/upload-funnel`, so conversion-fix prioritization targets real technical failures instead of paywall/empty noise, which indirectly protects upload to download.
