### PR TITLE
style: redesign the Developers page as a working dev hub

### DIFF
--- a/web/src/pages/DevelopersPage/DevelopersPage.module.css
+++ b/web/src/pages/DevelopersPage/DevelopersPage.module.css
@@ -6,6 +6,291 @@
   gap: 1.5rem;
 }
 
+.layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 16rem;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.main {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  min-width: 0;
+}
+
+@media (max-width: 56rem) {
+  .layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.rail {
+  position: sticky;
+  top: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  background: var(--color-bg-secondary);
+}
+
+.railHeading {
+  color: var(--color-text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.75rem;
+}
+
+.railList {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.railRow {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.4rem 0;
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.railRow:last-child {
+  border-bottom: none;
+}
+
+.railLabel {
+  color: var(--color-text-tertiary);
+  white-space: nowrap;
+}
+
+.railValue {
+  margin: 0;
+  color: var(--color-text-primary);
+  text-align: right;
+  overflow-wrap: anywhere;
+  font-variant-numeric: tabular-nums;
+}
+
+.railLink {
+  color: var(--color-text-link);
+  text-decoration: none;
+}
+
+.railLink:hover {
+  text-decoration: underline;
+}
+
+.railStatus {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+  color: var(--color-text-secondary);
+}
+
+.railStatusDot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: var(--radius-full);
+  background: var(--color-warning);
+  flex-shrink: 0;
+}
+
+.steps {
+  list-style: none;
+  counter-reset: step;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.step {
+  counter-increment: step;
+  display: grid;
+  grid-template-columns: 1.75rem minmax(0, 1fr);
+  gap: 0.25rem 0.75rem;
+}
+
+.step::before {
+  content: counter(step, decimal-leading-zero);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  padding-top: 0.2rem;
+}
+
+.stepLabel {
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+  font-size: var(--text-sm);
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.step::before {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.stepBody {
+  grid-column: 2;
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+}
+
+.step > :global(div) {
+  grid-column: 2;
+}
+
+.terminal {
+  grid-column: 2;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-tertiary);
+  overflow: hidden;
+}
+
+.terminalTabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.terminalTab,
+.terminalTabActive {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  padding: 0.4rem 0.75rem;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+}
+
+.terminalTabActive {
+  color: var(--color-text-primary);
+  border-bottom-color: var(--color-primary);
+}
+
+.terminalTab:hover {
+  color: var(--color-text-primary);
+}
+
+.terminalLine {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.terminalPrompt {
+  font-family: var(--font-mono);
+  color: var(--color-text-tertiary);
+  font-size: var(--text-sm);
+}
+
+.terminalCommand {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  flex: 1;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.terminalLink {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-text-link);
+}
+
+.terminalNote {
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  line-height: 1.5;
+  flex-basis: 100%;
+}
+
+.terminalNote code {
+  font-family: var(--font-mono);
+  overflow-wrap: anywhere;
+}
+
+.copyButton {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  padding: 0.25rem 0.6rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-primary);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+}
+
+.copyButton:hover {
+  color: var(--color-text-primary);
+  border-color: var(--color-text-tertiary);
+}
+
+.inlineCode {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  background: var(--color-bg-tertiary);
+  border-radius: var(--radius-sm);
+  padding: 0.1rem 0.35rem;
+}
+
+.urlRow {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-secondary);
+  padding: 0.6rem 0.75rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.urlLabel {
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  white-space: nowrap;
+}
+
+.urlValue {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  flex: 1;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.contactNote {
+  margin-top: 1rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--color-border-light);
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+}
+
+.contactNote a {
+  color: var(--color-text-link);
+}
+
 .title {
   font-size: var(--text-2xl);
   font-weight: var(--font-semibold);

--- a/web/src/pages/DevelopersPage/DevelopersPage.test.tsx
+++ b/web/src/pages/DevelopersPage/DevelopersPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { describe, expect, test, vi, beforeEach } from 'vitest';
 import { HelmetProvider } from 'react-helmet-async';
@@ -48,7 +48,6 @@ describe('DevelopersPage', () => {
       'href',
       '/api/docs'
     );
-    expect(screen.getByText('Download the CLI')).toBeInTheDocument();
     expect(screen.getByText('Convert a file into a deck')).toBeInTheDocument();
   });
 
@@ -63,7 +62,7 @@ describe('DevelopersPage', () => {
     );
   });
 
-  test('shows the locked request-access state for a non-access account', () => {
+  test('shows the request-access card for a non-access account', () => {
     useUserLocals.mockReturnValue({
       data: { locals: { patreon: false, developer_access: false } },
       isLoading: false,
@@ -71,5 +70,70 @@ describe('DevelopersPage', () => {
     renderPage();
     expect(screen.getByText('Request access')).toBeInTheDocument();
     expect(screen.queryByText('Create key')).not.toBeInTheDocument();
+  });
+
+  test('install strip and MCP card are visible without access', () => {
+    useUserLocals.mockReturnValue({
+      data: { locals: { patreon: false, developer_access: false } },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByText('npx @2anki/cli login')).toBeInTheDocument();
+    expect(screen.getAllByText('https://2anki.net/mcp').length).toBeGreaterThan(
+      0
+    );
+    expect(screen.getByText('How to connect')).toHaveAttribute(
+      'href',
+      '/documentation/start-here/use-in-claude'
+    );
+  });
+
+  test('switching the package manager tab swaps the install command', () => {
+    useUserLocals.mockReturnValue({
+      data: { locals: { patreon: true } },
+      isLoading: false,
+    });
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: 'pnpm' }));
+    expect(screen.getByText('pnpm add -g @2anki/cli')).toBeInTheDocument();
+    expect(screen.queryByText('npx @2anki/cli login')).not.toBeInTheDocument();
+  });
+
+  test('binary tab links to the GitHub releases page', () => {
+    useUserLocals.mockReturnValue({
+      data: { locals: { patreon: true } },
+      isLoading: false,
+    });
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: 'binary' }));
+    expect(screen.getByText('Download the CLI')).toHaveAttribute(
+      'href',
+      'https://github.com/2anki/server/releases/latest'
+    );
+  });
+
+  test('invites contact when a use case is not covered', () => {
+    useUserLocals.mockReturnValue({
+      data: { locals: { patreon: true } },
+      isLoading: false,
+    });
+    renderPage();
+    const mailLinks = screen.getAllByRole('link', {
+      name: 'support@2anki.net',
+    });
+    expect(mailLinks[0]).toHaveAttribute('href', 'mailto:support@2anki.net');
+    expect(
+      screen.getByRole('link', { name: 'Open a GitHub issue' })
+    ).toHaveAttribute('href', 'https://github.com/2anki/server/issues');
+  });
+
+  test('spec rail lists the API base and MCP server', () => {
+    useUserLocals.mockReturnValue({
+      data: { locals: { patreon: true } },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByText('https://2anki.net/api')).toBeInTheDocument();
+    expect(screen.getByLabelText('Connection facts')).toBeInTheDocument();
   });
 });

--- a/web/src/pages/DevelopersPage/DevelopersPage.tsx
+++ b/web/src/pages/DevelopersPage/DevelopersPage.tsx
@@ -12,13 +12,151 @@ import {
 import sharedStyles from '../../styles/shared.module.css';
 import styles from './DevelopersPage.module.css';
 
+const MCP_SERVER_URL = 'https://2anki.net/mcp';
+const API_BASE_URL = 'https://2anki.net/api';
+const CLI_RELEASES_URL = 'https://github.com/2anki/server/releases/latest';
+const CLI_NPM_URL = 'https://www.npmjs.com/package/@2anki/cli';
+const GITHUB_ISSUES_URL = 'https://github.com/2anki/server/issues';
+const CONNECT_GUIDE_PATH = '/documentation/start-here/use-in-claude';
+
 function formatLastUsed(value: string | null): string {
   if (value == null) return 'Never used';
   const date = new Date(value);
   return `Used ${date.toLocaleDateString()}`;
 }
 
-function LockedState() {
+function CopyButton({
+  text,
+  label,
+}: Readonly<{ text: string; label: string }>) {
+  const [copied, setCopied] = useState(false);
+  const copy = () => {
+    void navigator.clipboard?.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+  return (
+    <button
+      type="button"
+      className={styles.copyButton}
+      onClick={copy}
+      aria-label={label}
+    >
+      {copied ? 'Copied' : 'Copy'}
+    </button>
+  );
+}
+
+const INSTALL_TABS = [
+  { id: 'npx', command: 'npx @2anki/cli login' },
+  { id: 'npm', command: 'npm install -g @2anki/cli' },
+  { id: 'pnpm', command: 'pnpm add -g @2anki/cli' },
+  { id: 'binary', command: null },
+] as const;
+
+type InstallTabId = (typeof INSTALL_TABS)[number]['id'];
+
+function InstallStrip() {
+  const [active, setActive] = useState<InstallTabId>('npx');
+  const tab = INSTALL_TABS.find((t) => t.id === active) ?? INSTALL_TABS[0];
+
+  return (
+    <div className={styles.terminal}>
+      <div
+        className={styles.terminalTabs}
+        role="group"
+        aria-label="Install method"
+      >
+        {INSTALL_TABS.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            className={
+              t.id === active ? styles.terminalTabActive : styles.terminalTab
+            }
+            aria-pressed={t.id === active}
+            onClick={() => setActive(t.id)}
+          >
+            {t.id}
+          </button>
+        ))}
+      </div>
+      {tab.command != null ? (
+        <div className={styles.terminalLine}>
+          <span className={styles.terminalPrompt} aria-hidden="true">
+            $
+          </span>
+          <code className={styles.terminalCommand}>{tab.command}</code>
+          <CopyButton text={tab.command} label={`Copy ${tab.id} command`} />
+        </div>
+      ) : (
+        <div className={styles.terminalLine}>
+          <a
+            className={styles.terminalLink}
+            href={CLI_RELEASES_URL}
+            target="_blank"
+            rel="noreferrer"
+          >
+            Download the CLI
+          </a>
+          <span className={styles.terminalNote}>
+            macOS, Linux, and Windows binaries. On macOS, clear quarantine once:{' '}
+            <code>xattr -d com.apple.quarantine ./2anki-macos-arm64</code>
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function GetStarted() {
+  return (
+    <section className={sharedStyles.sectionCard}>
+      <h2 className={styles.cardTitle}>Get started</h2>
+      <ol className={styles.steps}>
+        <li className={styles.step}>
+          <span className={styles.stepLabel}>Create an API key</span>
+          <span className={styles.stepBody}>
+            Below, under API keys. The key is shown once.
+          </span>
+        </li>
+        <li className={styles.step}>
+          <span className={styles.stepLabel}>Install the CLI and sign in</span>
+          <InstallStrip />
+        </li>
+        <li className={styles.step}>
+          <span className={styles.stepLabel}>Convert</span>
+          <span className={styles.stepBody}>
+            <code className={styles.inlineCode}>2anki convert notes.md</code>{' '}
+            builds an Anki deck from your file and prints the download path.
+          </span>
+        </li>
+      </ol>
+    </section>
+  );
+}
+
+function McpCard() {
+  return (
+    <section className={sharedStyles.sectionCard}>
+      <h2 className={styles.cardTitle}>Use 2anki in Claude or ChatGPT</h2>
+      <p className={styles.body}>
+        Add 2anki as a connector and build decks straight from a conversation.
+        During the beta, connector access follows your developer access.
+      </p>
+      <div className={styles.urlRow}>
+        <span className={styles.urlLabel}>Connector URL</span>
+        <code className={styles.urlValue}>{MCP_SERVER_URL}</code>
+        <CopyButton text={MCP_SERVER_URL} label="Copy connector URL" />
+      </div>
+      <a className={sharedStyles.btnSecondary} href={CONNECT_GUIDE_PATH}>
+        How to connect
+      </a>
+    </section>
+  );
+}
+
+function RequestAccessCard() {
   const [status, setStatus] = useState<'idle' | 'sending' | 'sent' | 'error'>(
     'idle'
   );
@@ -39,10 +177,9 @@ function LockedState() {
     <section className={sharedStyles.sectionCard}>
       <h2 className={styles.cardTitle}>Developer access</h2>
       <p className={styles.body}>
-        The developer API and CLI are under development and invite-only. Use an
-        API key to convert from your own tools — a script, a cron job, or an MCP
-        client. Access is open to lifetime accounts; everyone else can request
-        it.
+        API keys and the connector are in a limited beta. Lifetime accounts have
+        access already; everyone else can request it and accounts are enabled by
+        email.
       </p>
       {status === 'sent' ? (
         <p className={styles.noticeSuccess}>
@@ -155,9 +292,8 @@ function KeyManager() {
     <section className={sharedStyles.sectionCard}>
       <h2 className={styles.cardTitle}>API keys</h2>
       <p className={styles.body}>
-        Use an API key to convert from your own tools — a script, a cron job, or
-        an MCP client. Keep it secret; anyone with the key can convert on your
-        account.
+        Send the key as a bearer token. Keep it secret; anyone with the key can
+        convert on your account.
       </p>
 
       <div className={styles.createRow}>
@@ -231,16 +367,16 @@ const RELEVANT_ENDPOINTS = [
   { method: 'GET', path: '/api/apkg/:key/cards', label: 'Rendered cards' },
 ];
 
-const CLI_RELEASES_URL = 'https://github.com/2anki/server/releases/latest';
-
 function ApiGuide() {
   return (
     <section className={sharedStyles.sectionCard}>
       <h2 className={styles.cardTitle}>Using the API</h2>
       <p className={styles.body}>
         Send your key as a bearer token:{' '}
-        <code>Authorization: Bearer sk_live_…</code>. These are the endpoints a
-        converter client needs.
+        <code className={styles.inlineCode}>
+          Authorization: Bearer sk_live_…
+        </code>
+        . These are the endpoints a converter client needs.
       </p>
       <ul className={styles.endpointList}>
         {RELEVANT_ENDPOINTS.map((endpoint) => (
@@ -253,20 +389,93 @@ function ApiGuide() {
           </li>
         ))}
       </ul>
-      <div className={styles.linkRow}>
-        <a className={sharedStyles.btnSecondary} href="/api/docs">
-          Full API docs
+      <a className={sharedStyles.btnSecondary} href="/api/docs">
+        Full API docs
+      </a>
+      <p className={styles.contactNote}>
+        Use case not covered, or need more access? Email{' '}
+        <a href="mailto:support@2anki.net">support@2anki.net</a> — every message
+        is read, and access is widened for real projects. Found a bug?{' '}
+        <a href={GITHUB_ISSUES_URL} target="_blank" rel="noreferrer">
+          Open a GitHub issue
         </a>
-        <a
-          className={sharedStyles.btnSecondary}
-          href={CLI_RELEASES_URL}
-          target="_blank"
-          rel="noreferrer"
-        >
-          Download the CLI
-        </a>
-      </div>
+        .
+      </p>
     </section>
+  );
+}
+
+const RAIL_FACTS: Array<{
+  label: string;
+  value: string;
+  href?: string;
+  external?: boolean;
+}> = [
+  { label: 'API base', value: API_BASE_URL },
+  { label: 'Auth', value: 'Bearer sk_live_…' },
+  { label: 'MCP server', value: MCP_SERVER_URL },
+  {
+    label: 'CLI',
+    value: '@2anki/cli',
+    href: CLI_NPM_URL,
+    external: true,
+  },
+  {
+    label: 'Binaries',
+    value: 'github releases',
+    href: CLI_RELEASES_URL,
+    external: true,
+  },
+  { label: 'API docs', value: '/api/docs', href: '/api/docs' },
+  {
+    label: 'Connect guide',
+    value: 'use-in-claude',
+    href: CONNECT_GUIDE_PATH,
+  },
+  {
+    label: 'Bug reports',
+    value: 'github issues',
+    href: GITHUB_ISSUES_URL,
+    external: true,
+  },
+  {
+    label: 'Support',
+    value: 'support@2anki.net',
+    href: 'mailto:support@2anki.net',
+  },
+];
+
+function SpecRail() {
+  return (
+    <aside className={styles.rail} aria-label="Connection facts">
+      <div className={styles.railHeading}>Reference</div>
+      <dl className={styles.railList}>
+        {RAIL_FACTS.map((fact) => (
+          <div key={fact.label} className={styles.railRow}>
+            <dt className={styles.railLabel}>{fact.label}</dt>
+            <dd className={styles.railValue}>
+              {fact.href != null ? (
+                <a
+                  className={styles.railLink}
+                  href={fact.href}
+                  {...(fact.external === true
+                    ? { target: '_blank', rel: 'noreferrer' }
+                    : {})}
+                >
+                  {fact.value}
+                </a>
+              ) : (
+                fact.value
+              )}
+            </dd>
+          </div>
+        ))}
+      </dl>
+      <div className={styles.railStatus}>
+        <span className={styles.railStatusDot} aria-hidden="true" />
+        API and connector in limited beta
+      </div>
+    </aside>
   );
 }
 
@@ -283,19 +492,24 @@ export default function DevelopersPage() {
       <header className={sharedStyles.pageHeader}>
         <h1 className={styles.title}>Developers</h1>
         <p className={styles.body}>
-          Convert with the 2anki API from your own tools. Under development.
+          Convert from your own tools — a script, the CLI, or an AI assistant.
         </p>
       </header>
-      {isLoading ? (
-        <p className={styles.body}>Loading</p>
-      ) : hasAccess ? (
-        <>
-          <KeyManager />
+      <div className={styles.layout}>
+        <main className={styles.main}>
+          <GetStarted />
+          <McpCard />
+          {isLoading ? (
+            <p className={styles.body}>Loading</p>
+          ) : hasAccess ? (
+            <KeyManager />
+          ) : (
+            <RequestAccessCard />
+          )}
           <ApiGuide />
-        </>
-      ) : (
-        <LockedState />
-      )}
+        </main>
+        <SpecRail />
+      </div>
     </div>
   );
 }

--- a/web/src/pages/DocsPage/content/reference/api.md
+++ b/web/src/pages/DocsPage/content/reference/api.md
@@ -1,22 +1,50 @@
 ---
 title: API access
-description: Status of the 2anki.net HTTP API and how to request early access
+description: The 2anki.net HTTP API — keys, endpoints, and the CLI.
 ---
 
-The 2anki.net HTTP API is under heavy development. **It is not open to the public yet.** Endpoints, payloads, and authentication are all subject to change without notice, so please treat the API as **private** for now.
+The 2anki.net HTTP API is in a **limited beta**. Endpoints and payloads can still change between releases, but API keys, bearer authentication, and the core conversion endpoints are live and used by the [2anki CLI](https://www.npmjs.com/package/@2anki/cli).
 
-We plan to open it up once the surface has stabilised and we're confident we can support external integrations without breaking them.
+## Access
 
-## Reference
+Keys are managed on the [Developers page](/developers). Lifetime accounts have access already; everyone else can request it from the same page and accounts are enabled by email.
 
-The current (unstable) OpenAPI reference lives at [`/api/docs`](/api/docs) — a live Swagger UI generated from the running server. Everything there is considered internal until this page says otherwise, and may change between releases.
+Send your key as a bearer token on every request:
 
-## Early access
+```
+Authorization: Bearer sk_live_…
+```
 
-If you have a concrete use case you'd like to build against, you can request early access by emailing [support@2anki.net](mailto:support@2anki.net) with:
+Keep the key secret. Anyone holding it can convert on your account, against your plan's limits.
 
-- Who you are and what you're building
-- The endpoints or capabilities you need
-- Your expected request volume
+## Endpoints
 
-Early access is granted **at our discretion** and may be revoked while we iterate on the design. Approved users will receive credentials directly and updates as the API evolves.
+The endpoints a converter client needs:
+
+| Method | Path                   | What it does                    |
+| ------ | ---------------------- | ------------------------------- |
+| POST   | `/api/upload/file`     | Convert a file into a deck      |
+| GET    | `/api/upload/jobs`     | Check conversion status         |
+| GET    | `/api/apkg/:key/meta`  | Deck preview — counts and decks |
+| GET    | `/api/apkg/:key/cards` | Rendered cards                  |
+
+The full OpenAPI reference lives at [`/api/docs`](/api/docs) — a live Swagger UI generated from the running server. Anything not listed above should be treated as internal and may change without notice.
+
+## The CLI
+
+The [2anki CLI](https://www.npmjs.com/package/@2anki/cli) is the quickest way to use the API:
+
+```
+npx @2anki/cli login
+2anki convert notes.md
+```
+
+Prebuilt binaries for macOS, Linux, and Windows are on the [releases page](https://github.com/2anki/server/releases/latest).
+
+## Assistants
+
+To use 2anki from Claude or ChatGPT instead of your own code, see the [MCP connector](/documentation/reference/mcp).
+
+## Feedback
+
+Use case not covered, or need more volume? Email [support@2anki.net](mailto:support@2anki.net) with what you're building — access is widened for real projects. Bugs go to [GitHub issues](https://github.com/2anki/server/issues).

--- a/web/src/pages/DocsPage/content/reference/mcp.md
+++ b/web/src/pages/DocsPage/content/reference/mcp.md
@@ -1,0 +1,33 @@
+---
+title: MCP connector
+description: The hosted 2anki MCP server — tools, limits, and how it authenticates.
+---
+
+2anki runs a hosted MCP (Model Context Protocol) server, so AI assistants can build Anki decks on your account. Connect it once and ask for flashcards from inside a conversation — the assistant calls 2anki and returns a download link for a ready `.apkg`.
+
+**Server URL:** `https://2anki.net/mcp`
+
+For step-by-step connection instructions for Claude and ChatGPT, see [Use 2anki inside Claude or ChatGPT](/documentation/start-here/use-in-claude). Connector access is in a limited beta — request it from the [Developers page](/developers).
+
+## Tools
+
+| Tool                | What it does                                                                     |
+| ------------------- | -------------------------------------------------------------------------------- |
+| `convert_to_deck`   | Turn text, Markdown, or a URL into a finished deck                               |
+| `create_deck`       | Build a deck from structured cards — supports subdecks via a per-card deck field |
+| `photo_to_deck`     | Turn a photo of notes, a textbook page, or a slide into cards                    |
+| `get_deck_preview`  | Show a deck's cards before downloading                                           |
+| `list_my_decks`     | List the decks on your account                                                   |
+| `deck_capabilities` | Discover available note types and card options                                   |
+
+## Authentication
+
+The server uses OAuth 2.1. The first time an assistant connects, 2anki opens a sign-in and consent screen; approve it once and the connection persists. Revoke it any time by removing the connector in the assistant's settings.
+
+## Limits
+
+Conversions through MCP count against the same plan limits as the web app: free accounts have a monthly card limit and a photo quota; paid plans convert without limits. Individual requests are capped at 5 MB of text, 500 cards per deck, and 10 MB per photo.
+
+## Feedback
+
+Something the tools can't do? Email [support@2anki.net](mailto:support@2anki.net). Bugs go to [GitHub issues](https://github.com/2anki/server/issues).

--- a/web/src/pages/DocsPage/sidebar.ts
+++ b/web/src/pages/DocsPage/sidebar.ts
@@ -90,6 +90,7 @@ export const sidebar: SidebarGroup[] = [
       { label: 'Print or export to PDF', slug: 'reference/print-export' },
       { label: 'Self-hosting', slug: 'reference/self-hosting' },
       { label: 'API access', slug: 'reference/api' },
+      { label: 'MCP connector', slug: 'reference/mcp' },
       { label: 'Privacy policy', slug: 'reference/privacy' },
       { label: 'Terms of service', slug: 'reference/terms' },
     ],

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-21-developers-redesign.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-21-developers-redesign.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-21-developers-redesign",
+  "date": "2026-07-21",
+  "type": "style",
+  "title": "Developers page — install the CLI, connect Claude or ChatGPT, and manage API keys in one place"
+}


### PR DESCRIPTION
## Why

The Developers page was a single locked card for most users: no CLI install story (a bare releases link), no MCP mention, and nothing visible until access was granted. The API reference doc still called the entire API private. Requested as part of making the developer/MCP surface self-service-ready (#3727, #3686).

## What

**Page (Swiss Panel DNA — main work column + right-hand mono spec rail):**
- Get started: numbered 1-2-3 (create key → install → convert) with a package-manager install strip — npx / npm / pnpm / binary tabs, copy-to-clipboard, real published commands (`@2anki/cli@0.1.6` verified on npm).
- MCP connector card: server URL with copy button + link to the connect guide.
- API keys: existing manager unchanged in behavior; request-access card redesigned for non-granted accounts.
- Endpoint reference + contact note: email for uncovered use cases / more access, GitHub issues for bugs.
- Spec rail: API base, auth shape, MCP URL, CLI links, docs, bug reports, support — tabular mono, sticky, beta status line.
- Install strip, MCP card, and endpoints now render for every signed-in user; only key management stays behind the beta gate.

**Docs:**
- `reference/api` rewritten: beta-with-keys reality (keys on /developers, bearer auth, endpoint table, CLI, MCP cross-link) instead of "treat as private".
- New `reference/mcp`: connector URL, 6 tools, OAuth 2.1, limits; registered in the docs sidebar.

Trio context: designer direction from the #3727 synthesis (Connect-card reframe); copy per VOICE.md. Strings hardcoded English matching the existing page (dev surface; i18n pass deferred deliberately).

Metric: developer-access requests + `mcp_tool_called` growth after the connector guide became reachable; read at the #3727 T+30 review.

## Tests

- DevelopersPage suite rewritten: 8 tests (gate states, tab switching, binary link, MCP visibility, contact links, spec rail). 71/71 across DevelopersPage + DocsPage suites.
- Web typecheck, tree-wide `pnpm format:check` clean.

Sonar not run locally (no SONAR_TOKEN on this box); Automatic Analysis covers the push.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: machine-backed via `pnpm --filter 2anki-web test:golden-path` (2 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
