### PR TITLE
feat: add /answers/claude-to-anki landing page for the MCP connector

### DIFF
--- a/src/routes/knownRoutes.test.ts
+++ b/src/routes/knownRoutes.test.ts
@@ -15,6 +15,7 @@ describe('isKnownAppRoute', () => {
     '/answers/fsrs-explained',
     '/answers/pdf-to-anki',
     '/answers/convert-notion-to-anki',
+    '/answers/claude-to-anki',
     '/account',
     '/account/claim',
     '/ankify',

--- a/src/routes/knownRoutes.ts
+++ b/src/routes/knownRoutes.ts
@@ -125,6 +125,7 @@ const ANSWERS_SLUGS = new Set<string>([
   'kindle-highlights-to-anki',
   'language-app-to-anki',
   'obsidian-to-anki',
+  'claude-to-anki',
 ]);
 
 const PARAM_PREFIXES = [

--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -331,6 +331,12 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://2anki.net/answers/claude-to-anki/</loc>
+    <lastmod>2026-07-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://2anki.net/answers/convert-notion-to-anki/</loc>
     <lastmod>2026-06-10</lastmod>
     <changefreq>monthly</changefreq>

--- a/web/src/pages/AnswersPage/AnswersPage.test.tsx
+++ b/web/src/pages/AnswersPage/AnswersPage.test.tsx
@@ -137,6 +137,7 @@ describe('AnswersPage', () => {
     'kindle-highlights-to-anki',
     'language-app-to-anki',
     'obsidian-to-anki',
+    'claude-to-anki',
   ])('renders the %s page', (slug) => {
     const config = ANSWERS_PAGES.get(slug)!;
     renderAtSlug(slug);

--- a/web/src/pages/AnswersPage/answersConfig.ts
+++ b/web/src/pages/AnswersPage/answersConfig.ts
@@ -807,6 +807,75 @@ const obsidianToAnki: AnswerConfig = {
   ],
 };
 
+const claudeToAnki: AnswerConfig = {
+  slug: 'claude-to-anki',
+  title: 'How to make Anki flashcards in Claude or ChatGPT | 2anki',
+  description:
+    'Add the 2anki MCP connector in Claude or ChatGPT, ask for flashcards, and get a download link for a ready .apkg deck. Text, notes, and photos become cards.',
+  h1: 'Turn Claude conversations into Anki flashcards',
+  intro:
+    '2anki runs a hosted MCP connector. Add https://2anki.net/mcp in Claude or ChatGPT, ask for flashcards on any topic or paste in your notes, and the assistant hands back a download link for a ready .apkg deck you open in Anki.',
+  sections: [
+    {
+      heading: 'What the MCP connector is',
+      body: '2anki runs a hosted MCP connector at https://2anki.net/mcp. Add it once in Claude — Settings → Connectors — or in ChatGPT with developer mode turned on. From then on you ask the assistant for flashcards the same way you ask it anything else, and it builds the deck through 2anki and returns a download link. Nothing runs on your machine; the connector talks to 2anki directly.',
+    },
+    {
+      heading: 'Add the connector and ask for cards',
+      body: 'In Claude, open Settings → Connectors, add a custom connector, and paste https://2anki.net/mcp. In ChatGPT, turn on developer mode and add the same URL. Sign in when prompted so the deck lands in your account. Then type a normal request — "make 20 cards on the Krebs cycle" or "turn these notes into cloze cards" — and download the .apkg the assistant links back. The full walkthrough, with screenshots, is in the docs guide.',
+    },
+    {
+      heading: 'What you can ask for',
+      body: 'Text and notes become a deck — paste a chapter, a list of terms, or a summary and get question-and-answer cards. A photo becomes cards — attach an image of your notes and the assistant reads the page. You can ask for specific note types, including cloze deletions, and organise a large topic into subdecks. Preview the cards in the chat before you download the .apkg, so nothing lands in Anki that you did not check.',
+    },
+    {
+      heading: 'Connector access and the self-service path',
+      body: 'The hosted connector is in a limited beta — request access from the developers page. API keys and the command-line tool are self-service today, so if you would rather script deck creation without the connector you can start there right away. Both paths build decks through the same 2anki account, so anything you make in the connector shows up alongside your uploads.',
+    },
+    {
+      heading: 'What it costs',
+      body: 'The free plan converts 100 cards a month, whether you build them through the connector or upload files directly. Unlimited removes the cap. It is the same account and the same decks — the connector is another way in, not a separate product or a separate bill.',
+    },
+  ],
+  faqs: [
+    {
+      q: 'Which assistants work with the connector?',
+      a: 'Claude and ChatGPT. In Claude, add it under Settings → Connectors. In ChatGPT, turn on developer mode and add the same https://2anki.net/mcp URL. Ask for flashcards the way you would ask anything else.',
+    },
+    {
+      q: 'Do I need an API key?',
+      a: 'Not for the connector — signing in through it is enough. API keys and the command-line tool are a separate, self-service path if you would rather script deck creation instead of using the chat connector.',
+    },
+    {
+      q: 'Can it read a photo of my notes?',
+      a: 'Yes. Attach an image in the chat and ask for cards. The assistant reads the page and drafts cards you preview before downloading the .apkg.',
+    },
+    {
+      q: 'What do I get back?',
+      a: 'A download link for a standard .apkg deck. Open it in Anki with a double-click — no add-on required. The cards work with FSRS or SM-2, whichever scheduling you have enabled.',
+    },
+  ],
+  relatedLinks: [
+    {
+      label: 'Use 2anki in Claude — full walkthrough',
+      href: '/documentation/start-here/use-in-claude?ref=ai',
+    },
+    {
+      label: 'MCP connector reference',
+      href: '/documentation/reference/mcp?ref=ai',
+    },
+    {
+      label: 'Request beta access — developer tools',
+      href: '/developers?ref=ai',
+    },
+    {
+      label: 'Turn handwritten notes into Anki flashcards',
+      href: '/answers/handwritten-notes-to-anki?ref=ai',
+    },
+    { label: 'Pricing', href: '/pricing?ref=ai' },
+  ],
+};
+
 export const ANSWERS_PAGES: ReadonlyMap<string, AnswerConfig> = new Map([
   ['convert-notion-to-anki', convertNotionToAnki],
   ['notion-to-anki-sync', notionToAnkiSync],
@@ -822,4 +891,5 @@ export const ANSWERS_PAGES: ReadonlyMap<string, AnswerConfig> = new Map([
   ['kindle-highlights-to-anki', kindleHighlightsToAnki],
   ['language-app-to-anki', languageAppToAnki],
   ['obsidian-to-anki', obsidianToAnki],
+  ['claude-to-anki', claudeToAnki],
 ]);

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-21-claude-landing.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-21-claude-landing.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-21-claude-landing",
+  "date": "2026-07-21",
+  "type": "feature",
+  "title": "Guide page for building Anki decks from Claude or ChatGPT conversations"
+}


### PR DESCRIPTION
## What
Adds an SEO answers page at `/answers/claude-to-anki` — "Turn Claude conversations into Anki flashcards" — explaining how to add the hosted 2anki MCP connector (`https://2anki.net/mcp`) in Claude or ChatGPT and get a downloadable `.apkg` back from a chat request.

## Why
Part of #3686 (distribution). Learners increasingly ask Claude and ChatGPT to make their flashcards, but nothing on 2anki tells them the connector exists or how to wire it up. This page captures that search intent and routes it into signup and the docs walkthrough.

## How
Mirrors the existing answers-page machinery exactly — no new page mechanism:
- New `claudeToAnki` config in `answersConfig.ts` (5 sections + 4 FAQs, honest limited-beta status for the connector, self-service API-key/CLI note).
- `claude-to-anki` added to `ANSWERS_SLUGS` in `src/routes/knownRoutes.ts` so direct loads/refreshes serve the SPA shell (200, not 404).
- Sitemap entry in `web/public/sitemap.xml`.
- Route (`/answers/:slug`) and prerender (`emitAnswersPages` iterates `ANSWERS_PAGES`) are generic — they pick up the new slug automatically.
- Internal links: docs walkthrough (`/documentation/start-here/use-in-claude`), MCP reference (`/documentation/reference/mcp`), `/developers` for beta access, a sibling answers page, and `/pricing`.

## Measuring success
`landing_page_viewed` fires on the answers page render; track `/answers/claude-to-anki` → signup conversion via the landing-page yield report (same funnel the other answers slugs are read on). Search Console: impressions/clicks for the new URL after indexing.

## Testing
- Unit tests added: extended `AnswersPage.test.tsx` it.each and `knownRoutes.test.ts` to cover `claude-to-anki`.
- Docs link-integrity suite (`content-links.test.ts`) stays green.
- `pnpm --filter 2anki-web typecheck`, `npx tsc -p . --noEmit`, `pnpm format:check` all pass.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: machine-backed via `pnpm --filter 2anki-web test:golden-path` — 2 passed at 375px, no console errors.

## Changelog
`2026-07-21-claude-landing.json` — "Guide page for building Anki decks from Claude or ChatGPT conversations"

## Risks
Low. Additive SEO content page reusing shared machinery; no runtime code paths change. Rollback = revert the PR. The page states the connector is in limited beta, so it does not over-promise if beta access stays gated.

Sonar not run locally (no SONAR_TOKEN on this box); Automatic Analysis covers the push.

## Goal alignment
Acquisition lane: a new organic search entry point for the "make Anki cards in Claude/ChatGPT" query, feeding the landing → signup → first-conversion funnel. Metric to move: `landing_page_viewed` → signup for the new slug, read via the landing-page yield report. Toward the 300K-user goal by widening top-of-funnel where AI-assistant search demand is growing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018J3WrD4pRWsCFM1XxcTasX
