### PR TITLE
feat: MCP deck contract — input formats, applied-options echo, clear error, success metric

### DIFF
--- a/src/routes/McpRouter.ts
+++ b/src/routes/McpRouter.ts
@@ -118,6 +118,18 @@ const McpRouter = () => {
           props: { tool: toolName },
           created_at: new Date(),
         }),
+      recordToolResult: (toolName, success, errorCode) =>
+        getEventsSink().record({
+          name: 'mcp_tool_result',
+          user_id: Number(user.id),
+          anonymous_id: null,
+          props: {
+            tool: toolName,
+            success,
+            ...(errorCode != null ? { error_code: errorCode } : {}),
+          },
+          created_at: new Date(),
+        }),
     });
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined,

--- a/src/services/mcp/McpServerFactory.test.ts
+++ b/src/services/mcp/McpServerFactory.test.ts
@@ -8,6 +8,7 @@ const buildContext = (
   locals: {},
   toolsService: {} as McpToolsService,
   recordToolCall: () => {},
+  recordToolResult: () => {},
   ...overrides,
 });
 
@@ -158,5 +159,87 @@ describe('get_deck_preview handler', () => {
       '[mcp] get_deck_preview failed for missing: Deck not found.'
     );
     errorSpy.mockRestore();
+  });
+});
+
+describe('tool result metric', () => {
+  type ResultCall = [string, boolean, string?];
+
+  it('records a successful convert_to_deck result', async () => {
+    const calls: ResultCall[] = [];
+    const convertToDeck = jest.fn(async () => ({
+      kind: 'deck' as const,
+      cardCount: 3,
+      filename: 'deck.apkg',
+      summary: 'ready',
+    }));
+    const handler = getHandler(
+      buildContext({
+        toolsService: { convertToDeck } as unknown as McpToolsService,
+        recordToolResult: (tool, success, errorCode) =>
+          calls.push([tool, success, errorCode]),
+      }),
+      'convert_to_deck'
+    );
+    await handler({ text: 'Q :: A' });
+    expect(calls).toEqual([['convert_to_deck', true, undefined]]);
+  });
+
+  it('records a failed convert_to_deck result with its error code', async () => {
+    const calls: ResultCall[] = [];
+    const convertToDeck = jest.fn(async () => ({
+      kind: 'error' as const,
+      message: 'No cards found in this text.',
+      code: 'empty_export',
+    }));
+    const handler = getHandler(
+      buildContext({
+        toolsService: { convertToDeck } as unknown as McpToolsService,
+        recordToolResult: (tool, success, errorCode) =>
+          calls.push([tool, success, errorCode]),
+      }),
+      'convert_to_deck'
+    );
+    await handler({ text: 'a table' });
+    expect(calls).toEqual([['convert_to_deck', false, 'empty_export']]);
+  });
+
+  it('records create_deck success and failure results', async () => {
+    const successCalls: ResultCall[] = [];
+    const successHandler = getHandler(
+      buildContext({
+        toolsService: {
+          createDeck: jest.fn(async () => ({
+            kind: 'deck' as const,
+            cardCount: 2,
+            filename: 'deck.apkg',
+            summary: 'ready',
+          })),
+        } as unknown as McpToolsService,
+        recordToolResult: (tool, success, errorCode) =>
+          successCalls.push([tool, success, errorCode]),
+      }),
+      'create_deck'
+    );
+    await successHandler({ cards: [{ front: 'Q', back: 'A' }] });
+    expect(successCalls).toEqual([['create_deck', true, undefined]]);
+
+    const failCalls: ResultCall[] = [];
+    const failHandler = getHandler(
+      buildContext({
+        toolsService: {
+          createDeck: jest.fn(async () => ({
+            kind: 'error' as const,
+            message: 'Some cards have an empty back.',
+            code: 'empty_export',
+          })),
+        } as unknown as McpToolsService,
+        recordToolResult: (tool, success, errorCode) =>
+          failCalls.push([tool, success, errorCode]),
+      }),
+      'create_deck'
+    );
+    await failHandler({ cards: [{ front: 'Q', back: '' }] });
+    expect(failCalls).toEqual([['create_deck', false, 'empty_export']]);
   });
 });

--- a/src/services/mcp/McpServerFactory.ts
+++ b/src/services/mcp/McpServerFactory.ts
@@ -17,6 +17,11 @@ export interface McpRequestContext {
   locals: Record<string, unknown>;
   toolsService: McpToolsService;
   recordToolCall: (toolName: string) => void;
+  recordToolResult: (
+    toolName: string,
+    success: boolean,
+    errorCode?: string
+  ) => void;
 }
 
 type ToolShape = Record<string, z.ZodTypeAny>;
@@ -215,8 +220,10 @@ export function buildMcpServer(context: McpRequestContext): McpServer {
         context.locals
       );
       if (result.kind === 'error') {
+        context.recordToolResult('convert_to_deck', false, result.code);
         return errorResult(result.message);
       }
+      context.recordToolResult('convert_to_deck', true);
       return textResult(result);
     }
   );
@@ -257,8 +264,10 @@ export function buildMcpServer(context: McpRequestContext): McpServer {
         context.locals
       );
       if (result.kind === 'error') {
+        context.recordToolResult('create_deck', false, result.code);
         return errorResult(result.message);
       }
