### PR TITLE
fix: stop browsers serving stale cached ops dashboard data

### DIFF
--- a/src/routes/OpsRouter.test.ts
+++ b/src/routes/OpsRouter.test.ts
@@ -280,6 +280,28 @@ describe('OpsRouter /api/ops/business/metrics', () => {
     }
   });
 
+  it('sets Cache-Control no-store on ops endpoints so browsers never serve stale dashboard data', async () => {
+    const { url, close } = await startServer(true);
+    try {
+      const response = await fetch(`${url}/api/ops/performance/metrics`);
+      expect(response.headers.get('cache-control')).toBe('no-store');
+    } finally {
+      await close();
+    }
+  });
+
+  it('lets business metrics keep its deliberate day-long cache header', async () => {
+    const { url, close } = await startServer(true);
+    try {
+      const response = await fetch(`${url}/api/ops/business/metrics`);
+      expect(response.headers.get('cache-control')).toBe(
+        'private, max-age=86400'
+      );
+    } finally {
+      await close();
+    }
+  });
+
   it('returns 200 with the business metrics shape for the ops owner', async () => {
     const { url, close } = await startServer(true);
     try {

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -75,6 +75,10 @@ import { ReconcileOrphanedSubscriptionsUseCase } from '../usecases/ops/Reconcile
 
 const OpsRouter = () => {
   const router = express.Router();
+  router.use('/api/ops', (_req, res, next) => {
+    res.set('Cache-Control', 'no-store');
+    next();
+  });
   const database = getDatabase();
   const repo = new ObservabilityRepository(database);
   const queryService = new ObservabilityQueryService(

--- a/web/src/pages/OpsPage/usePerformanceMetrics.test.ts
+++ b/web/src/pages/OpsPage/usePerformanceMetrics.test.ts
@@ -50,6 +50,25 @@ describe('usePerformanceMetrics', () => {
     expect(result.current.data).toEqual(payload);
   });
 
+  test('bypasses the browser HTTP cache on every request', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => '{}',
+    });
+
+    const { result } = renderHook(() => usePerformanceMetrics(), {
+      wrapper: wrap(noRetryClient()),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/ops/performance/metrics',
+      expect.objectContaining({ cache: 'no-store' })
+    );
+  });
+
   test('surfaces a clean error when a 200 has an empty body', async () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,

--- a/web/src/pages/OpsPage/usePerformanceMetrics.ts
+++ b/web/src/pages/OpsPage/usePerformanceMetrics.ts
@@ -8,6 +8,7 @@ const fetchPerformanceMetrics =
   async (): Promise<PerformanceMetricsResponse> => {
     const response = await fetch('/api/ops/performance/metrics', {
       credentials: 'include',
+      cache: 'no-store',
     });
     if (!response.ok) {
       throw new Error(`${response.status} ${response.statusText}`);


### PR DESCRIPTION
## Why

The ops performance tab showed `/api/ops/performance/metrics failed: empty response body` with stale data. Apache access logs proved the browser had not sent that request since Jul 14 while every other ops endpoint was fetched normally the same minute — Safari was serving the fetch from its HTTP cache, including a poisoned empty 200. Ops API responses carried no `Cache-Control` at all, leaving cache behavior to browser heuristics.

## What

- `OpsRouter` sets `Cache-Control: no-store` on everything under `/api/ops`.
- `getBusinessMetrics` keeps its deliberate `private, max-age=86400` (controller sets it after the middleware, so the override is explicit and now pinned by a test).
- `usePerformanceMetrics` fetches with `cache: 'no-store'` — request-level bypass, needed because a browser holding a poisoned entry may never revisit the network to learn the new response header.

## Tests

- Router test: `/api/ops/performance/metrics` response carries `no-store`; business metrics keeps its day-long header.
- Hook test: fetch is called with `cache: 'no-store'`.
- `tsc -p . --noEmit` clean, `pnpm format:check` clean, OpsRouter suite 24/24, hook suite 5/5.

No changelog entry — internal ops dashboard, no user-visible behavior change.

Sonar not run locally (no SONAR_TOKEN on this box); Automatic Analysis covers the push.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: machine-backed via `pnpm --filter 2anki-web test:golden-path` (2 passed); change is ops-owner-only fetch/header behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
