### PR TITLE
fix: rate-limit public MCP OAuth endpoints

### DIFF
--- a/src/routes/McpRouter.ts
+++ b/src/routes/McpRouter.ts
@@ -36,6 +36,7 @@ const McpRouter = () => {
   const database = getDatabase();
   const issuerUrl = resolveIssuerUrl();
   const resourceUrl = new URL('/mcp', issuerUrl);
+  const consentSecret = process.env.SECRET ?? '';
 
   const usersRepository = new UsersRepository(database);
   const authService = new AuthenticationService(
@@ -53,7 +54,7 @@ const McpRouter = () => {
       resourceUrl,
       loginPath: '/login',
       authorizePath: MCP_AUTHORIZE_PATH,
-      consentSecret: process.env.SECRET ?? '',
+      consentSecret,
     },
   });
 
@@ -149,6 +150,7 @@ const McpRouter = () => {
     issuerUrl,
     resourceUrl,
     onAuthenticatedPost,
+    consentSecret,
   });
 };
 

--- a/src/routes/mcp/createMcpRouter.test.ts
+++ b/src/routes/mcp/createMcpRouter.test.ts
@@ -4,7 +4,9 @@ import type { AddressInfo } from 'node:net';
 import type { OAuthServerProvider } from '@modelcontextprotocol/sdk/server/auth/provider.js';
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 
-import { createMcpRouter } from './createMcpRouter';
+import { InMemoryRateLimiter } from '../../lib/rateLimit/InMemoryRateLimiter';
+
+import { createMcpRouter, McpRouterDeps } from './createMcpRouter';
 
 const RESOURCE = 'https://2anki.net/mcp';
 
@@ -49,7 +51,8 @@ async function withServer(
   onPost: express.RequestHandler = (_req, res) => {
     res.json({ ok: true });
   },
-  mountExtra?: (app: express.Express) => void
+  mountExtra?: (app: express.Express) => void,
+  depsOverride?: Partial<McpRouterDeps>
 ): Promise<void> {
   const app = express();
   app.use(express.json());
@@ -59,6 +62,8 @@ async function withServer(
       issuerUrl: new URL('https://2anki.net'),
       resourceUrl: new URL(RESOURCE),
       onAuthenticatedPost: onPost,
+      consentSecret: 'test-secret',
+      ...depsOverride,
     })
   );
   if (mountExtra) {
@@ -189,5 +194,102 @@ describe('McpRouter endpoint namespacing (no /register collision)', () => {
       });
       expect(resource.status).toBe(401);
     });
+  });
+});
+
+function registerBody() {
+  return JSON.stringify({ redirect_uris: ['https://claude.ai/callback'] });
+}
+
+describe('McpRouter registration rate limiting', () => {
+  it('registers a client while under the per-IP cap', async () => {
+    const limiter = new InMemoryRateLimiter({
+      windowMs: 60_000,
+      perKeyMax: 2,
+      globalMax: 100,
+    });
+    await withServer(
+      async (base) => {
+        for (let i = 0; i < 2; i += 1) {
+          const res = await fetch(`${base}/mcp/register`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: registerBody(),
+          });
+          expect(res.status).toBe(201);
+        }
+      },
+      undefined,
+      undefined,
+      { rateLimiters: { register: limiter } }
+    );
+  });
+
+  it('returns 429 with a rate_limited body once the per-IP cap is exceeded', async () => {
+    const limiter = new InMemoryRateLimiter({
+      windowMs: 60_000,
+      perKeyMax: 2,
+      globalMax: 100,
+    });
+    await withServer(
+      async (base) => {
+        for (let i = 0; i < 2; i += 1) {
+          await fetch(`${base}/mcp/register`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: registerBody(),
+          });
+        }
+        const blocked = await fetch(`${base}/mcp/register`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: registerBody(),
+        });
+        expect(blocked.status).toBe(429);
+        const body = (await blocked.json()) as {
+          error?: string;
+          error_description?: string;
+        };
+        expect(body.error).toBe('rate_limited');
+        expect(typeof body.error_description).toBe('string');
+      },
+      undefined,
+      undefined,
+      { rateLimiters: { register: limiter } }
+    );
+  });
+});
+
+describe('McpRouter consent-secret boot assertion', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('throws when the consent secret is empty in production', () => {
+    process.env.NODE_ENV = 'production';
+    expect(() =>
+      createMcpRouter({
+        provider: fakeProvider(),
+        issuerUrl: new URL('https://2anki.net'),
+        resourceUrl: new URL(RESOURCE),
+        onAuthenticatedPost: (_req, res) => res.json({ ok: true }),
+        consentSecret: '',
+      })
+    ).toThrow();
+  });
+
+  it('does not throw for an empty consent secret outside production', () => {
+    process.env.NODE_ENV = 'development';
+    expect(() =>
+      createMcpRouter({
+        provider: fakeProvider(),
+        issuerUrl: new URL('https://2anki.net'),
+        resourceUrl: new URL(RESOURCE),
+        onAuthenticatedPost: (_req, res) => res.json({ ok: true }),
+        consentSecret: '',
+      })
+    ).not.toThrow();
   });
 });

