### PR TITLE
fix: show Developers sidebar entry to every signed-in user

### DIFF
--- a/web/src/components/AppShell/Sidebar.test.tsx
+++ b/web/src/components/AppShell/Sidebar.test.tsx
@@ -202,6 +202,31 @@ describe('Sidebar help group', () => {
   });
 });
 
+describe('Sidebar developers entry', () => {
+  it('shows Developers for a free logged-in user so they can request access', () => {
+    renderSidebar();
+    expect(screen.getByRole('link', { name: 'Developers' })).toHaveAttribute(
+      'href',
+      '/developers'
+    );
+  });
+
+  it('shows Developers for lifetime users', () => {
+    renderSidebar({ patreon: true });
+    expect(screen.getByRole('link', { name: 'Developers' })).toHaveAttribute(
+      'href',
+      '/developers'
+    );
+  });
+
+  it('hides Developers for unauthenticated visitors', () => {
+    renderSidebar({ locals: null });
+    expect(
+      screen.queryByRole('link', { name: 'Developers' })
+    ).not.toBeInTheDocument();
+  });
+});
+
 describe('Sidebar admin group', () => {
   it('hides the admin group when no flags are on', () => {
     renderSidebar();

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -225,10 +225,9 @@ export function Sidebar({
   const logoSrc = getLogoSrc(collapsed, theme);
   const showAnkify =
     locals?.patreon === true || locals?.autoSyncActive === true;
-  const showDevelopers =
-    locals?.patreon === true || locals?.developer_access === true;
-  const showFavorites = email != null && email !== '';
   const isLoggedIn = locals != null;
+  const showDevelopers = isLoggedIn;
+  const showFavorites = email != null && email !== '';
   const paying = isPayingUser(locals);
   const showPricing = !paying;
   const showKi = features?.kiUI === true;

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-21-developers-sidebar.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-21-developers-sidebar.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-21-developers-sidebar",
+  "date": "2026-07-21",
+  "type": "fix",
+  "title": "Developers section visible to every signed-in account — request API and connector access from the sidebar"
+}


### PR DESCRIPTION
## Why

Free users had no way to request developer/MCP access: the sidebar hid the Developers entry unless the account was lifetime or already granted, while `DevelopersPage` itself renders a "Request access" flow for exactly those users. The MCP beta's request door was invisible to the people it was built for. Surfaced during the #3727 beta-exit audit.

## What

- Sidebar shows Developers for every signed-in account (hidden for unauthenticated visitors).
- The page's existing two-state rendering (request flow vs key management) is unchanged.

## Tests

- New: Developers visible for free logged-in user, visible for lifetime, hidden logged-out. Sidebar suite 59/59.
- `nav.developers` label verified present in all 10 locales.
- Web typecheck + tree-wide `pnpm format:check` clean.

Part of #3727 (beta-exit blocker 1).

Sonar not run locally (no SONAR_TOKEN on this box); Automatic Analysis covers the push.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: machine-backed via `pnpm --filter 2anki-web test:golden-path` (2 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
