### PR TITLE
feat: reap expired MCP OAuth rows on an hourly schedule

### DIFF
--- a/migrations/20260928000000_index_mcp_oauth_expires_at.js
+++ b/migrations/20260928000000_index_mcp_oauth_expires_at.js
@@ -1,0 +1,23 @@
+module.exports.up = async function (knex) {
+  await knex.schema.alterTable('mcp_authorization_codes', (table) => {
+    table.index(['expires_at'], 'mcp_authorization_codes_expires_at_idx');
+  });
+  await knex.schema.alterTable('mcp_access_tokens', (table) => {
+    table.index(['expires_at'], 'mcp_access_tokens_expires_at_idx');
+  });
+  await knex.schema.alterTable('mcp_refresh_tokens', (table) => {
+    table.index(['expires_at'], 'mcp_refresh_tokens_expires_at_idx');
+  });
+};
+
+module.exports.down = async function (knex) {
+  await knex.schema.alterTable('mcp_authorization_codes', (table) => {
+    table.dropIndex(['expires_at'], 'mcp_authorization_codes_expires_at_idx');
+  });
+  await knex.schema.alterTable('mcp_access_tokens', (table) => {
+    table.dropIndex(['expires_at'], 'mcp_access_tokens_expires_at_idx');
+  });
+  await knex.schema.alterTable('mcp_refresh_tokens', (table) => {
+    table.dropIndex(['expires_at'], 'mcp_refresh_tokens_expires_at_idx');
+  });
+};

--- a/src/data_layer/McpAuthorizationCodeRepository.sql.test.ts
+++ b/src/data_layer/McpAuthorizationCodeRepository.sql.test.ts
@@ -1,0 +1,23 @@
+import knex from 'knex';
+
+import { McpAuthorizationCodeRepository } from './McpAuthorizationCodeRepository';
+
+const now = new Date('2026-07-20T00:00:00.000Z');
+
+describe('McpAuthorizationCodeRepository deleteExpired generated SQL', () => {
+  const pg = knex({ client: 'pg' });
+  const repository = new McpAuthorizationCodeRepository(pg);
+
+  afterAll(async () => {
+    await pg.destroy();
+  });
+
+  it('deletes authorization codes whose expiry has passed', () => {
+    const { sql, bindings } = repository.buildDeleteExpiredQuery(now).toSQL();
+
+    expect(sql).toBe(
+      'delete from "mcp_authorization_codes" where "expires_at" < ?'
+    );
+    expect(bindings).toEqual([now]);
+  });
+});

--- a/src/data_layer/McpAuthorizationCodeRepository.ts
+++ b/src/data_layer/McpAuthorizationCodeRepository.ts
@@ -28,6 +28,7 @@ export interface IMcpAuthorizationCodeRepository {
   create(input: CreateAuthorizationCodeInput): Promise<void>;
   findByHash(codeHash: string): Promise<StoredAuthorizationCode | null>;
   consume(id: number, now: Date): Promise<boolean>;
+  deleteExpired(now: Date): Promise<number>;
 }
 
 function toStored(row: McpAuthorizationCodes): StoredAuthorizationCode {
@@ -75,5 +76,13 @@ export class McpAuthorizationCodeRepository implements IMcpAuthorizationCodeRepo
       .whereNull('consumed_at')
       .update({ consumed_at: now });
     return updated === 1;
+  }
+
+  buildDeleteExpiredQuery(now: Date): Knex.QueryBuilder {
+    return this.database(this.table).where('expires_at', '<', now).del();
+  }
+
+  async deleteExpired(now: Date): Promise<number> {
+    return this.buildDeleteExpiredQuery(now);
   }
 }

