### PR TITLE
fix: cc the owner on support notification emails

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -48,3 +48,4 @@ export const CREATE_DECK_SCRIPT_PATH = path.join(
 );
 
 export const SUPPORT_EMAIL_ADDRESS = 'support@2anki.net';
+export const SUPPORT_CC_ADDRESS = 'alexander@alemayhu.com';

--- a/src/services/EmailService/EmailService.test.ts
+++ b/src/services/EmailService/EmailService.test.ts
@@ -250,3 +250,60 @@ describe('EmailService conversion emails name the deck and count', () => {
     expect(msg.html).toContain('12 450 cards');
   });
 });
+
+describe('EmailService support notifications cc the owner', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SENDGRID_API_KEY = 'test-key';
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  function lastMessage() {
+    const calls = send.mock.calls;
+    return calls[calls.length - 1][0] as {
+      to: string;
+      cc?: string;
+      replyTo?: string;
+    };
+  }
+
+  it('ccs the owner on developer access requests', async () => {
+    const service = getDefaultEmailService();
+
+    await service.sendDeveloperAccessRequestEmail(
+      '21770',
+      'user@example.com',
+      'free'
+    );
+
+    const msg = lastMessage();
+    expect(msg.to).toBe('support@2anki.net');
+    expect(msg.cc).toBe('alexander@alemayhu.com');
+    expect(msg.replyTo).toBe('user@example.com');
+  });
+
+  it('ccs the owner on Auto Sync access requests', async () => {
+    const service = getDefaultEmailService();
+
+    await service.sendHostedAnkiAccessRequestEmail('21770', 'user@example.com');
+
+    const msg = lastMessage();
+    expect(msg.to).toBe('support@2anki.net');
+    expect(msg.cc).toBe('alexander@alemayhu.com');
+  });
+
+  it('ccs the owner on contact form submissions', async () => {
+    const service = getDefaultEmailService();
+
+    await service.sendContactEmail('Ada', 'user@example.com', 'Hello', []);
+
+    const msg = lastMessage();
+    expect(msg.to).toBe('support@2anki.net');
+    expect(msg.cc).toBe('alexander@alemayhu.com');
+  });
+});

--- a/src/services/EmailService/EmailService.ts
+++ b/src/services/EmailService/EmailService.ts
@@ -25,7 +25,7 @@ import {
 import { isValidDeckName, addDeckNameSuffix } from '../../lib/anki/format';
 import { escapeHtml } from '../../lib/notion-render/escape';
 import { ClientResponse } from '@sendgrid/mail';
-import { SUPPORT_EMAIL_ADDRESS } from '../../lib/constants';
+import { SUPPORT_CC_ADDRESS, SUPPORT_EMAIL_ADDRESS } from '../../lib/constants';
 import { emailHash } from '../../lib/emailHash';
 import { getDatabase } from '../../data_layer';
 import { sendWithRetry } from './sendWithRetry';
@@ -323,6 +323,7 @@ export class EmailService implements IEmailService {
   ): Promise<EmailResponse> {
     const msg = {
       to: SUPPORT_EMAIL_ADDRESS,
+      cc: SUPPORT_CC_ADDRESS,
       from: DEFAULT_SENDER,
       replyTo: email,
       subject: `Contact form submission on behalf of ${
@@ -351,6 +352,7 @@ export class EmailService implements IEmailService {
   ): Promise<EmailResponse> {
     const msg = {
       to: SUPPORT_EMAIL_ADDRESS,
+      cc: SUPPORT_CC_ADDRESS,
       from: DEFAULT_SENDER,
       subject: 'Auto Sync access request',
       text: `User ${userId} <${userEmail}> requested access to Auto Sync.`,
@@ -372,6 +374,7 @@ export class EmailService implements IEmailService {
   ): Promise<EmailResponse> {
     const msg = {
       to: SUPPORT_EMAIL_ADDRESS,
+      cc: SUPPORT_CC_ADDRESS,
       from: DEFAULT_SENDER,
       subject: 'Developer API access request',
       text: `User ${userId} <${userEmail}> (${payingStatus}) requested access to the Developers API.`,


### PR DESCRIPTION
## Why

A developer-access request made from a free test account (2026-07-21) returned 202 and SendGrid accepted the send, but nothing arrived in the support inbox — when support@ delivery fails downstream (spam/forwarding), the request is invisible and the requester waits forever.

## What

All three support-notification sends — contact form, Auto Sync access request, developer access request — now `cc` the owner address (`SUPPORT_CC_ADDRESS` in `lib/constants.ts`), so a dropped support@ delivery still reaches a human.

## Tests

Three new EmailService tests assert the cc on each send. Suite 15/15; all EmailService suites 72/72; `tsc` + `pnpm format:check` clean.

No changelog entry — internal notification plumbing, no user-visible behavior change.

Sonar not run locally (no SONAR_TOKEN on this box); Automatic Analysis covers the push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
