### PR TITLE
docs: guide for connecting 2anki to Claude or ChatGPT via MCP

### DIFF
--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -54,6 +54,14 @@ minutes. No exports, no manual steps. $30/month.
 - Cloze deletion support from Notion toggle nesting.
 - Images and audio embed directly in cards.
 
+## MCP connector (use 2anki inside AI assistants)
+
+2anki runs a hosted MCP server at https://2anki.net/mcp (OAuth 2.1, streamable
+HTTP). Connect it to Claude or ChatGPT to turn conversation text or photos into
+downloadable Anki decks — tools cover convert, create with subdecks, photo to
+deck, preview, and deck listing. Setup guide:
+https://2anki.net/documentation/start-here/use-in-claude
+
 ## Canonical URLs
 
 - Homepage: https://2anki.net

--- a/web/src/pages/DocsPage/content-links.test.ts
+++ b/web/src/pages/DocsPage/content-links.test.ts
@@ -19,6 +19,7 @@ const KNOWN_APP_PREFIXES = [
   '/card-options',
   '/print',
   '/status',
+  '/developers',
 ];
 
 const LINK_RE = /(?<!!)\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;

--- a/web/src/pages/DocsPage/content/start-here/use-in-claude.md
+++ b/web/src/pages/DocsPage/content/start-here/use-in-claude.md
@@ -1,0 +1,74 @@
+---
+title: Use 2anki inside Claude or ChatGPT
+description: Connect the 2anki MCP server and build Anki decks straight from a conversation.
+---
+
+2anki runs as an MCP connector, so an AI assistant can build your Anki decks for you. Paste lecture notes into a conversation, ask for flashcards, and get a download link for a ready `.apkg` — without leaving the chat.
+
+**Connector access is in limited beta.** Sign in at [2anki.net](https://2anki.net/), open **Developers** in the sidebar, and click **Request access**. You'll get an email when your account is enabled. Lifetime accounts have access already.
+
+## Connect to Claude
+
+<ol class="steps">
+<li>
+
+**Open connector settings.** In Claude (web or desktop), go to **Settings → Connectors** and choose **Add custom connector**.
+
+</li>
+<li>
+
+**Add the 2anki server.** Enter `https://2anki.net/mcp` as the URL and confirm.
+
+</li>
+<li>
+
+**Sign in.** Claude opens a 2anki sign-in and consent screen. Approve it once; the connection persists across conversations.
+
+</li>
+<li>
+
+**Use it.** In any conversation, ask Claude to make flashcards — "turn these notes into an Anki deck". Claude calls 2anki and replies with a download link for the `.apkg`.
+
+</li>
+</ol>
+
+## Connect to ChatGPT
+
+<ol class="steps">
+<li>
+
+**Enable developer mode.** In ChatGPT, go to **Settings → Apps & Connectors → Advanced settings** and turn on **Developer mode** (requires a paid ChatGPT plan).
+
+</li>
+<li>
+
+**Create the connector.** Under **Apps & Connectors**, choose **Create**, enter `https://2anki.net/mcp` as the MCP server URL, and pick **OAuth** as the authentication method.
+
+</li>
+<li>
+
+**Sign in.** ChatGPT opens the 2anki sign-in and consent screen. Approve it once.
+
+</li>
+<li>
+
+**Use it.** Start a message, add the 2anki connector from the composer's tools menu, and ask for a deck.
+
+</li>
+</ol>
+
+## What the assistant can do
+
+- Turn pasted text, notes, or a document summary into a finished deck with a download link
+- Convert a photo of handwritten notes, a textbook page, or a slide into cards
+- Choose note types (Basic, reversed, cloze) and card options, including subdecks
+- Preview a deck's cards before you download
+- List the decks you've already created
+
+Free accounts keep their normal monthly card limit; paid plans convert without limits — the same [plans and limits](/documentation/reference/plans) as the web app.
+
+## If something fails
+
+- "MCP access is in limited beta" means your account isn't enabled yet — request access from the [Developers page](/developers).
+- If the connection stops working, remove the connector and add it again to re-run the sign-in.
+- Anything else: email [support@2anki.net](mailto:support@2anki.net).

--- a/web/src/pages/DocsPage/sidebar.ts
+++ b/web/src/pages/DocsPage/sidebar.ts
@@ -25,6 +25,10 @@ export const sidebar: SidebarGroup[] = [
         slug: 'start-here/import-from-anki',
       },
       { label: 'Share a deck with a link', slug: 'start-here/share-a-deck' },
+      {
+        label: 'Use 2anki inside Claude or ChatGPT',
+        slug: 'start-here/use-in-claude',
+      },
     ],
   },
   {

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-21-claude-chatgpt-guide.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-21-claude-chatgpt-guide.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-21-claude-chatgpt-guide",
+  "date": "2026-07-21",
+  "type": "feature",
+  "title": "Docs — step-by-step guide for connecting 2anki to Claude or ChatGPT"
+}


### PR DESCRIPTION
## Why

The hosted MCP connector (#3726–#3771) shipped with no user-facing setup path: nothing tells users the server exists, where it lives, or how to add it to Claude or ChatGPT. Two #3686 distribution items (docs + llms.txt mention) close here; part of the #3727 beta-exit plan.

## What

- New docs page `start-here/use-in-claude`: connect steps for Claude (Settings → Connectors → custom connector) and ChatGPT (developer mode → MCP server + OAuth), what the tools can do, limits note, beta access-request note, troubleshooting.
- Registered in the docs sidebar under Start here.
- `llms.txt` gains an MCP section (server URL, capabilities, guide link) so assistants can discover the connector.
- Link-integrity test allowlist gains `/developers` (a real app route, `src/routes/knownRoutes.ts`).

The beta-access wording gets replaced when the self-service gate design lands (#3727).

## Tests

- DocsPage suites 63/63 (link-integrity test validates the new page's links).
- Web typecheck + tree-wide `pnpm format:check` clean.

Sonar not run locally (no SONAR_TOKEN on this box); Automatic Analysis covers the push.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: machine-backed via `pnpm --filter 2anki-web test:golden-path` (2 passed); content-only docs addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