--- a/src/data_layer/McpOAuthClientRepository.sql.test.ts
+++ b/src/data_layer/McpOAuthClientRepository.sql.test.ts
@@ -1,0 +1,33 @@
+import knex from 'knex';
+
+import { McpOAuthClientRepository } from './McpOAuthClientRepository';
+
+describe('McpOAuthClientRepository deleteOrphaned generated SQL', () => {
+  const pg = knex({ client: 'pg' });
+  const repository = new McpOAuthClientRepository(pg);
+
+  afterAll(async () => {
+    await pg.destroy();
+  });
+
+  it('deletes clients issued before the cutoff with no codes or tokens', () => {
+    const issuedBefore = 1_700_000_000;
+    const { sql, bindings } = repository
+      .buildDeleteOrphanedQuery(issuedBefore)
+      .toSQL();
+
+    expect(sql).toBe(
+      'delete from "mcp_oauth_clients" where "client_id_issued_at" < ? ' +
+        'and not exists ' +
+        '(select 1 from "mcp_authorization_codes" ' +
+        'where mcp_authorization_codes.client_id = mcp_oauth_clients.client_id) ' +
+        'and not exists ' +
+        '(select 1 from "mcp_access_tokens" ' +
+        'where mcp_access_tokens.client_id = mcp_oauth_clients.client_id) ' +
+        'and not exists ' +
+        '(select 1 from "mcp_refresh_tokens" ' +
+        'where mcp_refresh_tokens.client_id = mcp_oauth_clients.client_id)'
+    );
+    expect(bindings).toEqual([issuedBefore]);
+  });
+});

--- a/src/data_layer/McpOAuthClientRepository.ts
+++ b/src/data_layer/McpOAuthClientRepository.ts
@@ -16,6 +16,7 @@ export interface StoredMcpClient {
 export interface IMcpOAuthClientRepository {
   create(client: StoredMcpClient): Promise<StoredMcpClient>;
   findById(clientId: string): Promise<StoredMcpClient | null>;
+  deleteOrphaned(issuedBeforeUnixSeconds: number): Promise<number>;
 }
 
 function toStored(row: McpOauthClients): StoredMcpClient {
@@ -59,5 +60,37 @@ export class McpOAuthClientRepository implements IMcpOAuthClientRepository {
       .where({ client_id: clientId })
       .first()) as McpOauthClients | undefined;
     return row == null ? null : toStored(row);
+  }
+
+  buildDeleteOrphanedQuery(issuedBeforeUnixSeconds: number): Knex.QueryBuilder {
+    return this.database(this.table)
+      .where('client_id_issued_at', '<', issuedBeforeUnixSeconds)
+      .whereNotExists((qb) =>
+        qb
+          .select(1)
+          .from('mcp_authorization_codes')
+          .whereRaw(
+            'mcp_authorization_codes.client_id = mcp_oauth_clients.client_id'
+          )
+      )
+      .whereNotExists((qb) =>
+        qb
+          .select(1)
+          .from('mcp_access_tokens')
+          .whereRaw('mcp_access_tokens.client_id = mcp_oauth_clients.client_id')
+      )
+      .whereNotExists((qb) =>
+        qb
+          .select(1)
+          .from('mcp_refresh_tokens')
+          .whereRaw(
+            'mcp_refresh_tokens.client_id = mcp_oauth_clients.client_id'
+          )
+      )
+      .del();
+  }
+
+  async deleteOrphaned(issuedBeforeUnixSeconds: number): Promise<number> {
+    return this.buildDeleteOrphanedQuery(issuedBeforeUnixSeconds);
   }
 }

--- a/src/data_layer/McpTokenRepository.sql.test.ts
+++ b/src/data_layer/McpTokenRepository.sql.test.ts
@@ -1,0 +1,32 @@
+import knex from 'knex';
+
+import { McpTokenRepository } from './McpTokenRepository';
+
+const now = new Date('2026-07-20T00:00:00.000Z');
+
+describe('McpTokenRepository deletion generated SQL', () => {
+  const pg = knex({ client: 'pg' });
+  const repository = new McpTokenRepository(pg);
+
+  afterAll(async () => {
+    await pg.destroy();
+  });
+
+  it('deletes access tokens whose expiry has passed', () => {
+    const { sql, bindings } = repository
+      .buildDeleteExpiredAccessTokensQuery(now)
+      .toSQL();
+
+    expect(sql).toBe('delete from "mcp_access_tokens" where "expires_at" < ?');
+    expect(bindings).toEqual([now]);
+  });
+
+  it('deletes refresh tokens whose expiry has passed', () => {
+    const { sql, bindings } = repository
+      .buildDeleteExpiredRefreshTokensQuery(now)
+      .toSQL();
+
+    expect(sql).toBe('delete from "mcp_refresh_tokens" where "expires_at" < ?');
+    expect(bindings).toEqual([now]);
+  });
+});