--- a/src/routes/mcp/createMcpRouter.ts
+++ b/src/routes/mcp/createMcpRouter.ts
@@ -11,21 +11,91 @@ import { revocationHandler } from '@modelcontextprotocol/sdk/server/auth/handler
 import { requireBearerAuth } from '@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js';
 import type { OAuthServerProvider } from '@modelcontextprotocol/sdk/server/auth/provider.js';
 
+import {
+  InMemoryRateLimiter,
+  RateLimiter,
+} from '../../lib/rateLimit/InMemoryRateLimiter';
+import { hashIp, resolveClientIp } from '../../lib/rateLimit/ipHelpers';
+
 export const MCP_AUTHORIZE_PATH = '/mcp/authorize';
 export const MCP_TOKEN_PATH = '/mcp/token';
 export const MCP_REGISTER_PATH = '/mcp/register';
 export const MCP_REVOKE_PATH = '/mcp/revoke';
+
+const HOUR_MS = 60 * 60 * 1000;
+const MINUTE_MS = 60 * 1000;
+
+const REGISTER_PER_IP_MAX = 10;
+const REGISTER_GLOBAL_MAX = 500;
+const AUTHORIZE_PER_IP_MAX = 30;
+const AUTHORIZE_GLOBAL_MAX = 3000;
+const TOKEN_PER_IP_MAX = 60;
+const TOKEN_GLOBAL_MAX = 6000;
+
+export interface McpRateLimiters {
+  register: RateLimiter;
+  authorize: RateLimiter;
+  token: RateLimiter;
+}
 
 export interface McpRouterDeps {
   provider: OAuthServerProvider;
   issuerUrl: URL;
   resourceUrl: URL;
   onAuthenticatedPost: RequestHandler;
+  consentSecret: string;
+  rateLimiters?: Partial<McpRateLimiters>;
+}
+
+function rateLimit(limiter: RateLimiter): RequestHandler {
+  return (req, res, next) => {
+    if (limiter.check(hashIp(resolveClientIp(req)))) {
+      next();
+      return;
+    }
+    res.set('Retry-After', '60');
+    res.status(429).json({
+      error: 'rate_limited',
+      error_description:
+        'Too many requests from this network. Wait a moment and try again.',
+    });
+  };
 }
 
 export function createMcpRouter(deps: McpRouterDeps): express.Router {
+  if (
+    process.env.NODE_ENV === 'production' &&
+    deps.consentSecret.length === 0
+  ) {
+    throw new Error(
+      'MCP consent secret is empty in production. Set process.env.SECRET.'
+    );
+  }
+
   const router = express.Router();
   const { provider, issuerUrl, resourceUrl } = deps;
+
+  const registerLimiter =
+    deps.rateLimiters?.register ??
+    new InMemoryRateLimiter({
+      windowMs: HOUR_MS,
+      perKeyMax: REGISTER_PER_IP_MAX,
+      globalMax: REGISTER_GLOBAL_MAX,
+    });
+  const authorizeLimiter =
+    deps.rateLimiters?.authorize ??
+    new InMemoryRateLimiter({
+      windowMs: MINUTE_MS,
+      perKeyMax: AUTHORIZE_PER_IP_MAX,
+      globalMax: AUTHORIZE_GLOBAL_MAX,
+    });
+  const tokenLimiter =
+    deps.rateLimiters?.token ??
+    new InMemoryRateLimiter({
+      windowMs: MINUTE_MS,
+      perKeyMax: TOKEN_PER_IP_MAX,
+      globalMax: TOKEN_GLOBAL_MAX,
+    });
 
   const baseMetadata = createOAuthMetadata({
     provider,
@@ -53,11 +123,20 @@ export function createMcpRouter(deps: McpRouterDeps): express.Router {
     })
   );
 
-  router.use(MCP_AUTHORIZE_PATH, authorizationHandler({ provider }));
-  router.use(MCP_TOKEN_PATH, tokenHandler({ provider }));
+  router.use(
+    MCP_AUTHORIZE_PATH,
+    rateLimit(authorizeLimiter),
+    authorizationHandler({ provider })
+  );
+  router.use(
+    MCP_TOKEN_PATH,
+    rateLimit(tokenLimiter),
+    tokenHandler({ provider })
+  );
   if (baseMetadata.registration_endpoint) {
     router.use(
       MCP_REGISTER_PATH,
+      rateLimit(registerLimiter),
       clientRegistrationHandler({ clientsStore: provider.clientsStore })
     );
   }


### PR DESCRIPTION
## What
Adds per-IP rate limits to the three unauthenticated MCP OAuth endpoints (`/mcp/register`, `/mcp/authorize`, `/mcp/token`) and a boot assertion that the consent secret is non-empty in production.

## Why
Security hardening item 3 from the beta-exit plan (#3727). `POST /mcp/register` is unauthenticated RFC 7591 dynamic client registration with no throttle, so anyone could flood `mcp_oauth_clients`; `/mcp/authorize` and `/mcp/token` were likewise unbounded. A misconfigured prod boot with an empty consent secret should fail loudly rather than run insecurely.

## How
Reuses `InMemoryRateLimiter` and the same trust-proxy IP derivation (`resolveClientIp` + `hashIp`) that `UploadController` uses. Per-IP caps are generous so NAT'd multi-user clients don't break: register 10/hour, authorize 30/min, token 60/min, each with a global cap. Blocked requests get `429` with `{ error: 'rate_limited', error_description: '...' }`. The consent secret assertion throws at `createMcpRouter` construction when `NODE_ENV === 'production'` and the secret is empty; the secret is threaded through `McpRouterDeps` from the value already used for the provider config. Limiters are injectable via deps for deterministic tests.

## Measuring success
A spike in `429`s on the MCP OAuth paths in access logs indicates an abuse attempt was absorbed rather than inflating `mcp_oauth_clients`; `select count(*) from mcp_oauth_clients` growth stays bounded. No new metric added — this is abuse hardening.

## Testing
- Unit tests added: register under cap returns 201; register over the per-IP cap returns 429 with a `rate_limited` body; empty consent secret + `NODE_ENV=production` throws at construction; empty secret outside production does not throw.
- `npx tsc -p . --noEmit`, `pnpm test src/routes/mcp src/routes/McpRouter.test.ts` (16 pass), `pnpm format:check` all green.
- Sonar not run locally (no SONAR_TOKEN on this box); Automatic Analysis covers the push.

## Browser check
Browser check: not applicable — server-only change, no `web/src/` files touched.

## Changelog
No changelog entry — abuse hardening on internal OAuth endpoints, invisible to end users.

## Risks
Legitimate clients behind shared NAT could theoretically hit a cap, but the limits are set well above normal single-user OAuth flows. Rollback is reverting this PR; the limiters hold no persistent state.

## Goal alignment
None — internal security hardening required to graduate MCP out of beta. Does not move a funnel metric directly.