+      context.recordToolResult('create_deck', true);
       return textResult(result);
     }
   );

--- a/src/services/mcp/McpToolsService.test.ts
+++ b/src/services/mcp/McpToolsService.test.ts
@@ -82,6 +82,77 @@ function makeService(overrides: {
   };
 }
 
+type SampleInput = { front: string; back: string; ord: number };
+
+function reversibleNoteTypes() {
+  return new Map([
+    [
+      1,
+      {
+        id: 1,
+        name: 'Basic (and reversed card)',
+        type: 0,
+        css: '',
+        fields: [],
+        templates: [
+          { name: 'Card 1', ord: 0, qfmt: '', afmt: '' },
+          { name: 'Card 2', ord: 1, qfmt: '', afmt: '' },
+        ],
+      },
+    ],
+  ]);
+}
+
+function basicNoteTypes() {
+  return new Map([
+    [
+      1,
+      {
+        id: 1,
+        name: 'Basic',
+        type: 0,
+        css: '',
+        fields: [],
+        templates: [{ name: 'Card 1', ord: 0, qfmt: '', afmt: '' }],
+      },
+    ],
+  ]);
+}
+
+function makePreview(
+  noteTypes: unknown,
+  cards: SampleInput[]
+): Partial<ApkgPreviewService> {
+  const parsed = {
+    collection: {
+      noteTypes,
+      cards: cards.map((card, index) => ({
+        id: index + 1,
+        nid: index + 1,
+        did: 1,
+        ord: card.ord,
+      })),
+      notes: new Map(),
+      decks: new Map(),
+    },
+  };
+  return {
+    parse: jest.fn(async () => parsed as never),
+    getMeta: jest.fn(() => ({ totalCards: cards.length, decks: [] })),
+    getCardsPage: jest.fn(
+      () => ({ cards, nextCursor: null, total: cards.length }) as never
+    ),
+  };
+}
+
+function reversiblePreview(cards: SampleInput[]): Partial<ApkgPreviewService> {
+  return makePreview(reversibleNoteTypes(), cards);
+}
+
+function basicPreview(cards: SampleInput[]): Partial<ApkgPreviewService> {
+  return makePreview(basicNoteTypes(), cards);
+}
+
 describe('McpToolsService.listMyDecks', () => {
   it('maps jobs to owner-scoped summaries with download URLs', async () => {
     const { service } = makeService({
@@ -355,6 +426,205 @@ describe('McpToolsService.convertToDeck', () => {
     });
     expect(persist).not.toHaveBeenCalled();
   });
+
+  it('remaps markdown_likely_lossy to the context-neutral no-cards guidance', async () => {
+    const uploadEntry: UploadEntrypoint = (_req, res) => {
+      res.status(400).json({
+        code: 'markdown_likely_lossy',
+        message: 'Notion-flavored lossy reason',
+      });
+    };
+    const { service } = makeService({ uploadEntry });
+    const result = await service.convertToDeck(
+      { text: 'a table' },
+      'owner',
+      {}
+    );
+    expect(result).toMatchObject({
+      kind: 'error',
+      code: 'markdown_likely_lossy',
+    });
+    const message = (result as { message: string }).message;
+    expect(message).toContain('No cards found in this text');
+    expect(message).toContain('create_deck');
+    expect(message).toContain('deck_capabilities');
+    expect(message).not.toContain('Notion-flavored lossy reason');
+  });
+
+  it('remaps empty_export to the same no-cards guidance', async () => {
+    const uploadEntry: UploadEntrypoint = (_req, res) => {
+      res.status(400).json({ code: 'empty_export', message: 'No cards.' });
+    };
+    const { service } = makeService({ uploadEntry });
+    const result = await service.convertToDeck({ text: 'x' }, 'owner', {});
+    expect(result).toMatchObject({ kind: 'error', code: 'empty_export' });
+    expect((result as { message: string }).message).toContain(
+      'No cards found in this text'
+    );
+  });
+
+  it('echoes the applied options back in the public option vocabulary', async () => {
+    const uploadEntry: UploadEntrypoint = (_req, res) => {
+      res.set('X-Card-Count', '3');
+      res.set('File-Name', 'deck.apkg');
+      res.status(200).send(Buffer.from('APKG-BYTES'));
+    };
+    const { service } = makeService({ uploadEntry });
+    const result = await service.convertToDeck(
+      {
+        text: 'Q :: A',
+        options: {
+          noteType: 'basic-reversed',
+          tags: ['bio'],
+          deckName: 'Cells',
+          styleTemplate: 'nostyle',
+        },
+      },
+      'owner-9',
+      {}
+    );
+    expect(result).toMatchObject({
+      kind: 'deck',
+      applied: {
+        noteType: 'basic-reversed',
+        tags: ['bio'],
+        deckName: 'Cells',
+        styleTemplate: 'nostyle',
+        splitByHeadings: false,
+        tts: { enabled: false },
+      },
+    });
+    expect((result as { ignored?: unknown }).ignored).toBeUndefined();
+  });
+
+  it('downgrades cloze to basic and reports it in ignored when the text has no markup', async () => {
+    const uploadEntry: UploadEntrypoint = (_req, res) => {
+      res.set('X-Card-Count', '1');
+      res.set('File-Name', 'deck.apkg');
+      res.status(200).send(Buffer.from('APKG-BYTES'));
+    };
+    const { service } = makeService({ uploadEntry });
+    const result = await service.convertToDeck(
+      { text: 'Front :: Back', options: { noteType: 'cloze' } },
+      'owner-9',
+      {}
+    );
+    expect(result).toMatchObject({
+      kind: 'deck',
+      applied: { noteType: 'basic' },
+      ignored: [
+        {
+          option: 'noteType',
+          requested: 'cloze',
+          reason:
+            'No {{c1::}} markup found in the text; built basic cards instead.',
+        },
+      ],
+    });
+  });
+
+  it('keeps cloze in applied when the text carries {{c1::}} markup', async () => {
+    const uploadEntry: UploadEntrypoint = (_req, res) => {
+      res.set('X-Card-Count', '1');
+      res.set('File-Name', 'deck.apkg');
+      res.status(200).send(Buffer.from('APKG-BYTES'));
+    };
+    const { service } = makeService({ uploadEntry });
+    const result = await service.convertToDeck(
+      {
+        text: 'The {{c1::mitochondrion}} is the powerhouse :: extra',
+        options: { noteType: 'cloze' },
+      },
+      'owner-9',
+      {}
+    );
+    expect(result).toMatchObject({
+      kind: 'deck',
+      applied: { noteType: 'cloze' },
+    });
+    expect((result as { ignored?: unknown }).ignored).toBeUndefined();
+  });
+
+  it('labels reversible sample cards with a forward/reverse direction', async () => {
+    const uploadEntry: UploadEntrypoint = (_req, res) => {
+      res.set('X-Card-Count', '2');
+      res.set('File-Name', 'deck.apkg');
+      res.status(200).send(Buffer.from('APKG-BYTES'));
+    };
+    const { service } = makeService({
+      uploadEntry,
+      preview: reversiblePreview([
+        { front: 'F', back: 'B', ord: 0 },
+        { front: 'B', back: 'F', ord: 1 },
+      ]),
+    });
+    const result = await service.convertToDeck({ text: 'x' }, 'owner-9', {});
+    expect((result as { sampleCards?: unknown }).sampleCards).toEqual([
+      { front: 'F', back: 'B', direction: 'forward' },
+      { front: 'B', back: 'F', direction: 'reverse' },
+    ]);
+  });
+
+  it('omits direction on a non-reversible deck', async () => {
+    const uploadEntry: UploadEntrypoint = (_req, res) => {
+      res.set('X-Card-Count', '1');
+      res.set('File-Name', 'deck.apkg');
+      res.status(200).send(Buffer.from('APKG-BYTES'));
+    };
+    const { service } = makeService({
+      uploadEntry,
+      preview: basicPreview([{ front: 'Q', back: 'A', ord: 0 }]),
+    });
+    const result = await service.convertToDeck({ text: 'x' }, 'owner-9', {});
+    expect((result as { sampleCards?: unknown }).sampleCards).toEqual([
+      { front: 'Q', back: 'A' },
+    ]);
+  });
+
+  it('adds a reverse sample when the first page of a reversible deck is all forward', async () => {
+    const uploadEntry: UploadEntrypoint = (_req, res) => {
+      res.set('X-Card-Count', '2');
+      res.set('File-Name', 'deck.apkg');
+      res.status(200).send(Buffer.from('APKG-BYTES'));
+    };
+    const parsed = {
+      collection: {
+        noteTypes: reversibleNoteTypes(),
+        cards: [
+          { id: 1, nid: 1, did: 1, ord: 0 },
+          { id: 2, nid: 1, did: 1, ord: 1 },
+        ],
+        notes: new Map(),
+        decks: new Map(),
+      },
+    };
+    const getCardsPage = jest.fn((_p: unknown, cursor: number) =>
+      cursor === 0
+        ? {
+            cards: [{ front: 'F', back: 'B', ord: 0 }],
+            nextCursor: null,
+            total: 2,
+          }
+        : {
+            cards: [{ front: 'B', back: 'F', ord: 1 }],
+            nextCursor: null,
+            total: 2,
+          }
+    );
+    const { service } = makeService({
+      uploadEntry,
+      preview: {
+        parse: jest.fn(async () => parsed as never),
+        getMeta: jest.fn(() => ({ totalCards: 2, decks: [] })),
+        getCardsPage,
+      } as unknown as Partial<ApkgPreviewService>,
+    });
+    const result = await service.convertToDeck({ text: 'x' }, 'owner-9', {});
+    expect((result as { sampleCards?: unknown }).sampleCards).toEqual([
+      { front: 'F', back: 'B', direction: 'forward' },
+      { front: 'B', back: 'F', direction: 'reverse' },
+    ]);
+  });
 });
 
 describe('McpToolsService.createDeck', () => {
@@ -522,6 +792,28 @@ describe('McpToolsService.createDeck', () => {
     const result = await service.createDeck(cards, 'Deck', 'owner-9', {});
     expect(result).toMatchObject({ kind: 'error' });
     expect(persist).not.toHaveBeenCalled();
+  });
+
+  it('returns the empty-back guidance instead of the convert-flavored message when every back is empty', async () => {
+    const uploadEntry: UploadEntrypoint = (_req, res) => {
+      res.status(400).json({ code: 'empty_export', message: 'No cards.' });
+    };
+    const { service } = makeService({ uploadEntry });
+    const result = await service.createDeck(
+      [
+        { front: 'Front only', back: '' },
+        { front: 'Another', back: '   ' },
+      ],
+      'Deck',
+      'owner-9',
+      {}
+    );
+    expect(result).toEqual({
+      kind: 'error',
+      code: 'empty_export',
+      message:
+        'Some cards have an empty back. Every card needs both a front and a back.',
+    });
   });
 });
 

--- a/src/services/mcp/McpToolsService.ts
+++ b/src/services/mcp/McpToolsService.ts
@@ -14,6 +14,14 @@ import {
   McpConvertOptions,
   mcpOptionsToCardSettings,
 } from './mcpOptionsToCardSettings';
+import {
+  AppliedOptions,
+  IgnoredOption,
+  buildAppliedOptions,
+  hasClozeMarkup,
+} from './buildAppliedOptions';
+import type { ParsedApkg } from '../ApkgPreviewService/ApkgPreviewService';
+import type { RenderedCard } from '../ApkgPreviewService/types';
 import { detectFileMime } from '../../lib/detectFileMime';
 import { mcpBaseUrl } from './mcpBaseUrl';
 import { isPaying } from '../../lib/isPaying';
@@ -33,6 +41,11 @@ const PREVIEW_CARD_LIMIT = 20;
 const MAX_CARDS = 500;
 const DEFAULT_DECK_NAME = 'MCP deck';
 const DATA_URL_PREFIX = /^data:[^,]*,/;
+const NO_CARDS_FOUND_MESSAGE =
+  'No cards found in this text. If you already have front/back pairs, call create_deck with them — it needs no special formatting. Otherwise mark up the text with one of these structures and call convert_to_deck again: `front :: back` on its own line, `<details><summary>front</summary>back</details>`, or a `## front` heading with the answer on the line below. Full grammar: deck_capabilities → inputFormats.';
+const EMPTY_BACK_MESSAGE =
+  'Some cards have an empty back. Every card needs both a front and a back.';
+const NO_CARD_CODES = new Set(['markdown_likely_lossy', 'empty_export']);
 const ALLOWED_PHOTO_MEDIA_TYPES: VisionMediaType[] = [
   'image/jpeg',
   'image/png',
@@ -119,11 +132,17 @@ export interface DeckSummary {
   downloadUrl: string | null;
 }
 
+export interface SampleCard {
+  front: string;
+  back: string;
+  direction?: 'forward' | 'reverse';
+}
+
 export interface DeckPreview {
   cardCount: number;
   deckCount: number;
   decks: { id: number; name: string; cardCount: number }[];
-  sampleCards: { front: string; back: string }[];
+  sampleCards: SampleCard[];
 }
 
 export type ConvertResult =
@@ -142,10 +161,12 @@ export type ConvertResult =
       downloadUrl?: string;
       deckCount?: number;
       decks?: { id: number; name: string; cardCount: number }[];
-      sampleCards?: { front: string; back: string }[];
+      sampleCards?: SampleCard[];
+      applied?: AppliedOptions;
+      ignored?: IgnoredOption[];
       summary: string;
     }
-  | { kind: 'error'; message: string };
+  | { kind: 'error'; message: string; code?: string };
 
 export interface ConvertInput {
   url?: string;
@@ -314,10 +335,10 @@ export class McpToolsService {
         name: deck.fullName,
         cardCount: deck.cardCount,
       })),
-      sampleCards: page.cards.map((card) => ({
-        front: card.front,
-        back: card.back,
-      })),
+      sampleCards: this.toSampleCards(
+        page.cards,
+        this.deckIsReversible(parsed)
+      ),
     };
   }
 