--- a/src/data_layer/McpTokenRepository.ts
+++ b/src/data_layer/McpTokenRepository.ts
@@ -29,6 +29,8 @@ export interface IMcpTokenRepository {
   revokeAccessTokenByHash(tokenHash: string): Promise<void>;
   revokeRefreshTokenByHash(tokenHash: string): Promise<void>;
   revokeAllForUserClient(userId: number, clientId: string): Promise<void>;
+  deleteExpiredAccessTokens(now: Date): Promise<number>;
+  deleteExpiredRefreshTokens(now: Date): Promise<number>;
 }
 
 function toStored(row: McpAccessTokens | McpRefreshTokens): StoredToken {
@@ -109,5 +111,21 @@ export class McpTokenRepository implements IMcpTokenRepository {
       .where({ user_id: userId, client_id: clientId })
       .whereNull('revoked_at')
       .update({ revoked_at: now });
+  }
+
+  buildDeleteExpiredAccessTokensQuery(now: Date): Knex.QueryBuilder {
+    return this.database(this.accessTable).where('expires_at', '<', now).del();
+  }
+
+  buildDeleteExpiredRefreshTokensQuery(now: Date): Knex.QueryBuilder {
+    return this.database(this.refreshTable).where('expires_at', '<', now).del();
+  }
+
+  async deleteExpiredAccessTokens(now: Date): Promise<number> {
+    return this.buildDeleteExpiredAccessTokensQuery(now);
+  }
+
+  async deleteExpiredRefreshTokens(now: Date): Promise<number> {
+    return this.buildDeleteExpiredRefreshTokensQuery(now);
   }
 }

--- a/src/lib/mcp/jobs/scheduleMcpOAuthReaper.test.ts
+++ b/src/lib/mcp/jobs/scheduleMcpOAuthReaper.test.ts
@@ -1,0 +1,114 @@
+import {
+  MCP_OAUTH_REAP_INTERVAL_MS,
+  MCP_ORPHAN_CLIENT_MAX_AGE_MS,
+  reapMcpOAuth,
+  scheduleMcpOAuthReaper,
+} from './scheduleMcpOAuthReaper';
+
+const buildRepos = () => ({
+  authorizationCodes: { deleteExpired: jest.fn().mockResolvedValue(2) },
+  tokens: {
+    deleteExpiredAccessTokens: jest.fn().mockResolvedValue(24),
+    deleteExpiredRefreshTokens: jest.fn().mockResolvedValue(3),
+  },
+  clients: { deleteOrphaned: jest.fn().mockResolvedValue(1) },
+});
+
+describe('reapMcpOAuth', () => {
+  it('reaps every table and reports per-table counts', async () => {
+    const repos = buildRepos();
+    const now = new Date('2026-07-20T12:00:00.000Z');
+
+    const result = await reapMcpOAuth(repos, now);
+
+    expect(result).toEqual({
+      authorizationCodes: 2,
+      accessTokens: 24,
+      refreshTokens: 3,
+      orphanedClients: 1,
+    });
+    expect(repos.authorizationCodes.deleteExpired).toHaveBeenCalledWith(now);
+    expect(repos.tokens.deleteExpiredAccessTokens).toHaveBeenCalledWith(now);
+    expect(repos.tokens.deleteExpiredRefreshTokens).toHaveBeenCalledWith(now);
+  });
+
+  it('reaps tokens before orphaned clients so drained clients qualify', async () => {
+    const repos = buildRepos();
+    const order: string[] = [];
+    repos.tokens.deleteExpiredAccessTokens.mockImplementation(async () => {
+      order.push('access');
+      return 0;
+    });
+    repos.tokens.deleteExpiredRefreshTokens.mockImplementation(async () => {
+      order.push('refresh');
+      return 0;
+    });
+    repos.authorizationCodes.deleteExpired.mockImplementation(async () => {
+      order.push('codes');
+      return 0;
+    });
+    repos.clients.deleteOrphaned.mockImplementation(async () => {
+      order.push('clients');
+      return 0;
+    });
+
+    await reapMcpOAuth(repos, new Date('2026-07-20T12:00:00.000Z'));
+
+    expect(order.indexOf('clients')).toBe(order.length - 1);
+  });
+
+  it('derives the orphan-client cutoff from the max age in seconds', async () => {
+    const repos = buildRepos();
+    const now = new Date('2026-07-20T12:00:00.000Z');
+
+    await reapMcpOAuth(repos, now);
+
+    const expectedCutoffSeconds = Math.floor(
+      (now.getTime() - MCP_ORPHAN_CLIENT_MAX_AGE_MS) / 1000
+    );
+    expect(repos.clients.deleteOrphaned).toHaveBeenCalledWith(
+      expectedCutoffSeconds
+    );
+  });
+});
+
+describe('scheduleMcpOAuthReaper', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('runs a sweep on each interval tick', async () => {
+    const repos = buildRepos();
+
+    const handle = scheduleMcpOAuthReaper(repos, { intervalMs: 1000 });
+
+    await jest.advanceTimersByTimeAsync(1000);
+
+    expect(repos.authorizationCodes.deleteExpired).toHaveBeenCalledTimes(1);
+    clearInterval(handle);
+  });
+
+  it('defaults to an hourly cadence', () => {
+    expect(MCP_OAUTH_REAP_INTERVAL_MS).toBe(60 * 60 * 1000);
+  });
+
+  it('swallows a sweep failure without throwing', async () => {
+    const repos = buildRepos();
+    repos.tokens.deleteExpiredAccessTokens.mockRejectedValue(
+      new Error('db down')
+    );
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const handle = scheduleMcpOAuthReaper(repos, { intervalMs: 1000 });
+    await jest.advanceTimersByTimeAsync(1000);
+
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+    clearInterval(handle);
+  });
+});

