### PR TITLE
feat: MCP create_deck subdecks via a per-card deck field

### DIFF
--- a/src/routes/McpRouter.ts
+++ b/src/routes/McpRouter.ts
@@ -77,7 +77,8 @@ const McpRouter = () => {
       new UploadRepository(database),
       storage
     ),
-    new PhotoToFlashcardsUseCase(new EventsRepository(database))
+    new PhotoToFlashcardsUseCase(new EventsRepository(database)),
+    usersRepository
   );
 
   const onAuthenticatedPost: RequestHandler = async (req, res) => {
@@ -118,7 +119,7 @@ const McpRouter = () => {
           props: { tool: toolName },
           created_at: new Date(),
         }),
-      recordToolResult: (toolName, success, errorCode) =>
+      recordToolResult: (toolName, success, errorCode, extraProps) =>
         getEventsSink().record({
           name: 'mcp_tool_result',
           user_id: Number(user.id),
@@ -127,6 +128,7 @@ const McpRouter = () => {
             tool: toolName,
             success,
             ...(errorCode != null ? { error_code: errorCode } : {}),
+            ...extraProps,
           },
           created_at: new Date(),
         }),

--- a/src/services/mcp/McpServerFactory.test.ts
+++ b/src/services/mcp/McpServerFactory.test.ts
@@ -87,6 +87,61 @@ describe('buildMcpServer', () => {
   });
 });
 
