### PR TITLE
fix: MCP tools explain the free card limit instead of a generic error

### DIFF
--- a/src/services/mcp/McpToolsService.test.ts
+++ b/src/services/mcp/McpToolsService.test.ts
@@ -430,6 +430,24 @@ describe('McpToolsService.convertToDeck', () => {
     expect(persist).not.toHaveBeenCalled();
   });
 
+  it('returns the paywall message when the upload redirects to the card limit', async () => {
+    const uploadEntry: UploadEntrypoint = (_req, res) => {
+      res.redirect('/limit?kind=card_count');
+    };
+    const { service, persist } = makeService({ uploadEntry });
+    const result = await service.convertToDeck({ text: 'x' }, 'owner', {});
+    expect(result).toEqual({
+      kind: 'error',
+      code: 'monthly_limit',
+      message:
+        "You've reached your free limit of 100 cards this month, so this deck wasn't created. Upgrade to Unlimited to keep converting, or wait for your limit to reset next month. Upgrade: https://2anki.net/pricing?from=mcp",
+    });
+    expect((result as { message: string }).message).toContain(
+      'https://2anki.net/pricing?from=mcp'
+    );
+    expect(persist).not.toHaveBeenCalled();
+  });
+
   it('surfaces the upload error message on a 400', async () => {
     const uploadEntry: UploadEntrypoint = (_req, res) => {
       res.status(400).json({ message: 'This file type is not supported.' });
@@ -1035,8 +1053,13 @@ describe('McpToolsService.createDeck with subdecks', () => {
     );
     expect(result).toEqual({
       kind: 'error',
-      message: 'Could not convert this input.',
+      code: 'monthly_limit',
+      message:
+        "You've reached your free limit of 100 cards this month, so this deck wasn't created. Upgrade to Unlimited to keep converting, or wait for your limit to reset next month. Upgrade: https://2anki.net/pricing?from=mcp",
     });
+    expect((result as { message: string }).message).toContain(
+      'https://2anki.net/pricing?from=mcp'
+    );
     expect(persist).not.toHaveBeenCalled();
     expect(incrementCardUsage).not.toHaveBeenCalled();
   });

--- a/src/services/mcp/McpToolsService.ts
+++ b/src/services/mcp/McpToolsService.ts
@@ -56,6 +56,10 @@ const NO_CARDS_FOUND_MESSAGE =
 const EMPTY_BACK_MESSAGE =
   'Some cards have an empty back. Every card needs both a front and a back.';
 const GENERIC_CONVERT_ERROR = 'Could not convert this input.';
+const MONTHLY_LIMIT_CODE = 'monthly_limit';
+const MONTHLY_LIMIT_MESSAGE =
+  "You've reached your free limit of 100 cards this month, so this deck wasn't created. Upgrade to Unlimited to keep converting, or wait for your limit to reset next month. Upgrade: https://2anki.net/pricing?from=mcp";
+const CARD_LIMIT_REDIRECT_PREFIX = '/limit?kind=card_count';
 const OVER_SIZE_MESSAGE =
   'These cards are over the 5 MB limit. Split into smaller decks.';
 const NO_CARD_CODES = new Set(['markdown_likely_lossy', 'empty_export']);
@@ -494,7 +498,11 @@ export class McpToolsService {
       });
     } catch (error) {
       if (error instanceof MonthlyLimitError) {
-        return { kind: 'error', message: GENERIC_CONVERT_ERROR };
+        return {
+          kind: 'error',
+          code: MONTHLY_LIMIT_CODE,
+          message: MONTHLY_LIMIT_MESSAGE,
+        };
       }
       throw error;
     }
@@ -701,6 +709,13 @@ export class McpToolsService {
     }
     if (res.statusCode === 200 && res.bodyBuffer != null) {
       return this.persistDeckResult(res.bodyBuffer, res, owner, fallbackTitle);
+    }
+    if (res.redirectedTo?.startsWith(CARD_LIMIT_REDIRECT_PREFIX)) {
+      return {
+        kind: 'error',
+        code: MONTHLY_LIMIT_CODE,
+        message: MONTHLY_LIMIT_MESSAGE,
+      };
     }
     const code = this.errorCode(res.body);
     return {

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-21-mcp-limit-message.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-21-mcp-limit-message.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-21-mcp-limit-message",
+  "date": "2026-07-21",
+  "type": "fix",
+  "title": "Claude and ChatGPT now explain the monthly card limit instead of failing silently"
+}


### PR DESCRIPTION
## What
When a free user over the 100-card monthly limit converts through the MCP connector (Claude / ChatGPT), the tool now returns a clear paywall message with an upgrade link instead of the generic "Could not convert this input." — and records `error_code: 'monthly_limit'` so the hit is measurable.

## Why
Refs #3727. For session-auth MCP calls, `UploadService.handleUpload` turns a `MonthlyLimitError` into `res.redirect('/limit?kind=card_count')`. `McpToolsService.CapturingResponse` stores that as `redirectedTo` with `statusCode` 200 and a null body, so `mapUploadResult` fell through to `GENERIC_CONVERT_ERROR`; the subdeck path caught `MonthlyLimitError` and returned the same generic string. The assistant read this as malformed input and never told the user they'd hit the paywall.

## How
- `mapUploadResult`: when `redirectedTo` starts with `/limit?kind=card_count`, return a distinct error result with the paywall message and `code: 'monthly_limit'`.
- Subdeck `createSubdeckDeck` `MonthlyLimitError` branch: same message and code (fixed copy — no invented numbers).
- The existing `result.code → recordToolResult(..., result.code)` path carries `monthly_limit` into the `mcp_tool_result` analytics event. One paywall return per capped call.
- Photo quota (`photo_to_deck` → `FreeQuotaReachedError`) already surfaces a clear message ("Free plan is N photos per month. You've used M. Upgrade for unlimited.") via the tool's error passthrough, so it was left unchanged.

## Measuring success
`mcp_tool_result` events with `error_code = 'monthly_limit'` (read at `/api/ops/metrics`) count MCP paywall hits — previously invisible under generic errors. A rise in `pricing?from=mcp` referrals confirms the CTA converts.

## Testing
- Unit tests added: redirect-to-`/limit?kind=card_count` capture → paywall message + `monthly_limit` code (asserts the upgrade URL verbatim); subdeck `MonthlyLimitError` → same; generic 400/no-card errors unchanged.
- `npx tsc -p . --noEmit`, `pnpm test src/services/mcp` (146 passed), changelog loader vitest, `pnpm format:check` all green.
- Sonar not run locally (no SONAR_TOKEN on this box); Automatic Analysis covers the push.

## Browser check
Browser check: not applicable — the only `web/src/` change is a new changelog JSON entry (no rendered logic).

## Changelog
"Claude and ChatGPT now explain the monthly card limit instead of failing silently" (`web/src/pages/WhatsNewPage/changelog/2026-07-21-mcp-limit-message.json`)

## Risks
Low. Behavior change is limited to the two error branches; the paywall message is a fixed string. Rollback: revert the commit.

## Goal alignment
Retention/revenue lever: a capped free user is exactly the conversion moment. Turning a confusing "couldn't convert" into a specific upgrade CTA should move MCP-sourced page→checkout (read via `pricing?from=mcp` referrals and the new `monthly_limit` tool-result code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