--- a/src/lib/mcp/jobs/scheduleMcpOAuthReaper.ts
+++ b/src/lib/mcp/jobs/scheduleMcpOAuthReaper.ts
@@ -1,0 +1,64 @@
+import type { IMcpAuthorizationCodeRepository } from '../../../data_layer/McpAuthorizationCodeRepository';
+import type { IMcpOAuthClientRepository } from '../../../data_layer/McpOAuthClientRepository';
+import type { IMcpTokenRepository } from '../../../data_layer/McpTokenRepository';
+
+export const MCP_OAUTH_REAP_INTERVAL_MS = 60 * 60 * 1000;
+
+export const MCP_ORPHAN_CLIENT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+export interface McpOAuthReaperRepos {
+  authorizationCodes: Pick<IMcpAuthorizationCodeRepository, 'deleteExpired'>;
+  tokens: Pick<
+    IMcpTokenRepository,
+    'deleteExpiredAccessTokens' | 'deleteExpiredRefreshTokens'
+  >;
+  clients: Pick<IMcpOAuthClientRepository, 'deleteOrphaned'>;
+}
+
+export interface McpOAuthReapResult {
+  authorizationCodes: number;
+  accessTokens: number;
+  refreshTokens: number;
+  orphanedClients: number;
+}
+
+export const reapMcpOAuth = async (
+  repos: McpOAuthReaperRepos,
+  now: Date
+): Promise<McpOAuthReapResult> => {
+  const authorizationCodes = await repos.authorizationCodes.deleteExpired(now);
+  const accessTokens = await repos.tokens.deleteExpiredAccessTokens(now);
+  const refreshTokens = await repos.tokens.deleteExpiredRefreshTokens(now);
+
+  const orphanCutoffSeconds = Math.floor(
+    (now.getTime() - MCP_ORPHAN_CLIENT_MAX_AGE_MS) / 1000
+  );
+  const orphanedClients =
+    await repos.clients.deleteOrphaned(orphanCutoffSeconds);
+
+  return { authorizationCodes, accessTokens, refreshTokens, orphanedClients };
+};
+
+export const scheduleMcpOAuthReaper = (
+  repos: McpOAuthReaperRepos,
+  options: { intervalMs?: number } = {}
+): NodeJS.Timeout => {
+  const intervalMs = options.intervalMs ?? MCP_OAUTH_REAP_INTERVAL_MS;
+
+  const tick = async () => {
+    try {
+      const result = await reapMcpOAuth(repos, new Date());
+      console.info(
+        `[mcp-oauth-reaper] completed — deleted ${result.authorizationCodes} authorization code(s), ` +
+          `${result.accessTokens} access token(s), ${result.refreshTokens} refresh token(s), ` +
+          `${result.orphanedClients} orphaned client(s)`
+      );
+    } catch (error) {
+      console.error('[mcp-oauth-reaper] tick failed', error);
+    }
+  };
+
+  const handle = setInterval(tick, intervalMs);
+  handle.unref();
+  return handle;
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -94,6 +94,10 @@ import { EventsRepository } from './data_layer/EventsRepository';
 import { scheduleParserCanary } from './lib/parser/canary/scheduleParserCanary';
 import { scheduleExportDriftCanary } from './lib/parser/canary/scheduleExportDriftCanary';
 import { scheduleObservabilityCleanup } from './lib/observability/jobs/scheduleObservabilityCleanup';
+import { scheduleMcpOAuthReaper } from './lib/mcp/jobs/scheduleMcpOAuthReaper';
+import { McpAuthorizationCodeRepository } from './data_layer/McpAuthorizationCodeRepository';
+import { McpTokenRepository } from './data_layer/McpTokenRepository';
+import { McpOAuthClientRepository } from './data_layer/McpOAuthClientRepository';
 import { ObservabilityRepository } from './data_layer/ObservabilityRepository';
 import { getDefaultEmailService } from './services/EmailService/EmailService';
 import { SendInactivityWarningsUseCase } from './usecases/ops/SendInactivityWarningsUseCase';
@@ -337,6 +341,12 @@ const serve = async () => {
   scheduleExportDriftCanary(emailService);
 
   scheduleObservabilityCleanup(new ObservabilityRepository(database));
+
+  scheduleMcpOAuthReaper({
+    authorizationCodes: new McpAuthorizationCodeRepository(database),
+    tokens: new McpTokenRepository(database),
+    clients: new McpOAuthClientRepository(database),
+  });
 
   try {
     ScheduleCleanup(database);

--- a/src/services/mcp/oauth/KnexOAuthProvider.test.ts
+++ b/src/services/mcp/oauth/KnexOAuthProvider.test.ts
@@ -35,6 +35,16 @@ class FakeClientRepo implements IMcpOAuthClientRepository {
   async findById(clientId: string): Promise<StoredMcpClient | null> {
     return this.clients.get(clientId) ?? null;
   }
+  async deleteOrphaned(issuedBeforeUnixSeconds: number): Promise<number> {
+    let deleted = 0;
+    for (const [id, client] of this.clients) {
+      if (client.client_id_issued_at < issuedBeforeUnixSeconds) {
+        this.clients.delete(id);
+        deleted++;
+      }
+    }
+    return deleted;
+  }
 }
 
 class FakeCodeRepo implements IMcpAuthorizationCodeRepository {
@@ -73,6 +83,17 @@ class FakeCodeRepo implements IMcpAuthorizationCodeRepository {
     }
     return false;
   }
+  async deleteExpired(now: Date): Promise<number> {
+    let deleted = 0;
+    for (const [hash, row] of this.byHash) {
+      if (row.expires_at < now) {
+        this.byHash.delete(hash);
+        this.rows = this.rows.filter((r) => r.id !== row.id);
+        deleted++;
+      }
+    }
+    return deleted;
+  }
 }
 
 class FakeTokenRepo implements IMcpTokenRepository {
@@ -108,6 +129,25 @@ class FakeTokenRepo implements IMcpTokenRepository {
     if (t) t.revoked_at = new Date();
   }
   async revokeAllForUserClient(): Promise<void> {}
+  async deleteExpiredAccessTokens(now: Date): Promise<number> {
+    return this.deleteExpiredFrom(this.access, now);
+  }
+  async deleteExpiredRefreshTokens(now: Date): Promise<number> {
+    return this.deleteExpiredFrom(this.refresh, now);
+  }
+  private deleteExpiredFrom(
+    store: Map<string, StoredToken>,
+    now: Date
+  ): number {
+    let deleted = 0;
+    for (const [hash, token] of store) {
+      if (token.expires_at < now) {
+        store.delete(hash);
+        deleted++;
+      }
+    }
+    return deleted;
+  }
 }
 
 function fakeResponse(


### PR DESCRIPTION
## What
Adds an hourly reaper that deletes dead rows from the four MCP OAuth tables (`mcp_oauth_clients`, `mcp_authorization_codes`, `mcp_access_tokens`, `mcp_refresh_tokens`), plus the `expires_at` indexes those deletes need. Unblocks blocker 3 of #3727.

## Why
The MCP OAuth tables carry `expires_at`/`consumed_at`/`revoked_at` but nothing ever deletes dead rows. Refresh-token rotation leaves roughly 24 dead access-token rows per active client per day, and today's deletes would be sequential scans (no `expires_at` index). Left unattended these tables grow without bound.

## How
- **Migration** `20260928000000_index_mcp_oauth_expires_at.js` adds a b-tree index on `expires_at` to the three code/token tables. Index-only, no table or column changes, so no kanel regeneration is needed. Applied against local Postgres and verified before pushing.
- **Repository deletion methods** (query-builder only, no raw SQL with user input):
  - `McpAuthorizationCodeRepository.deleteExpired(now)` deletes codes where `expires_at < now` (consumed rows past expiry included).
  - `McpTokenRepository.deleteExpiredAccessTokens(now)` / `deleteExpiredRefreshTokens(now)` apply the same predicate per token table (revoked rows past expiry included).
  - `McpOAuthClientRepository.deleteOrphaned(issuedBeforeUnixSeconds)` deletes clients with zero remaining codes, zero remaining access tokens, zero remaining refresh tokens, and `client_id_issued_at` older than 30 days, using correlated `whereNotExists` subqueries with static identifiers.
- **`scheduleMcpOAuthReaper`** follows the `scheduleAnkifyReaper` / `scheduleObservabilityCleanup` pattern: `setInterval` (hourly, unref'd), try/catch, one info line per sweep with per-table delete counts. The tick reaps codes and tokens first, then orphaned clients, so a client whose tokens were just reaped becomes eligible in the same sweep.
- **Wired** into `server.ts` startup next to the other schedulers (one import group + one call). The interface additions required updating the fake repos in `KnexOAuthProvider.test.ts`.

## Measuring success
Prod log line each sweep: `[mcp-oauth-reaper] completed — deleted N authorization code(s), N access token(s), N refresh token(s), N orphaned client(s)`. Steady-state row counts on the four tables should plateau instead of climbing. Grep the log for `mcp-oauth-reaper` after deploy to confirm sweeps run and counts are non-zero once dead rows exist.

## Testing
- SQL-shape tests (pg-dialect `toString`) for all four deletion queries, asserting generated SQL plus bindings.
- Behavior tests for the tick with fake repos and jest fake timers: per-table counts returned, tokens reaped before orphaned clients, orphan cutoff derived from a 30-day max age, sweep runs each interval, and a sweep failure swallowed without throwing.
- Full `src/services/mcp` and `src/routes/McpRouter.test.ts` suites pass (155 tests). `tsc -p . --noEmit` clean.

## Browser check
Browser check: not applicable — server-only change, no `web/src/` files touched.

## Changelog
No changelog entry — internal maintenance job, no user-visible change.

## Risks
Low. Deletes only rows already dead by their own timestamps. Orphaned-client deletion is guarded by three `whereNotExists` checks plus a 30-day age floor. The scheduler is unref'd and self-contained; a sweep failure logs and is swallowed, never crashing the process. Rollback: revert the PR. The indexes are harmless if left.

Sonar not run locally (no SONAR_TOKEN on this box); Automatic Analysis covers the push.

## Goal alignment
None — internal maintenance. Keeps the MCP OAuth surface's storage bounded and its expiry deletes indexed, protecting the developer/MCP integration path that supports per-user value.
