### PR TITLE
fix: strip empty toggle-summary tag from generated card HTML

### DIFF
--- a/src/lib/parser/DeckParser.emptyToggleSummary.test.ts
+++ b/src/lib/parser/DeckParser.emptyToggleSummary.test.ts
@@ -1,0 +1,46 @@
+import { setupTests } from '../../test/configure-jest';
+import CardOption from './Settings/CardOption';
+import { DeckParser } from './DeckParser';
+import Workspace from './WorkSpace';
+
+beforeEach(() => setupTests());
+
+const wrap = (body: string) =>
+  `<html><head><title>Toggles</title></head><body><article class="page sans"><header><h1 class="page-title">Toggles</h1></header><div class="page-body">${body}</div></article></body></html>`;
+
+async function cardsFor(html: string, options: Record<string, string>) {
+  const workspace = new Workspace(true, 'fs');
+  const parser = new DeckParser({
+    name: 'toggle.html',
+    settings: new CardOption(options),
+    files: [{ name: 'toggle.html', contents: html }],
+    noLimits: true,
+    workspace,
+  });
+  try {
+    await parser.build(workspace);
+  } catch {
+    // Full .apkg packaging needs the Python venv (main checkout only); the
+    // parsed cards are populated on parser.payload before packaging runs.
+  }
+  return parser.payload.flatMap((d) => d.cards);
+}
+
+describe('empty toggle-summary cleanup', () => {
+  const html = wrap(
+    `<details class="toggle" open=""><summary>What is the capital of Albania?</summary><div class="indented"><p>Tirana!</p></div></details>`
+  );
+
+  it('strips the empty summary from the back at default settings', async () => {
+    const cards = await cardsFor(html, { cherry: 'false' });
+    expect(cards).toHaveLength(1);
+    expect(cards[0].back).not.toContain('<summary class="toggle"></summary>');
+  });
+
+  it('keeps the real answer content while stripping the empty summary', async () => {
+    const cards = await cardsFor(html, { cherry: 'false' });
+    expect(cards).toHaveLength(1);
+    expect(cards[0].back).toContain('Tirana!');
+    expect(cards[0].name).toContain('What is the capital of Albania?');
+  });
+});

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -1448,6 +1448,10 @@ export class DeckParser {
                     ? this.removeNestedTogglesNewFormat(b)
                     : this.removeNestedTogglesLegacy(b);
                 }
+                mangleBackSide = mangleBackSide.replaceAll(
+                  '<summary class="toggle"></summary>',
+                  ''
+                );
                 if (this.settings.perserveNewLines) {
                   mangleBackSide = replaceAll(mangleBackSide, '\n', '<br />');
                 }