+describe('create_deck handler', () => {
+  it('records the distinct subdeck count on the result event', async () => {
+    const createDeck = jest.fn(async () => ({
+      kind: 'deck' as const,
+      cardCount: 3,
+      filename: 'JLPT N5.apkg',
+      summary: 'Deck ready: JLPT N5 — 3 cards across 2 subdecks.',
+      applied: {
+        noteType: 'basic' as const,
+        tags: [],
+        splitByHeadings: false,
+        tts: { enabled: false },
+        subdecks: [
+          { deck: 'JLPT N5::Grammar', cards: 1 },
+          { deck: 'JLPT N5::Vocabulary', cards: 2 },
+        ],
+      },
+    }));
+    const results: Array<{
+      success: boolean;
+      props?: Record<string, unknown>;
+    }> = [];
+    const handler = getHandler(
+      buildContext({
+        toolsService: { createDeck } as unknown as McpToolsService,
+        recordToolResult: (_name, success, _code, props) =>
+          results.push({ success, props }),
+      }),
+      'create_deck'
+    );
+    await handler({ cards: [{ front: 'a', back: 'b', deck: 'X' }] });
+    expect(results).toEqual([{ success: true, props: { subdeckCount: 2 } }]);
+  });
+
+  it('records a subdeck count of 1 for a flat deck with no applied subdecks', async () => {
+    const createDeck = jest.fn(async () => ({
+      kind: 'deck' as const,
+      cardCount: 2,
+      filename: 'deck.apkg',
+      summary: '2 cards. Ready to download.',
+    }));
+    const results: Array<Record<string, unknown> | undefined> = [];
+    const handler = getHandler(
+      buildContext({
+        toolsService: { createDeck } as unknown as McpToolsService,
+        recordToolResult: (_name, _success, _code, props) =>
+          results.push(props),
+      }),
+      'create_deck'
+    );
+    await handler({ cards: [{ front: 'a', back: 'b' }] });
+    expect(results).toEqual([{ subdeckCount: 1 }]);
+  });
+});
+
 describe('get_deck_preview handler', () => {
   it('passes a jobId through to getDeckPreview and returns the preview', async () => {
     const getDeckPreview = jest.fn(async () => ({

--- a/src/services/mcp/McpServerFactory.ts
+++ b/src/services/mcp/McpServerFactory.ts
@@ -20,7 +20,8 @@ export interface McpRequestContext {
   recordToolResult: (
     toolName: string,
     success: boolean,
-    errorCode?: string
+    errorCode?: string,
+    extraProps?: Record<string, unknown>
   ) => void;
 }
 
@@ -228,13 +229,16 @@ export function buildMcpServer(context: McpRequestContext): McpServer {
     }
   );
 
-  registerTool<{ cards: { front: string; back: string }[]; deckName?: string }>(
+  registerTool<{
+    cards: { front: string; back: string; deck?: string }[];
+    deckName?: string;
+  }>(
     server,
     'create_deck',
     {
       title: 'Create an Anki deck from cards',
       description:
-        'Build an Anki deck from structured front/back cards. Returns a deck preview and a no-login download link for the .apkg, plus a job id you can find later with list_my_decks.',
+        'Build an Anki deck from structured front/back cards. Returns a deck preview and a no-login download link for the .apkg, plus a job id you can find later with list_my_decks. Give a card a deck to sort it into a subdeck under deckName — e.g. deck "Vocabulary" under deckName "JLPT N5" lands in JLPT N5::Vocabulary.',
       inputSchema: {
         cards: z
           .array(
@@ -244,6 +248,12 @@ export function buildMcpServer(context: McpRequestContext): McpServer {
                 .min(1)
                 .describe('The question or prompt shown first.'),
               back: z.string().describe('The answer shown after.'),
+              deck: z
+                .string()
+                .optional()
+                .describe(
+                  'Optional leaf subdeck name under deckName, e.g. Vocabulary under JLPT N5 makes JLPT N5::Vocabulary. Use :: to nest deeper (Verbs::Irregular). Omit to keep the card in deckName.'
+                ),
             })
           )
           .min(1)
@@ -267,7 +277,13 @@ export function buildMcpServer(context: McpRequestContext): McpServer {
         context.recordToolResult('create_deck', false, result.code);
         return errorResult(result.message);
       }
-      context.recordToolResult('create_deck', true);
+      const subdeckCount =
+        result.kind === 'deck' && result.applied?.subdecks != null
+          ? result.applied.subdecks.length
+          : 1;
+      context.recordToolResult('create_deck', true, undefined, {
+        subdeckCount,
+      });
       return textResult(result);
     }
   );

--- a/src/services/mcp/McpToolsService.test.ts
+++ b/src/services/mcp/McpToolsService.test.ts
@@ -1,5 +1,9 @@
 import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
+import type UsersRepository from '../../data_layer/UsersRepository';
 import { McpToolsService, UploadEntrypoint } from './McpToolsService';
 import { DeckPersistence } from './McpDeckPersistence';
 import { JobWithDownloadKey } from '../../data_layer/JobRepository';
@@ -23,6 +27,8 @@ function makeService(overrides: {
   persist?: DeckPersistence['persist'];
   getPresignedUrl?: StorageHandler['getPresignedUrl'];
   generateCards?: jest.Mock;
+  getCardUsage?: jest.Mock;
+  incrementCardUsage?: jest.Mock;
   baseUrl?: string;
 }) {
   const jobLister = {
@@ -61,6 +67,13 @@ function makeService(overrides: {
   const photoToFlashcards = {
     generateCards,
   } as unknown as PhotoToFlashcardsUseCase;
+  const getCardUsage =
+    overrides.getCardUsage ?? jest.fn(async () => ({ cards_used: 0 }));
+  const incrementCardUsage = overrides.incrementCardUsage ?? jest.fn();
+  const usersRepository = {
+    getCardUsage,
+    incrementCardUsage,
+  } as unknown as UsersRepository;
   const service = new McpToolsService(
     jobLister,
     downloadService,
@@ -69,6 +82,7 @@ function makeService(overrides: {
     storage,
     deckPersistence,
     photoToFlashcards,
+    usersRepository,
     overrides.baseUrl ?? 'https://mcp.test'
   );
   return {
@@ -78,6 +92,8 @@ function makeService(overrides: {
     persist,
     getPresignedUrl,
     generateCards,
+    getCardUsage,
+    incrementCardUsage,
     previewService,
   };
 }
@@ -925,5 +941,166 @@ describe('McpToolsService.photoToDeck', () => {
     await expect(
       service.photoToDeck({ image: ONE_PIXEL_PNG_BASE64 }, 'o', {})
     ).rejects.toThrow(/Free plan is 5 photos per month/);
+  });
+});
+
+describe('McpToolsService.createDeck with subdecks', () => {
+  let workspaceBase: string;
+  let priorWorkspaceBase: string | undefined;
+  let priorSkip: string | undefined;
+
+  beforeAll(() => {
+    priorWorkspaceBase = process.env.WORKSPACE_BASE;
+    priorSkip = process.env.SKIP_CREATE_DECK;
+    workspaceBase = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-subdeck-'));
+    process.env.WORKSPACE_BASE = workspaceBase;
+    process.env.SKIP_CREATE_DECK = '1';
+  });
+
+  afterAll(() => {
+    if (priorWorkspaceBase == null) {
+      delete process.env.WORKSPACE_BASE;
+    } else {
+      process.env.WORKSPACE_BASE = priorWorkspaceBase;
+    }
+    if (priorSkip == null) {
+      delete process.env.SKIP_CREATE_DECK;
+    } else {
+      process.env.SKIP_CREATE_DECK = priorSkip;
+    }
+    fs.rmSync(workspaceBase, { recursive: true, force: true });
+  });
+
+  const subdeckCards = () => [
+    { front: 'ichi', back: '1', deck: 'Vocabulary' },
+    { front: 'taberu', back: 'to eat', deck: 'Grammar' },
+    { front: 'ni', back: '2', deck: 'Vocabulary' },
+  ];
+
+  it('builds one deck per composed subdeck name with the right per-deck card counts', async () => {
+    const { service, persist } = makeService({});
+    const result = await service.createDeck(
+      subdeckCards(),
+      'JLPT N5',
+      'owner-9',
+      {}
+    );
+
+    expect(persist).toHaveBeenCalledTimes(1);
+    const deckInfoBuffer = persist.mock.calls[0][3] as Buffer;
+    const decks = JSON.parse(deckInfoBuffer.toString('utf-8')) as {
+      name: string;
+      cards: unknown[];
+    }[];
+    const byName = new Map(decks.map((deck) => [deck.name, deck.cards.length]));
+    expect(byName.get('JLPT N5::Vocabulary')).toBe(2);
+    expect(byName.get('JLPT N5::Grammar')).toBe(1);
+    expect(byName.size).toBe(2);
+
+    expect(result).toMatchObject({
+      kind: 'deck',
+      cardCount: 3,
+      filename: 'JLPT N5.apkg',
+      summary: 'Deck ready: JLPT N5 — 3 cards across 2 subdecks.',
+      applied: {
+        subdecks: [
+          { deck: 'JLPT N5::Grammar', cards: 1 },
+          { deck: 'JLPT N5::Vocabulary', cards: 2 },
+        ],
+      },
+    });
+  });
+
+  it('increments card usage by the flat total across all subdecks', async () => {
+    const incrementCardUsage = jest.fn();
+    const { service } = makeService({ incrementCardUsage });
+    await service.createDeck(subdeckCards(), 'JLPT N5', 'owner-9', {});
+    expect(incrementCardUsage).toHaveBeenCalledWith('owner-9', 3);
+  });
+
+  it('blocks an over-limit free user with the limit error and does not package or bill', async () => {
+    const persist = jest.fn(async () => 'k');
+    const incrementCardUsage = jest.fn();
+    const getCardUsage = jest.fn(async () => ({ cards_used: 99 }));
+    const { service } = makeService({
+      persist,
+      incrementCardUsage,
+      getCardUsage,
+    });
+    const result = await service.createDeck(
+      subdeckCards(),
+      'JLPT N5',
+      'owner-9',
+      {}
+    );
+    expect(result).toEqual({
+      kind: 'error',
+      message: 'Could not convert this input.',
+    });
+    expect(persist).not.toHaveBeenCalled();
+    expect(incrementCardUsage).not.toHaveBeenCalled();
+  });
+
+  it('exempts a paying user from the monthly card limit', async () => {
+    const incrementCardUsage = jest.fn();
+    const getCardUsage = jest.fn(async () => ({ cards_used: 9999 }));
+    const { service, persist } = makeService({
+      incrementCardUsage,
+      getCardUsage,
+    });
+    const result = await service.createDeck(
+      subdeckCards(),
+      'JLPT N5',
+      'owner-9',
+      { subscriber: true }
+    );
+    expect(result).toMatchObject({ kind: 'deck', cardCount: 3 });
+    expect(getCardUsage).not.toHaveBeenCalled();
+    expect(persist).toHaveBeenCalledTimes(1);
+    expect(incrementCardUsage).toHaveBeenCalledWith('owner-9', 3);
+  });
+
+  it('keeps deckless cards in the bare parent bucket alongside subdecks', async () => {
+    const { service, persist } = makeService({});
+    await service.createDeck(
+      [
+        { front: 'intro', back: 'welcome' },
+        { front: 'ichi', back: '1', deck: 'Vocabulary' },
+      ],
+      'JLPT N5',
+      'owner-9',
+      {}
+    );
+    const deckInfoBuffer = persist.mock.calls[0][3] as Buffer;
+    const decks = JSON.parse(deckInfoBuffer.toString('utf-8')) as {
+      name: string;
+      cards: unknown[];
+    }[];
+    const byName = new Map(decks.map((deck) => [deck.name, deck.cards.length]));
+    expect(byName.get('JLPT N5')).toBe(1);
+    expect(byName.get('JLPT N5::Vocabulary')).toBe(1);
+  });
+
+  it('takes the flat path untouched when no card carries a deck', async () => {
+    let uploadedBody: Record<string, unknown> | undefined;
+    const entry: UploadEntrypoint = (req, res) => {
+      uploadedBody = (req as unknown as { body: Record<string, unknown> }).body;
+      res.set('X-Card-Count', '2');
+      res.set('File-Name', 'deck.apkg');
+      res.status(200).send(Buffer.from('APKG-BYTES'));
+    };
+    const { service, persist } = makeService({ uploadEntry: entry });
+    const result = await service.createDeck(
+      [
+        { front: 'a', back: 'b' },
+        { front: 'c', back: 'd' },
+      ],
+      'JLPT N5',
+      'owner-9',
+      {}
+    );
+    expect(uploadedBody).toEqual({ deckName: 'JLPT N5' });
+    expect((result as { applied?: unknown }).applied).toBeUndefined();
+    expect(persist).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/services/mcp/McpToolsService.ts
+++ b/src/services/mcp/McpToolsService.ts
@@ -3,13 +3,23 @@ import { randomUUID } from 'node:crypto';
 import imageSize from 'image-size';
 
 import { JobWithDownloadKey } from '../../data_layer/JobRepository';
+import UsersRepository from '../../data_layer/UsersRepository';
 import ApkgPreviewService from '../ApkgPreviewService/ApkgPreviewService';
 import DownloadService from '../DownloadService';
 import StorageHandler from '../../lib/storage/StorageHandler';
 import instrumentedAxios from '../observability/instrumentedAxios';
 import { getSafeFilename } from '../../lib/getSafeFilename';
+import getDeckFilename from '../../lib/anki/getDeckFilename';
+import Workspace from '../../lib/parser/WorkSpace';
+import CustomExporter from '../../lib/parser/exporters/CustomExporter';
+import {
+  CheckMonthlyCardLimitUseCase,
+  MonthlyLimitError,
+} from '../../usecases/users/CheckMonthlyCardLimitUseCase';
 import { DeckPersistence } from './McpDeckPersistence';
 import { McpCard, serializeCardsToMarkdown } from './serializeCardsToMarkdown';
+import { groupCardsBySubdeck, hasSubdecks } from './composeSubdecks';
+import { buildSubdeckDecks } from './buildSubdeckDecks';
 import {
   McpConvertOptions,
   mcpOptionsToCardSettings,
@@ -45,6 +55,9 @@ const NO_CARDS_FOUND_MESSAGE =
   'No cards found in this text. If you already have front/back pairs, call create_deck with them — it needs no special formatting. Otherwise mark up the text with one of these structures and call convert_to_deck again: `front :: back` on its own line, `<details><summary>front</summary>back</details>`, or a `## front` heading with the answer on the line below. Full grammar: deck_capabilities → inputFormats.';
 const EMPTY_BACK_MESSAGE =
   'Some cards have an empty back. Every card needs both a front and a back.';
+const GENERIC_CONVERT_ERROR = 'Could not convert this input.';
+const OVER_SIZE_MESSAGE =
+  'These cards are over the 5 MB limit. Split into smaller decks.';
 const NO_CARD_CODES = new Set(['markdown_likely_lossy', 'empty_export']);
 const ALLOWED_PHOTO_MEDIA_TYPES: VisionMediaType[] = [
   'image/jpeg',
@@ -122,6 +135,16 @@ function decodeFileNameHeader(raw: string | null): string | null {
   } catch {
     return raw;
   }
+}
+
+function subdeckSummary(
+  title: string,
+  cardCount: number,
+  deckCount: number
+): string {
+  const cardLabel = cardCount === 1 ? 'card' : 'cards';
+  const deckLabel = deckCount === 1 ? 'subdeck' : 'subdecks';
+  return `Deck ready: ${title} — ${cardCount} ${cardLabel} across ${deckCount} ${deckLabel}.`;
 }
 
 export interface DeckSummary {
@@ -260,6 +283,7 @@ export class McpToolsService {
     private readonly storage: StorageHandler,
     private readonly deckPersistence: DeckPersistence,
     private readonly photoToFlashcards: PhotoToFlashcardsUseCase,
+    private readonly usersRepository: UsersRepository,
     private readonly baseUrl: string = mcpBaseUrl()
   ) {}
 
@@ -423,14 +447,15 @@ export class McpToolsService {
       deckName != null && deckName.trim().length > 0
         ? deckName.trim()
         : DEFAULT_DECK_NAME;
+
+    if (hasSubdecks(cards)) {
+      return this.createSubdeckDeck(cards, title, owner, locals);
+    }
+
     const markdown = serializeCardsToMarkdown(cards);
     const buffer = Buffer.from(markdown, 'utf-8');
     if (buffer.byteLength > MAX_TEXT_BYTES) {
-      return {
-        kind: 'error',
-        message:
-          'These cards are over the 5 MB limit. Split into smaller decks.',
-      };
+      return { kind: 'error', message: OVER_SIZE_MESSAGE };
     }
 
     const file: UploadedFile = {
@@ -447,6 +472,65 @@ export class McpToolsService {
       return { ...result, message: EMPTY_BACK_MESSAGE };
     }
     return result;
+  }
+
+  private async createSubdeckDeck(
+    cards: McpCard[],
+    title: string,
+    owner: string,
+    locals: Record<string, unknown>
+  ): Promise<ConvertResult> {
+    const combined = serializeCardsToMarkdown(cards);
+    if (Buffer.byteLength(combined, 'utf-8') > MAX_TEXT_BYTES) {
+      return { kind: 'error', message: OVER_SIZE_MESSAGE };
+    }
+
+    const totalCards = cards.length;
+    try {
+      await new CheckMonthlyCardLimitUseCase(this.usersRepository).execute({
+        userId: owner,
+        candidateCardCount: totalCards,
+        isPaying: isPaying(locals),
+      });
+    } catch (error) {
+      if (error instanceof MonthlyLimitError) {
+        return { kind: 'error', message: GENERIC_CONVERT_ERROR };
+      }
+      throw error;
+    }
+
+    const groups = groupCardsBySubdeck(title, cards);
+    const workspace = new Workspace(true, 'fs');
+    const exporter = new CustomExporter(title, workspace.location);
+    exporter.configure(buildSubdeckDecks(groups));
+    const apkg = await exporter.save();
+
+    const filename = getDeckFilename(title);
+    const objectId = randomUUID();
+    await this.deckPersistence.persist(owner, objectId, filename, apkg);
+    await this.usersRepository.incrementCardUsage(owner, totalCards);
+
+    const preview = await this.previewFromBytes(apkg, `mcp:${objectId}`);
+    const subdecks = groups
+      .map((group) => ({ deck: group.deck, cards: group.cards.length }))
+      .sort((a, b) => a.deck.localeCompare(b.deck));
+    const applied: AppliedOptions = {
+      noteType: 'basic',
+      tags: [],
+      splitByHeadings: false,
+      tts: { enabled: false },
+      subdecks,
+    };
+    return {
+      kind: 'deck',
+      jobId: objectId,
+      cardCount: totalCards,
+      filename,
+      downloadUrl: `${this.baseUrl}/api/mcp/decks/${objectId}/download`,
+      ...preview,
+      applied,
+      summary: subdeckSummary(title, totalCards, subdecks.length),
+    };
   }
 
   private everyBackEmpty(cards: McpCard[]): boolean {
@@ -696,6 +780,6 @@ export class McpToolsService {
     ) {
       return (body as { message: string }).message;
     }
-    return 'Could not convert this input.';
+    return GENERIC_CONVERT_ERROR;
   }
 }

--- a/src/services/mcp/buildAppliedOptions.ts
+++ b/src/services/mcp/buildAppliedOptions.ts
@@ -11,6 +11,11 @@ export interface AppliedTts {
   side?: McpTtsSide;
 }
 
+export interface AppliedSubdeck {
+  deck: string;
+  cards: number;
+}
+
 export interface AppliedOptions {
   noteType: McpNoteType;
   tags: string[];
@@ -18,6 +23,7 @@ export interface AppliedOptions {
   splitByHeadings: boolean;
   styleTemplate?: McpStyleTemplate;
   tts: AppliedTts;
+  subdecks?: AppliedSubdeck[];
 }
 
 export interface IgnoredOption {

--- a/src/services/mcp/buildSubdeckDecks.ts
+++ b/src/services/mcp/buildSubdeckDecks.ts
@@ -1,0 +1,21 @@
+import Deck from '../../lib/parser/Deck';
+import CardOption from '../../lib/parser/Settings';
+import { guessMarkdownCards } from '../../lib/parser/guessMarkdownCards';
+import get16DigitRandomId from '../../shared/helpers/get16DigitRandomId';
+import { serializeCardsToMarkdown } from './serializeCardsToMarkdown';
+import { SubdeckGroup } from './composeSubdecks';
+
+function buildDeck(group: SubdeckGroup): Deck {
+  const markdown = serializeCardsToMarkdown(group.cards);
+  const heuristic = guessMarkdownCards(markdown);
+  const notes = heuristic?.notes ?? [];
+  for (const note of notes) {
+    note.media = [];
+  }
+  const settings = new CardOption({ deckName: group.deck });
+  return new Deck(group.deck, notes, '', '', get16DigitRandomId(), settings);
+}
+
+export function buildSubdeckDecks(groups: SubdeckGroup[]): Deck[] {
+  return groups.map(buildDeck);
+}

--- a/src/services/mcp/composeSubdecks.test.ts
+++ b/src/services/mcp/composeSubdecks.test.ts
@@ -1,0 +1,99 @@
+import {
+  composeDeckName,
+  groupCardsBySubdeck,
+  hasSubdecks,
+} from './composeSubdecks';
+
+describe('composeDeckName', () => {
+  it('nests a leaf name under the parent', () => {
+    expect(composeDeckName('JLPT N5', 'Vocabulary')).toBe(
+      'JLPT N5::Vocabulary'
+    );
+  });
+
+  it('keeps the card in the parent when no deck is given', () => {
+    expect(composeDeckName('JLPT N5', undefined)).toBe('JLPT N5');
+    expect(composeDeckName('JLPT N5', null)).toBe('JLPT N5');
+    expect(composeDeckName('JLPT N5', '   ')).toBe('JLPT N5');
+  });
+
+  it('nests deeper when the card deck itself carries ::', () => {
+    expect(composeDeckName('JLPT N5', 'Verbs::Irregular')).toBe(
+      'JLPT N5::Verbs::Irregular'
+    );
+  });
+
+  it('does not double-prefix when the card sent the full path (idempotence)', () => {
+    expect(composeDeckName('JLPT N5', 'JLPT N5::Vocabulary')).toBe(
+      'JLPT N5::Vocabulary'
+    );
+  });
+
+  it('uses the card deck as-is when it equals the parent', () => {
+    expect(composeDeckName('JLPT N5', 'JLPT N5')).toBe('JLPT N5');
+  });
+
+  it('never treats a card deck as absolute — a bare-prefix collision still nests', () => {
+    expect(composeDeckName('MS3::Pharmacology', 'MS3::PharmacologyExtra')).toBe(
+      'MS3::Pharmacology::MS3::PharmacologyExtra'
+    );
+  });
+});
+
+describe('hasSubdecks', () => {
+  it('is true when at least one card carries a non-empty deck', () => {
+    expect(
+      hasSubdecks([
+        { front: 'a', back: 'b' },
+        { front: 'c', back: 'd', deck: 'Vocabulary' },
+      ])
+    ).toBe(true);
+  });
+
+  it('is false when no card carries a deck', () => {
+    expect(
+      hasSubdecks([
+        { front: 'a', back: 'b' },
+        { front: 'c', back: 'd' },
+      ])
+    ).toBe(false);
+  });
+
+  it('is false when the only deck values are blank', () => {
+    expect(hasSubdecks([{ front: 'a', back: 'b', deck: '  ' }])).toBe(false);
+  });
+});
+
+describe('groupCardsBySubdeck', () => {
+  it('groups cards under composed deck names, preserving first-seen order', () => {
+    const groups = groupCardsBySubdeck('JLPT N5', [
+      { front: 'ichi', back: '1', deck: 'Vocabulary' },
+      { front: 'taberu', back: 'to eat', deck: 'Grammar' },
+      { front: 'ni', back: '2', deck: 'Vocabulary' },
+    ]);
+    expect(groups).toEqual([
+      {
+        deck: 'JLPT N5::Vocabulary',
+        cards: [
+          { front: 'ichi', back: '1' },
+          { front: 'ni', back: '2' },
+        ],
+      },
+      {
+        deck: 'JLPT N5::Grammar',
+        cards: [{ front: 'taberu', back: 'to eat' }],
+      },
+    ]);
+  });
+
+  it('puts deckless cards in the bare parent bucket', () => {
+    const groups = groupCardsBySubdeck('JLPT N5', [
+      { front: 'intro', back: 'welcome' },
+      { front: 'ichi', back: '1', deck: 'Vocabulary' },
+    ]);
+    expect(groups).toEqual([
+      { deck: 'JLPT N5', cards: [{ front: 'intro', back: 'welcome' }] },
+      { deck: 'JLPT N5::Vocabulary', cards: [{ front: 'ichi', back: '1' }] },
+    ]);
+  });
+});

--- a/src/services/mcp/composeSubdecks.ts
+++ b/src/services/mcp/composeSubdecks.ts
@@ -1,0 +1,55 @@
+import { sanitizeDeckPath } from '../../lib/ankify/transforms/tags';
+
+export interface CardWithDeck {
+  front: string;
+  back: string;
+  deck?: string;
+}
+
+export interface SubdeckGroup {
+  deck: string;
+  cards: { front: string; back: string }[];
+}
+
+export function composeDeckName(
+  parent: string,
+  cardDeck: string | undefined | null
+): string {
+  const parentPath = sanitizeDeckPath(parent);
+  if (cardDeck == null) {
+    return parentPath;
+  }
+  const leaf = sanitizeDeckPath(cardDeck);
+  if (leaf.length === 0) {
+    return parentPath;
+  }
+  if (leaf === parentPath || leaf.startsWith(`${parentPath}::`)) {
+    return leaf;
+  }
+  return sanitizeDeckPath(`${parentPath}::${leaf}`);
+}
+
+export function hasSubdecks(cards: CardWithDeck[]): boolean {
+  return cards.some(
+    (card) => typeof card.deck === 'string' && card.deck.trim().length > 0
+  );
+}
+
+export function groupCardsBySubdeck(
+  parent: string,
+  cards: CardWithDeck[]
+): SubdeckGroup[] {
+  const order: string[] = [];
+  const byDeck = new Map<string, { front: string; back: string }[]>();
+  for (const card of cards) {
+    const name = composeDeckName(parent, card.deck);
+    let bucket = byDeck.get(name);
+    if (bucket == null) {
+      bucket = [];
+      byDeck.set(name, bucket);
+      order.push(name);
+    }
+    bucket.push({ front: card.front, back: card.back });
+  }
+  return order.map((deck) => ({ deck, cards: byDeck.get(deck) ?? [] }));
+}

--- a/src/services/mcp/deckCapabilities.ts
+++ b/src/services/mcp/deckCapabilities.ts
@@ -163,6 +163,7 @@ export const DECK_CAPABILITIES: DeckCapabilities = {
   conventions: [
     'Cloze cards require {{c1::...}} markup in the text; without it, cloze falls back to basic.',
     'Deck names use :: to nest subdecks, e.g. Spanish::Verbs::Irregular.',
+    'create_deck sorts cards into subdecks with a per-card deck field: a leaf name relative to deckName. deck "Vocabulary" under deckName "JLPT N5" lands in JLPT N5::Vocabulary; use :: in deck to nest deeper (Verbs::Irregular); omit deck to keep the card in deckName.',
     'Only these curated options are honored; unknown keys are ignored and never bypass account limits.',
   ],
 };

--- a/src/services/mcp/serializeCardsToMarkdown.ts
+++ b/src/services/mcp/serializeCardsToMarkdown.ts
@@ -1,6 +1,7 @@
 export interface McpCard {
   front: string;
   back: string;
+  deck?: string;
 }
 
 function escapeDetailsTags(text: string): string {

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-20-mcp-create-deck-subdecks.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-20-mcp-create-deck-subdecks.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-20-mcp-create-deck-subdecks",
+  "date": "2026-07-20",
+  "type": "feature",
+  "title": "MCP create_deck sorts cards into subdecks — give each card a deck under the parent in one call"
+}


### PR DESCRIPTION
## What
Adds subdeck support to the MCP `create_deck` tool. Each card can carry an optional `deck` field — a leaf subdeck name relative to `deckName`. `deck: "Vocabulary"` under `deckName: "JLPT N5"` lands in `JLPT N5::Vocabulary`; `::` inside `deck` nests deeper (`Verbs::Irregular`); omit `deck` to keep the card in the parent. One `create_deck` call now builds a structured, multi-subdeck `.apkg`.

## Why
Callers (LLMs driving the MCP server) could only produce one flat deck per call. Structuring a study set into subdecks meant multiple calls and no single downloadable deck. This lets an agent sort cards into a `::` hierarchy in one shot.

## How — the contained packaging path (and why)
When ≥1 card carries a `deck`, `createDeck` takes a **contained packaging path**: it groups cards by composed `::` name, builds one `Deck` per group (reusing the exact serialize → `guessMarkdownCards` rendering the flat path uses, plus `CustomExporter` + `CardGenerator`), and packages a single `.apkg` in the service. The shared markdown parser (`guessMarkdownCards`/`DeckParser`) and `convert_to_deck` are **not** touched.

The tradeoff of this path is that it bypasses `uploadService.handleUpload`, which is where the flat path gets its account guardrails for free. So the contained path **re-invokes them explicitly**:
- **`CheckMonthlyCardLimitUseCase`** on the flat total card count across all subdecks, preserving the `isPaying` exemption. Over-limit returns the same error the flat path returns (`Could not convert this input.`, extracted to a shared `GENERIC_CONVERT_ERROR` constant so the parity is guaranteed by construction, not by a copied literal). Noted below as a weak message inherited from the flat path.
- **`incrementCardUsage`** by the flat total — losing this would be a billing/quota regression.
- `MAX_CARDS = 500` stays a flat total across the hierarchy (unchanged).

Composition reuses `sanitizeDeckPath` with an **idempotence guard**: if `deck` already equals the parent or starts with `parent::`, it is used as-is, so an LLM sending the full path instead of the leaf is not double-prefixed. `::` inside `deck` is never treated as absolute.

**Backward compatibility:** if NO card carries a `deck`, the existing flat path (serialize → upload pipeline) runs completely unchanged — same guardrails, same output, no `applied` block.

## The explicit guardrail test (the reason this path was chosen)
`McpToolsService.test.ts` › `createDeck with subdecks`:
- asserts `incrementCardUsage` is called with the correct flat total (3) across subdecks;
- asserts an over-limit free user gets the limit error and does **not** package or bill (`persist` and `incrementCardUsage` not called);
- asserts a paying user is exempt (`getCardUsage` not consulted, deck built);
- asserts the `Deck[]` handed to `CustomExporter` (the `deck_info.json`, captured via `SKIP_CREATE_DECK`) contains `JLPT N5::Vocabulary` (2 cards) and `JLPT N5::Grammar` (1 card), and that deckless cards land in the bare parent bucket.

## Response, capabilities, and metric
- `applied.subdecks: [{ deck, cards }]` echo, sorted by path ascending, present only on the subdeck path (includes the bare `deckName` bucket when some cards had no `deck`).
- `subdeckCount` prop added to the `mcp_tool_result` create event (distinct decks produced; 1 = flat, >1 = structured) so `/api/ops/metrics` can measure adoption.
- `deck_capabilities` gains a convention entry documenting the per-card `deck` field with the JLPT N5 example.
- Result summary: `Deck ready: JLPT N5 — 3 cards across 2 subdecks.` (VOICE: sentence case, no exclamation, `::` literal).

## Measuring success
`mcp_tool_result` events at `/api/ops/metrics` where `props.tool = 'create_deck'`: `props.subdeckCount > 1` counts structured builds, `= 1` counts flat. That ratio is the adoption signal, tracked in the T+30d review issue.

## Testing
- Unit tests added: `composeSubdecks.test.ts` (compose/idempotence/grouping), the `createDeck with subdecks` block in `McpToolsService.test.ts` (guardrails + `Deck[]`/`deck_info.json` shape), and `create_deck handler` metric tests in `McpServerFactory.test.ts`.
- `pnpm test src/services/mcp` green (145 tests); `npx tsc -p . --noEmit` clean (prod deploy typechecks tests); `pnpm format:check` clean tree-wide; web typecheck + WhatsNewPage vitest green.
- **E2E `.apkg` (genanki) test: intentionally NOT added to the Jest suite.** No test in this repo spawns real Python — every packaging test mocks `CardGenerator`/`child_process.spawn`, and the venv is absent in worktrees and not set up in the Jest CI shards, so a genanki-spawning test would fail CI, not pass it. The `deck_info.json`-level assertion (via `SKIP_CREATE_DECK`) covers the exact `CustomExporter` input; real `.apkg` packaging is verified by a manual run in the main checkout (which has the venv). The contained path mirrors `PrepareDeck`'s Claude branch, which already packages multi-deck `::` hierarchies this way in production.

## Browser check
Browser check: not applicable — MCP server-side + changelog JSON only, no `web/src` runtime touched.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-07-20-mcp-create-deck-subdecks.json` — "MCP create_deck sorts cards into subdecks — give each card a deck under the parent in one call".

## Risks
- The contained path is a second packaging code path; the mandatory guardrail test locks in that quota/limit accounting fires. If a future pipeline guardrail is added to `handleUpload`, it must also be added here.
- Over-limit returns the flat path's generic `Could not convert this input.` message (weak, but identical to the flat path by design). Improving both paths' over-limit messaging is a possible follow-up, out of scope here.
- Rollback: revert the branch; the flat path is untouched, so create_deck without a `deck` field is unaffected.

## Surface lifecycle
T+30d adoption-review issue: https://github.com/2anki/server/issues/3770 (keep-or-remove on the `subdeckCount > 1` signal). Usage event (`mcp_tool_result` with `subdeckCount`) ships in this PR.

## Goal alignment
Internal-facing capability on the MCP surface (developer_access limited beta), so no direct acquisition-funnel metric. It makes the "drop something in, get a clean deck back" mission better for agent callers by producing a structured deck in one call. Adoption is measured via `subdeckCount` at `/api/ops/metrics`, reviewed at T+30d. Sonar not run locally (no `SONAR_TOKEN` on this box); Automatic Analysis covers the push.