@@ -357,7 +378,26 @@ export class McpToolsService {
       locals,
       mcpOptionsToCardSettings(input.options)
     );
-    return this.mapUploadResult(res, owner, file.originalname);
+    const result = await this.mapUploadResult(res, owner, file.originalname);
+    if (result.kind !== 'deck') {
+      return result;
+    }
+    const clozePresent =
+      input.options?.noteType === 'cloze'
+        ? hasClozeMarkup(this.clozeCheckText(input, file))
+        : false;
+    const { applied, ignored } = buildAppliedOptions(
+      input.options,
+      clozePresent
+    );
+    return { ...result, applied, ...(ignored ? { ignored } : {}) };
+  }
+
+  private clozeCheckText(input: ConvertInput, file: UploadedFile): string {
+    if (typeof input.text === 'string' && input.text.length > 0) {
+      return input.text;
+    }
+    return file.buffer.subarray(0, MAX_TEXT_BYTES).toString('utf-8');
   }
 
   async createDeck(
@@ -403,7 +443,14 @@ export class McpToolsService {
     if (result.kind === 'deck' && result.cardCount == null) {
       return { ...result, cardCount: cards.length };
     }
+    if (result.kind === 'error' && this.everyBackEmpty(cards)) {
+      return { ...result, message: EMPTY_BACK_MESSAGE };
+    }
     return result;
+  }
+
+  private everyBackEmpty(cards: McpCard[]): boolean {
+    return cards.every((card) => card.back == null || card.back.trim() === '');
   }
 
   private async runUpload(
@@ -436,6 +483,9 @@ export class McpToolsService {
         PREVIEW_CARD_LIMIT,
         ''
       );
+      const reversible = this.deckIsReversible(parsed);
+      const sampleCards = this.toSampleCards(page.cards, reversible);
+      this.ensureReverseSample(parsed, reversible, sampleCards);
       return {
         deckCount: meta.decks.length,
         decks: meta.decks.map((deck) => ({
@@ -443,13 +493,67 @@ export class McpToolsService {
           name: deck.fullName,
           cardCount: deck.cardCount,
         })),
-        sampleCards: page.cards.map((card) => ({
-          front: card.front,
-          back: card.back,
-        })),
+        sampleCards,
       };
     } catch {
       return null;
+    }
+  }
+
+  private deckIsReversible(parsed: ParsedApkg): boolean {
+    const noteTypes = parsed.collection?.noteTypes;
+    if (!(noteTypes instanceof Map)) {
+      return false;
+    }
+    for (const noteType of noteTypes.values()) {
+      if (
+        noteType.type === 0 &&
+        Array.isArray(noteType.templates) &&
+        noteType.templates.length >= 2
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private toSampleCards(
+    cards: RenderedCard[],
+    reversible: boolean
+  ): SampleCard[] {
+    return cards.map((card) => this.toSampleCard(card, reversible));
+  }
+
+  private toSampleCard(card: RenderedCard, reversible: boolean): SampleCard {
+    if (!reversible) {
+      return { front: card.front, back: card.back };
+    }
+    const direction: 'forward' | 'reverse' =
+      card.ord === 0 ? 'forward' : 'reverse';
+    return { front: card.front, back: card.back, direction };
+  }
+
+  private ensureReverseSample(
+    parsed: ParsedApkg,
+    reversible: boolean,
+    sampleCards: SampleCard[]
+  ): void {
+    if (!reversible) {
+      return;
+    }
+    if (sampleCards.some((card) => card.direction === 'reverse')) {
+      return;
+    }
+    const reverseIndex = parsed.collection.cards.findIndex(
+      (card) => card.ord >= 1
+    );
+    if (reverseIndex < 0) {
+      return;
+    }
+    const extra = this.previewService.getCardsPage(parsed, reverseIndex, 1, '');
+    const card = extra.cards[0];
+    if (card) {
+      sampleCards.push(this.toSampleCard(card, true));
     }
   }
 
@@ -514,9 +618,11 @@ export class McpToolsService {
     if (res.statusCode === 200 && res.bodyBuffer != null) {
       return this.persistDeckResult(res.bodyBuffer, res, owner, fallbackTitle);
     }
+    const code = this.errorCode(res.body);
     return {
       kind: 'error',
-      message: this.errorMessage(res.body),
+      message: this.errorMessage(res.body, code),
+      ...(code != null ? { code } : {}),
     };
   }
 
@@ -568,7 +674,21 @@ export class McpToolsService {
     );
   }
 
-  private errorMessage(body: unknown): string {
+  private errorCode(body: unknown): string | undefined {
+    if (
+      typeof body === 'object' &&
+      body != null &&
+      typeof (body as { code?: unknown }).code === 'string'
+    ) {
+      return (body as { code: string }).code;
+    }
+    return undefined;
+  }
+
+  private errorMessage(body: unknown, code: string | undefined): string {
+    if (code != null && NO_CARD_CODES.has(code)) {
+      return NO_CARDS_FOUND_MESSAGE;
+    }
     if (
       typeof body === 'object' &&
       body != null &&

--- a/src/services/mcp/buildAppliedOptions.test.ts
+++ b/src/services/mcp/buildAppliedOptions.test.ts
@@ -1,0 +1,94 @@
+import { buildAppliedOptions, hasClozeMarkup } from './buildAppliedOptions';
+
+describe('buildAppliedOptions', () => {
+  it('projects honored options into the public vocabulary', () => {
+    const { applied, ignored } = buildAppliedOptions(
+      {
+        noteType: 'basic-reversed',
+        tags: [' bio ', '', 'cells'],
+        deckName: '  Cell biology  ',
+        splitByHeadings: true,
+        styleTemplate: 'nostyle',
+        tts: { enabled: true, language: ' ja-JP ', side: 'back' },
+      },
+      false
+    );
+
+    expect(applied).toEqual({
+      noteType: 'basic-reversed',
+      tags: ['bio', 'cells'],
+      deckName: 'Cell biology',
+      splitByHeadings: true,
+      styleTemplate: 'nostyle',
+      tts: { enabled: true, language: 'ja-JP', side: 'back' },
+    });
+    expect(ignored).toBeUndefined();
+  });
+
+  it('defaults to basic with empty tags and disabled tts when no options are given', () => {
+    const { applied, ignored } = buildAppliedOptions(undefined, false);
+    expect(applied).toEqual({
+      noteType: 'basic',
+      tags: [],
+      splitByHeadings: false,
+      tts: { enabled: false },
+    });
+    expect(ignored).toBeUndefined();
+  });
+
+  it('treats splitSectionsIntoDecks as splitByHeadings', () => {
+    const { applied } = buildAppliedOptions(
+      { splitSectionsIntoDecks: true },
+      false
+    );
+    expect(applied.splitByHeadings).toBe(true);
+  });
+
+  it('falls back cloze to basic and records an ignored entry when markup is absent', () => {
+    const { applied, ignored } = buildAppliedOptions(
+      { noteType: 'cloze' },
+      false
+    );
+    expect(applied.noteType).toBe('basic');
+    expect(ignored).toEqual([
+      {
+        option: 'noteType',
+        requested: 'cloze',
+        reason:
+          'No {{c1::}} markup found in the text; built basic cards instead.',
+      },
+    ]);
+  });
+
+  it('keeps cloze when the markup is present', () => {
+    const { applied, ignored } = buildAppliedOptions(
+      { noteType: 'cloze' },
+      true
+    );
+    expect(applied.noteType).toBe('cloze');
+    expect(ignored).toBeUndefined();
+  });
+
+  it('omits deckName and styleTemplate when they resolve to empty or invalid', () => {
+    const { applied } = buildAppliedOptions(
+      { deckName: '   ', styleTemplate: 'unknown' as never },
+      false
+    );
+    expect(applied.deckName).toBeUndefined();
+    expect(applied.styleTemplate).toBeUndefined();
+  });
+});
+
+describe('hasClozeMarkup', () => {
+  it('detects cloze markup', () => {
+    expect(hasClozeMarkup('The {{c1::mitochondrion}} is the powerhouse')).toBe(
+      true
+    );
+    expect(hasClozeMarkup('The {{c12::term}} example')).toBe(true);
+  });
+
+  it('is false for plain text and bare double braces', () => {
+    expect(hasClozeMarkup('Mitochondrion :: powerhouse')).toBe(false);
+    expect(hasClozeMarkup('{{not a cloze}}')).toBe(false);
+  });
+});

--- a/src/services/mcp/buildAppliedOptions.ts
+++ b/src/services/mcp/buildAppliedOptions.ts
@@ -1,0 +1,129 @@
+import {
+  McpConvertOptions,
+  McpNoteType,
+  McpStyleTemplate,
+  McpTtsSide,
+} from './mcpOptionsToCardSettings';
+
+export interface AppliedTts {
+  enabled: boolean;
+  language?: string;
+  side?: McpTtsSide;
+}
+
+export interface AppliedOptions {
+  noteType: McpNoteType;
+  tags: string[];
+  deckName?: string;
+  splitByHeadings: boolean;
+  styleTemplate?: McpStyleTemplate;
+  tts: AppliedTts;
+}
+
+export interface IgnoredOption {
+  option: string;
+  requested: unknown;
+  reason: string;
+}
+
+export interface AppliedOptionsResult {
+  applied: AppliedOptions;
+  ignored?: IgnoredOption[];
+}
+
+const NOTE_TYPES: readonly McpNoteType[] = [
+  'basic',
+  'basic-reversed',
+  'cloze',
+  'input',
+  'mcq',
+];
+
+const STYLE_TEMPLATES: readonly McpStyleTemplate[] = [
+  'specialstyle',
+  'nostyle',
+  'abhiyan',
+  'alex_deluxe',
+];
+
+const TTS_SIDES: readonly McpTtsSide[] = ['front', 'back', 'both'];
+
+const CLOZE_MARKUP = /\{\{c\d+::/;
+
+export function hasClozeMarkup(text: string): boolean {
+  return CLOZE_MARKUP.test(text);
+}
+
+function resolveTags(tags: unknown): string[] {
+  if (!Array.isArray(tags)) {
+    return [];
+  }
+  return tags
+    .filter((tag): tag is string => typeof tag === 'string')
+    .map((tag) => tag.trim())
+    .filter((tag) => tag.length > 0);
+}
+
+function resolveTts(tts: McpConvertOptions['tts']): AppliedTts {
+  if (tts == null || tts.enabled !== true) {
+    return { enabled: false };
+  }
+  const result: AppliedTts = { enabled: true };
+  const language = typeof tts.language === 'string' ? tts.language.trim() : '';
+  if (language.length > 0) {
+    result.language = language;
+  }
+  if (tts.side != null && TTS_SIDES.includes(tts.side)) {
+    result.side = tts.side;
+  }
+  return result;
+}
+
+export function buildAppliedOptions(
+  options: McpConvertOptions | undefined,
+  clozeMarkupPresent: boolean
+): AppliedOptionsResult {
+  const ignored: IgnoredOption[] = [];
+
+  let noteType: McpNoteType = 'basic';
+  if (options?.noteType != null && NOTE_TYPES.includes(options.noteType)) {
+    noteType = options.noteType;
+  }
+
+  if (noteType === 'cloze' && !clozeMarkupPresent) {
+    noteType = 'basic';
+    ignored.push({
+      option: 'noteType',
+      requested: 'cloze',
+      reason:
+        'No {{c1::}} markup found in the text; built basic cards instead.',
+    });
+  }
+
+  const applied: AppliedOptions = {
+    noteType,
+    tags: resolveTags(options?.tags),
+    splitByHeadings:
+      options?.splitByHeadings === true ||
+      options?.splitSectionsIntoDecks === true,
+    tts: resolveTts(options?.tts),
+  };
+
+  const deckName =
+    typeof options?.deckName === 'string' ? options.deckName.trim() : '';
+  if (deckName.length > 0) {
+    applied.deckName = deckName;
+  }
+
+  if (
+    options?.styleTemplate != null &&
+    STYLE_TEMPLATES.includes(options.styleTemplate)
+  ) {
+    applied.styleTemplate = options.styleTemplate;
+  }
+
+  if (ignored.length > 0) {
+    return { applied, ignored };
+  }
+  return { applied };
+}

--- a/src/services/mcp/deckCapabilities.test.ts
+++ b/src/services/mcp/deckCapabilities.test.ts
@@ -1,0 +1,43 @@
+import { DECK_CAPABILITIES } from './deckCapabilities';
+import { guessMarkdownCards } from '../../lib/parser/guessMarkdownCards';
+
+describe('DECK_CAPABILITIES.inputFormats', () => {
+  it('documents the four verified structures', () => {
+    expect(
+      DECK_CAPABILITIES.inputFormats.structures.map((s) => s.name)
+    ).toEqual(['inline', 'toggle', 'heading', 'qa']);
+  });
+
+  it('every structure example parses to at least one note', () => {
+    for (const structure of DECK_CAPABILITIES.inputFormats.structures) {
+      const result = guessMarkdownCards(structure.example);
+      expect(result).not.toBeNull();
+      expect(result?.notes.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('the cloze note-type example carries cloze markup and parses to a note', () => {
+    const cloze = DECK_CAPABILITIES.inputFormats.noteTypes.find(
+      (n) => n.noteType === 'cloze'
+    );
+    expect(cloze).toBeDefined();
+    expect(cloze?.text).toMatch(/\{\{c\d+::/);
+    const result = guessMarkdownCards(cloze?.text ?? '');
+    expect(result?.notes.length).toBeGreaterThan(0);
+  });
+
+  it('shows basic, basic-reversed, and input sharing the same source text', () => {
+    const byType = new Map(
+      DECK_CAPABILITIES.inputFormats.noteTypes.map((n) => [n.noteType, n.text])
+    );
+    expect(byType.get('basic')).toBe(byType.get('basic-reversed'));
+    expect(byType.get('basic')).toBe(byType.get('input'));
+  });
+
+  it('does not ship an mcq example and directs mcq callers elsewhere', () => {
+    expect(
+      DECK_CAPABILITIES.inputFormats.noteTypes.some((n) => n.noteType === 'mcq')
+    ).toBe(false);
+    expect(DECK_CAPABILITIES.inputFormats.mcq).toContain('Notion');
+  });
+});

--- a/src/services/mcp/deckCapabilities.ts
+++ b/src/services/mcp/deckCapabilities.ts
@@ -9,10 +9,32 @@ export interface DeckCapabilityOption {
   description: string;
 }
 
+export interface DeckInputStructure {
+  name: string;
+  pattern: string;
+  example: string;
+}
+
+export interface DeckInputNoteType {
+  noteType: string;
+  options: Record<string, unknown>;
+  text: string;
+  note?: string;
+}
+
+export interface DeckInputFormats {
+  howItWorks: string;
+  shortcut: string;
+  structures: DeckInputStructure[];
+  noteTypes: DeckInputNoteType[];
+  mcq: string;
+}
+
 export interface DeckCapabilities {
   noteTypes: DeckCapabilityNoteType[];
   options: DeckCapabilityOption[];
   inputKinds: string[];
+  inputFormats: DeckInputFormats;
   conventions: string[];
 }
 
@@ -83,6 +105,61 @@ export const DECK_CAPABILITIES: DeckCapabilities = {
     'text — Markdown or HTML passed directly',
     'url — a public URL to an HTML, Markdown, CSV, or other supported file',
   ],
+  inputFormats: {
+    howItWorks:
+      'convert_to_deck scans your text for front and back pairs. Pick one structure below to separate each front from its back — you only need one. The note type (basic, basic-reversed, or input) is set through options.noteType and does not change which structure you use. Cloze is the exception: set options.noteType to cloze and put {{c1::...}} markup inside the front of any structure. Without the markup, cloze falls back to basic.',
+    shortcut:
+      'If you already have discrete front and back pairs, skip the text formatting and call create_deck with a { front, back } array instead. It cannot fail on formatting.',
+    structures: [
+      {
+        name: 'inline',
+        pattern: 'front :: back — one card per line',
+        example: 'What is the powerhouse of the cell? :: Mitochondria',
+      },
+      {
+        name: 'toggle',
+        pattern: '<details><summary>front</summary>back</details>',
+        example:
+          '<details><summary>What is ATP?</summary>The energy currency of the cell</details>',
+      },
+      {
+        name: 'heading',
+        pattern: '## front, then the answer on the lines below it',
+        example: '## What is ATP?\nThe energy currency of the cell',
+      },
+      {
+        name: 'qa',
+        pattern: 'Q: front on one line, A: back on the next',
+        example: 'Q: What is ATP?\nA: The energy currency of the cell',
+      },
+    ],
+    noteTypes: [
+      {
+        noteType: 'basic',
+        options: { noteType: 'basic' },
+        text: 'Mitochondrion :: The powerhouse of the cell',
+      },
+      {
+        noteType: 'basic-reversed',
+        options: { noteType: 'basic-reversed' },
+        text: 'Mitochondrion :: The powerhouse of the cell',
+        note: 'Same text as basic. Builds two cards per line — front to back and back to front.',
+      },
+      {
+        noteType: 'input',
+        options: { noteType: 'input' },
+        text: 'Mitochondrion :: The powerhouse of the cell',
+        note: 'Same text as basic. The learner types the answer during review.',
+      },
+      {
+        noteType: 'cloze',
+        options: { noteType: 'cloze' },
+        text: 'The {{c1::mitochondrion}} is the powerhouse of the cell :: Found in eukaryotic cells',
+        note: 'Cloze needs {{c1::...}} markup in the front of the card. Without the markup, cloze falls back to basic.',
+      },
+    ],
+    mcq: 'Multiple-choice cards are built from Notion toggle-list exports that mark the correct option, not from free-form text. To make them, convert a Notion export with options.noteType set to mcq. create_deck builds basic front and back cards only.',
+  },
   conventions: [
     'Cloze cards require {{c1::...}} markup in the text; without it, cloze falls back to basic.',
     'Deck names use :: to nest subdecks, e.g. Spanish::Verbs::Irregular.',

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-20-mcp-deck-contract.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-20-mcp-deck-contract.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-20-mcp-deck-contract",
+  "date": "2026-07-20",
+  "type": "feature",
+  "title": "MCP deck tools list the accepted text formats and echo back which options were applied"
+}


### PR DESCRIPTION
## What
Improves the MCP deck-tool contract so an AI caller can get it right on the first try. Synthesized output of a pm/designer/engineer trio on real MCP user feedback. Five changes, all inside `src/services/mcp/` plus one metric hook — no parser change.

## Why
A caller hit a dead end: `convert_to_deck` rejected a Markdown table (genuinely unsupported) with a Notion-flavored error, and there was no machine-readable description of what card grammar the tool actually accepts. The five changes give the model the grammar up front, a clear recovery path in the error, and confirmation of what the tool did with its options.

## How
1. **`inputFormats` in `deck_capabilities`** — documents how convert_to_deck separates front from back, a create_deck shortcut for discrete pairs, the four verified structures (`inline`, `toggle`, `heading`, `qa`), and per-note-type examples (`basic`/`basic-reversed`/`input` share one `::` text; `cloze` shows `{{c1::}}` markup with the basic-fallback warning). Each example was verified against `guessMarkdownCards.ts` — a test asserts every one parses to a note.
2. **MCP-boundary error remap** — `markdown_likely_lossy` / `empty_export` from the upload become one context-neutral message pointing at create_deck and the three structures. The shared `MARKDOWN_LIKELY_LOSSY_REASON` (web/i18n) is untouched. create_deck gets its own all-empty-backs message.
3. **`applied` + `ignored` echo** on the deck result, in the public option vocabulary (never internal settings keys). Includes the one semantic check: `noteType: cloze` with no `{{c1::}}` markup downgrades to basic and reports it in `ignored`.
4. **Sample-card `direction`** (`forward`/`reverse`), populated only for reversible (basic-reversed) decks, derived from the card template ordinal; at least one reverse card is ensured in the sample.
5. **Outcome metric** — a new `mcp_tool_result` event (`{ tool, success, error_code? }`) fires after `convert_to_deck` and `create_deck`. The existing start-count `mcp_tool_called` is unchanged.

Parser note: `guessMarkdownCards` already accepts all four documented shapes; the user's failure was a Markdown table, which stays intentionally unsupported. No parser code was changed.

## mcq decision
The Markdown heuristics have no mcq grammar — mcq is built from Notion toggle-list structure (`findNotionToggleLists` / `isMCQ`), not free-form text, and create_deck only emits basic front/back cards. So no mcq example is shipped (a guessed example would violate first-time-fix). Instead `inputFormats.mcq` states plainly that mcq comes from a Notion export with `noteType: mcq`.

## Measuring success
First-try MCP convert success rate per tool, computed at `/api/ops/metrics` from the new `mcp_tool_result` event: the `success = true` share for `convert_to_deck` and `create_deck`, plus the `error_code` breakdown for failures. Day-7 prod check that the event is firing; T+14 review of the first-try success rate.

## Testing
- Unit tests added: `buildAppliedOptions.test.ts` (applied/ignored assembly, cloze fallback, tag/tts projection), `deckCapabilities.test.ts` (every documented structure + cloze example parses through `guessMarkdownCards`; no mcq example), extended `McpToolsService.test.ts` (error remap per code, applied/ignored echo, cloze downgrade, direction labeling for reversible vs basic, reverse-sample inclusion, create_deck empty-back message), extended `McpServerFactory.test.ts` (`mcp_tool_result` fires with success and error_code for both tools).
- Full `src/services/mcp` suite green (126 tests). `tsc -p . --noEmit` clean (deploy typechecks tests). `pnpm format:check` clean.
- Sonar not run locally; Automatic Analysis covers the push.

## Browser check
Browser check: not applicable — MCP server-side + changelog only

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-07-20-mcp-deck-contract.json` — "MCP deck tools list the accepted text formats and echo back which options were applied"

## Risks
Low. Additive response fields (`applied`, `ignored`, `direction`, `inputFormats`) and a new event; no change to conversion output or the upload pipeline. The error remap only changes MCP-facing text for two codes; the web string is untouched. Rollback is a straight revert.

## Goal alignment
Developer-facing surface (MCP beta). It moves first-try MCP conversion success — read at `/api/ops/metrics` via the new `mcp_tool_result` event, reviewed at day-7 and T+14. A caller that gets a clean deck on the first attempt is a retained integration; a dead-ended one churns silently.