--- a/src/lib/parser/golden/__snapshots__/conversionGolden.test.ts.snap
+++ b/src/lib/parser/golden/__snapshots__/conversionGolden.test.ts.snap
@@ -64,7 +64,7 @@ exports[`produces a stable deck for Notion cloze export 1`] = `
     "cards": [
       {
         "back": "
-						<summary class="toggle"></summary>
+						
 					",
         "front": "<div class='toggle'>1️⃣{{c1::Canberra}} was founded in 1️⃣{{c2::1913}}.
 						</div>",
@@ -74,7 +74,7 @@ exports[`produces a stable deck for Notion cloze export 1`] = `
       },
       {
         "back": "
-						<summary class="toggle"></summary>
+						
 					",
         "front": "<div class='toggle'>The {{c1::second}} number is 2️⃣</div>",
         "media": [],
@@ -83,7 +83,7 @@ exports[`produces a stable deck for Notion cloze export 1`] = `
       },
       {
         "back": "
-						<summary class="toggle"></summary>
+						
 					",
         "front": "<div class='toggle'>The {{c1::third}} number is 3️⃣</div>",
         "media": [],
@@ -92,7 +92,7 @@ exports[`produces a stable deck for Notion cloze export 1`] = `
       },
       {
         "back": "
-						<summary class="toggle"></summary>
+						
 					",
         "front": "<div class='toggle'>The {{c1::fourth}} number is 4️⃣</div>",
         "media": [],
@@ -101,7 +101,7 @@ exports[`produces a stable deck for Notion cloze export 1`] = `
       },
       {
         "back": "
-						<summary class="toggle"></summary>
+						
 					",
         "front": "<div class='toggle'>The {{c1::fifth}} number is 5️⃣</div>",
         "media": [],
@@ -110,7 +110,7 @@ exports[`produces a stable deck for Notion cloze export 1`] = `
       },
       {
         "back": "
-						<summary class="toggle"></summary>
+						
 					",
         "front": "<div class='toggle'>The {{c1::sixth}} number is 6️⃣</div>",
         "media": [],
@@ -119,7 +119,7 @@ exports[`produces a stable deck for Notion cloze export 1`] = `
       },
       {
         "back": "
-						<summary class="toggle"></summary>
+						
 					",
         "front": "<div class='toggle'>The {{c1::seventh}} number is 7️⃣</div>",
         "media": [],
@@ -128,7 +128,7 @@ exports[`produces a stable deck for Notion cloze export 1`] = `
       },
       {
         "back": "
-						<summary class="toggle"></summary>
+						
 					",
         "front": "<div class='toggle'>The {{c1::eight}} number is 8️⃣</div>",
         "media": [],
@@ -137,7 +137,7 @@ exports[`produces a stable deck for Notion cloze export 1`] = `
       },
       {
         "back": "
-						<summary class="toggle"></summary>
+						
 					",
         "front": "<div class='toggle'>The {{c1::nineth}} number is 9️⃣</div>",
         "media": [],
@@ -146,7 +146,7 @@ exports[`produces a stable deck for Notion cloze export 1`] = `
       },
       {
         "back": "
-						<summary class="toggle"></summary>
+						
 					",
         "front": "<div class='toggle'>The {{c1::tenth}} number is 🔟</div>",
         "media": [],
@@ -168,7 +168,7 @@ exports[`produces a stable deck for Notion nested toggles 1`] = `
     "cards": [
       {
         "back": "
-						<summary class="toggle"></summary>
+						
 						<ul id="0c61603c-a49f-49fd-87c2-4230f074c27d" class="toggle">
 							<li>
 								<details class="toggle">
@@ -240,8 +240,7 @@ exports[`produces a stable deck for Notion page with a remote image 1`] = `
     "cardCount": 1,
     "cards": [
       {
-        "back": "<html><head></head><body><summary class="toggle"></summary>
-<figure class="image"><img src="c97cfbb92381fe7b4b44188669ef61fd7beff685e1c85810e13e53a21fb0fe3f8ed74901c1db96f90834fbe964e9823f8798.png"></figure>
+        "back": "<html><head></head><body><figure class="image"><img src="c97cfbb92381fe7b4b44188669ef61fd7beff685e1c85810e13e53a21fb0fe3f8ed74901c1db96f90834fbe964e9823f8798.png"></figure>
 <p>The mitochondrion.</p></body></html>",
         "front": "<div class='toggle'>What does the diagram show?</div>",
         "media": [
@@ -264,14 +263,14 @@ exports[`produces a stable deck for Notion page with an image 1`] = `
     "cardCount": 3,
     "cards": [
       {
-        "back": "<summary class="toggle"></summary><p id="2429bda0-3b9f-47af-b7d0-c9f2edfab3f3" class=""><strong>This is the back. In bold font.</strong></p>",
+        "back": "<p id="2429bda0-3b9f-47af-b7d0-c9f2edfab3f3" class=""><strong>This is the back. In bold font.</strong></p>",
         "front": "<div class='toggle'><strong>Front</strong></div>",
         "media": [],
         "tags": [],
         "type": "cloze",
       },
       {
-        "back": "<summary class="toggle"></summary><p id="410dc1a5-1b5d-487b-ae39-ef9f5deea236" class=""></p>",
+        "back": "<p id="410dc1a5-1b5d-487b-ae39-ef9f5deea236" class=""></p>",
         "front": "<div class='toggle'><em>Back </em><a href="https://google.com"><strong><em>https://google.com</em></strong></a></div>",
         "media": [],
         "tags": [
@@ -280,7 +279,7 @@ exports[`produces a stable deck for Notion page with an image 1`] = `
         "type": "cloze",
       },
       {
-        "back": "<html><head></head><body><summary class="toggle"></summary><figure id="202b0d67-c058-4bc6-b1ce-9e35b753128b" class="image"><a href="HTML%20test%20202b0d67c0584bc6b1ce9e35b753128b/Skjermbilde_2020-05-13_kl._19.45.08.png"><img style="width:532px" src="Skjermbilde_2020-05-13_kl._19.45.08.png"></a></figure></body></html>",
+        "back": "<html><head></head><body><figure id="202b0d67-c058-4bc6-b1ce-9e35b753128b" class="image"><a href="HTML%20test%20202b0d67c0584bc6b1ce9e35b753128b/Skjermbilde_2020-05-13_kl._19.45.08.png"><img style="width:532px" src="Skjermbilde_2020-05-13_kl._19.45.08.png"></a></figure></body></html>",
         "front": "<div class='toggle'>With an image</div>",
         "media": [],
         "tags": [],


### PR DESCRIPTION
## What
Notion toggle conversion left a stray empty `<summary class="toggle"></summary>` at the start of the generated card back at default settings. The answer is built by removing the summary's inner text from the toggle HTML, which leaves the empty `<summary>` tag behind. This strips it.

## Why
Issue 4 from MCP user feedback (scoped down): inspecting/restyling generated notes surfaced an empty `<summary class="toggle"></summary>` in the card back HTML — pure noise. The existing empty-element cleanup (`cleanupEmptyElements`, `removeNestedTogglesLegacy`) already does this exact substitution, but only ran when `max-one-toggle-per-card` was enabled; at default settings the tag survived into card output.

## How
Extend the existing substitution — the same `replaceAll('<summary class="toggle"></summary>', '')` already used in `cleanupEmptyElements`/`removeNestedTogglesLegacy` — to run unconditionally in the `backSide` builder at the emission site (`DeckParser.ts` ~line 1451), right after the maxOne cleanup branch. No new regex; reuses the existing canonical substitution string. Idempotent when maxOne is on (already stripped there).

An empty `<summary class="toggle"></summary>` carries no content and no styling of its own, so stripping it is safe and invisible in normal Anki rendering.

## Scope note (deliberately NOT touched)
The `front-text-pre`, `front-text-post`, and `back-text` spans in card HTML are load-bearing note-type template hooks defined in `src/templates/n2a-basic.json`, consumed by `src/templates/custom.css` (font sizing, back-text alignment), and mirrored in `ankifyModels.ts`. They are NOT cruft and are left exactly as-is. This PR strips only the empty `<summary class="toggle"></summary>`. `n2a-basic.json` and `custom.css` are untouched.

## Diagnosis note
The empty `<summary class="toggle"></summary>` originates in the Notion-export/HTML toggle conversion path (the `class="toggle"` is added by the HTML normalization, not by markdown), surviving at default settings because the existing strip only ran under `max-one-toggle-per-card`. The fix removes it on every path, which covers the reported card-output noise.

## Measuring success
Convert a Notion page containing a toggle at default settings: the resulting card back no longer starts with `<summary class="toggle"></summary>`. Regression guard: `src/lib/parser/DeckParser.emptyToggleSummary.test.ts` asserts the back does not contain the empty tag and that the real answer content (`Tirana!`) plus the question front are preserved.

## Testing
- Unit tests added: `DeckParser.emptyToggleSummary.test.ts` — (1) empty summary stripped at default settings, (2) real answer content + front preserved (over-strip guard).
- Verified TDD: the "strips" assertion fails on the pre-fix source and passes after.
- Full `src/lib/parser/` suite: no assertion regressions. The remaining failures in this worktree are all `PythonExitError` from `.apkg` packaging (the Python venv only exists in the main checkout) and are identical with and without this change.
- `tsc -p . --noEmit` clean; tree-wide `oxfmt --check src web/src` clean.
- Sonar not run locally; Automatic Analysis covers the push.

## Browser check
Browser check: not applicable — server-side card output only, no `web/src/` change.

## Changelog
No entry — cosmetic HTML noise in generated card markup, invisible in normal Anki rendering; a real user studying cards would not notice.

## Risks
Low. Only removes a literal empty `<summary class="toggle"></summary>` string. Existing tests that assert a back contains `summary` use nested toggles with real (non-empty) summary content, so they are unaffected. Rollback: revert the single-hunk change.

## Goal alignment
Simpler, cleaner deck output for anyone inspecting or restyling notes (MCP power users). Internal quality fix — no funnel/revenue metric targeted.

no changelog entry — cosmetic card-output cleanup (strips an orphaned empty tag), invisible in Anki rendering.
