### PR TITLE
fix: stop abandoned-checkout emails to lifetime and subscribed users

### DIFF
--- a/src/data_layer/AbandonedCheckoutRecoveryRepository.ts
+++ b/src/data_layer/AbandonedCheckoutRecoveryRepository.ts
@@ -19,6 +19,8 @@ export interface IAbandonedCheckoutRecoveryRepository {
   ): Promise<boolean>;
   recordEmailSend(userEmail: string, token: string): Promise<void>;
   isMarketingOptedOut(userEmail: string): Promise<boolean>;
+  hasLifetimeOrActiveSubscription(userEmail: string): Promise<boolean>;
+  hasSendSince(userEmail: string, since: Date): Promise<boolean>;
   getRecoveryByToken(token: string): Promise<CheckoutRecoveryLookup | null>;
 }
 
@@ -72,6 +74,31 @@ export class AbandonedCheckoutRecoveryRepository implements IAbandonedCheckoutRe
     return row != null;
   }
 
+  async hasLifetimeOrActiveSubscription(userEmail: string): Promise<boolean> {
+    const lifetimeUser = await this.database('users')
+      .where('email', userEmail)
+      .where('patreon', true)
+      .first();
+    if (lifetimeUser != null) {
+      return true;
+    }
+    const activeSubscription = await this.database('subscriptions')
+      .where('active', true)
+      .where(function () {
+        this.where('email', userEmail).orWhere('linked_email', userEmail);
+      })
+      .first();
+    return activeSubscription != null;
+  }
+
+  async hasSendSince(userEmail: string, since: Date): Promise<boolean> {
+    const row = await this.database<AbandonedCheckoutRecoveryRow>(this.table)
+      .where('user_email', userEmail)
+      .where('sent_at', '>', since)
+      .first();
+    return row != null;
+  }
+
   async getRecoveryByToken(
     token: string
   ): Promise<CheckoutRecoveryLookup | null> {
@@ -94,6 +121,8 @@ export class AbandonedCheckoutRecoveryRepository implements IAbandonedCheckoutRe
 export class InMemoryAbandonedCheckoutRecoveryRepository implements IAbandonedCheckoutRecoveryRepository {
   private readonly claimed = new Set<string>();
   private readonly optedOut = new Set<string>();
+  private readonly payingEmails = new Set<string>();
+  private readonly lastSendByEmail = new Map<string, Date>();
   private readonly tokensByEmail = new Map<string, string>();
   private readonly tokensBySessionId = new Map<string, string>();
   private readonly recoveryByToken = new Map<string, CheckoutRecoveryLookup>();
@@ -128,6 +157,15 @@ export class InMemoryAbandonedCheckoutRecoveryRepository implements IAbandonedCh
     return this.optedOut.has(userEmail);
   }
 
+  async hasLifetimeOrActiveSubscription(userEmail: string): Promise<boolean> {
+    return this.payingEmails.has(userEmail);
+  }
+
+  async hasSendSince(userEmail: string, since: Date): Promise<boolean> {
+    const lastSend = this.lastSendByEmail.get(userEmail);
+    return lastSend != null && lastSend > since;
+  }
+
   async getRecoveryByToken(
     token: string
   ): Promise<CheckoutRecoveryLookup | null> {
@@ -136,6 +174,14 @@ export class InMemoryAbandonedCheckoutRecoveryRepository implements IAbandonedCh
 
   seedOptedOut(userEmail: string): void {
     this.optedOut.add(userEmail);
+  }
+
+  seedPaying(userEmail: string): void {
+    this.payingEmails.add(userEmail);
+  }
+
+  seedSendAt(userEmail: string, sentAt: Date): void {
+    this.lastSendByEmail.set(userEmail, sentAt);
   }
 
   getClaimedSessions(): ReadonlySet<string> {
@@ -153,6 +199,8 @@ export class InMemoryAbandonedCheckoutRecoveryRepository implements IAbandonedCh
   clear(): void {
     this.claimed.clear();
     this.optedOut.clear();
+    this.payingEmails.clear();
+    this.lastSendByEmail.clear();
     this.tokensByEmail.clear();
     this.tokensBySessionId.clear();
     this.recoveryByToken.clear();

--- a/src/routes/WebhookRouter.test.ts
+++ b/src/routes/WebhookRouter.test.ts
@@ -34,11 +34,15 @@ jest.mock('../data_layer', () => ({ getDatabase: jest.fn() }));
 
 const mockClaimSession = jest.fn().mockResolvedValue(true);
 const mockIsMarketingOptedOut = jest.fn().mockResolvedValue(false);
+const mockHasLifetimeOrActiveSubscription = jest.fn().mockResolvedValue(false);
+const mockHasSendSince = jest.fn().mockResolvedValue(false);
 jest.mock('../data_layer/AbandonedCheckoutRecoveryRepository', () => ({
   __esModule: true,
   default: jest.fn().mockImplementation(() => ({
     claimSession: mockClaimSession,
     isMarketingOptedOut: mockIsMarketingOptedOut,
+    hasLifetimeOrActiveSubscription: mockHasLifetimeOrActiveSubscription,
+    hasSendSince: mockHasSendSince,
   })),
 }));
 

--- a/src/usecases/ops/SendAbandonedCheckoutRecoveryOnExpiryUseCase.test.ts
+++ b/src/usecases/ops/SendAbandonedCheckoutRecoveryOnExpiryUseCase.test.ts
@@ -11,12 +11,16 @@ function makeEventsSink(): jest.Mocked<Pick<EventsSink, 'record'>> {
 
 function makeRepo(
   claimed = true,
-  optedOut = false
+  optedOut = false,
+  alreadyPaying = false,
+  recentlySent = false
 ): jest.Mocked<IAbandonedCheckoutRecoveryRepository> {
   return {
     claimSession: jest.fn().mockResolvedValue(claimed),
     recordEmailSend: jest.fn().mockResolvedValue(undefined),
     isMarketingOptedOut: jest.fn().mockResolvedValue(optedOut),
+    hasLifetimeOrActiveSubscription: jest.fn().mockResolvedValue(alreadyPaying),
+    hasSendSince: jest.fn().mockResolvedValue(recentlySent),
     getRecoveryByToken: jest.fn().mockResolvedValue(null),
   };
 }
@@ -206,6 +210,72 @@ describe('SendAbandonedCheckoutRecoveryOnExpiryUseCase', () => {
     ).not.toHaveBeenCalled();
   });
 
+  it('does not send when the recipient has lifetime or an active subscription', async () => {
+    const repo = makeRepo(true, false, true);
+    const emailService = makeEmailService();
+    const eventsSink = makeEventsSink();
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+    const useCase = new SendAbandonedCheckoutRecoveryOnExpiryUseCase(
+      repo,
+      emailService,
+      eventsSink
+    );
+
+    await useCase.execute('cs_lifetime', 'lifetime@example.com');
+
+    expect(repo.hasLifetimeOrActiveSubscription).toHaveBeenCalledWith(
+      'lifetime@example.com'
+    );
+    expect(repo.claimSession).not.toHaveBeenCalled();
+    expect(
+      emailService.sendAbandonedCheckoutRecoveryEmail
+    ).not.toHaveBeenCalled();
+    expect(eventsSink.record).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledWith(
+      'checkout.session.expired.already_paying',
+      { session_id_hash: 'hashed:cs_lifetime' }
+    );
+    infoSpy.mockRestore();
+  });
+
+  it('does not send when a recovery email already went to the address recently', async () => {
+    const repo = makeRepo(true, false, false, true);
+    const emailService = makeEmailService();
+    const eventsSink = makeEventsSink();
+    const useCase = new SendAbandonedCheckoutRecoveryOnExpiryUseCase(
+      repo,
+      emailService,
+      eventsSink
+    );
+
+    await useCase.execute('cs_second_session', 'alice@example.com');
+
+    expect(repo.claimSession).not.toHaveBeenCalled();
+    expect(
+      emailService.sendAbandonedCheckoutRecoveryEmail
+    ).not.toHaveBeenCalled();
+    expect(eventsSink.record).not.toHaveBeenCalled();
+  });
+
+  it('checks recent sends against a cutoff 7 days back', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-07-20T12:00:00Z'));
+    const repo = makeRepo(true);
+    const emailService = makeEmailService();
+    const useCase = new SendAbandonedCheckoutRecoveryOnExpiryUseCase(
+      repo,
+      emailService
+    );
+
+    await useCase.execute('cs_window', 'alice@example.com');
+
+    expect(repo.hasSendSince).toHaveBeenCalledWith(
+      'alice@example.com',
+      new Date('2026-07-13T12:00:00Z')
+    );
+    jest.useRealTimers();
+  });
+
   it('skips with warn log when email is missing', async () => {
     const repo = makeRepo(true);
     const emailService = makeEmailService();
@@ -236,6 +306,8 @@ describe('SendAbandonedCheckoutRecoveryOnExpiryUseCase', () => {
       }),
       recordEmailSend: jest.fn().mockResolvedValue(undefined),
       isMarketingOptedOut: jest.fn().mockResolvedValue(false),
+      hasLifetimeOrActiveSubscription: jest.fn().mockResolvedValue(false),
+      hasSendSince: jest.fn().mockResolvedValue(false),
       getRecoveryByToken: jest.fn().mockResolvedValue(null),
     };
     const emailService = makeEmailService();

--- a/src/usecases/ops/SendAbandonedCheckoutRecoveryOnExpiryUseCase.ts
+++ b/src/usecases/ops/SendAbandonedCheckoutRecoveryOnExpiryUseCase.ts
@@ -6,6 +6,8 @@ import type {
 import type { IEmailService } from '../../services/EmailService/EmailService';
 import type { EventsSink } from '../../services/events/EventsSink';
 
+const RECENT_SEND_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
 export class SendAbandonedCheckoutRecoveryOnExpiryUseCase {
   constructor(
     private readonly repository: IAbandonedCheckoutRecoveryRepository,
@@ -33,6 +35,24 @@ export class SendAbandonedCheckoutRecoveryOnExpiryUseCase {
     const optedOut = await this.repository.isMarketingOptedOut(email);
     if (optedOut) {
       console.info('checkout.session.expired.opted_out', {
+        session_id_hash: hashToken(sessionId),
+      });
+      return;
+    }
+
+    const alreadyPaying =
+      await this.repository.hasLifetimeOrActiveSubscription(email);
+    if (alreadyPaying) {
+      console.info('checkout.session.expired.already_paying', {
+        session_id_hash: hashToken(sessionId),
+      });
+      return;
+    }
+
+    const cutoff = new Date(Date.now() - RECENT_SEND_WINDOW_MS);
+    const recentlySent = await this.repository.hasSendSince(email, cutoff);
+    if (recentlySent) {
+      console.info('checkout.session.expired.recently_sent', {
         session_id_hash: hashToken(sessionId),
       });
       return;

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-20-checkout-reminder-skip.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-20-checkout-reminder-skip.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-20-checkout-reminder-skip",
+  "date": "2026-07-20",
+  "type": "fix",
+  "title": "Checkout reminder emails skip lifetime members and active subscribers, and arrive at most once a week"
+}


### PR DESCRIPTION
## Why

A lifetime (patreon) user received two "Schließe dein 2anki-Unlimited-Abo ab" recovery emails today. The `checkout.session.expired` → `SendAbandonedCheckoutRecoveryOnExpiryUseCase` path checked only `marketing_opt_out` — no lifetime/subscription gate — and deduped per `session_id`, so two expired sessions meant two emails.

## What

- `SendAbandonedCheckoutRecoveryOnExpiryUseCase` now skips when the recipient has `users.patreon = true` or an active `subscriptions` row (`email` or `linked_email` match) — the same predicate `InactivityEmailRepository` already uses for other marketing sends.
- Adds a 7-day per-email window: at most one recovery email per address per week, regardless of how many checkout sessions expire.
- New repository methods `hasLifetimeOrActiveSubscription` / `hasSendSince` (query-builder only, no raw SQL). `sent_at` already defaults to `now()`, so existing rows feed the window — no migration.

Deliberately not excluded: active pass holders. A pass user who starts a subscription checkout is a legitimate upsell; the bug was emailing people who already have what checkout would sell them.

## Construction sites checked

`SendAbandonedCheckoutRecoveryOnExpiryUseCase` is constructed once (`src/routes/WebhookRouter.ts`); the repository is also consumed by `ResumeAbandonedCheckoutUseCase`/`ResumeCheckoutController` (untouched read path, tests green).

## Tests

- Lifetime/subscribed recipient → no claim, no send, no event
- Recent send to same address → no send
- Cutoff is exactly 7 days (fake timers)
- Full affected suites: 82 passed; `tsc -p . --noEmit` clean; `pnpm format:check` clean

Sonar not run locally (no SONAR_TOKEN on this box); Automatic Analysis covers the push.

Changelog entry included (`2026-07-20-checkout-reminder-skip.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
