### PR TITLE
fix: default checkout to monthly, yearly stays the promoted upsell

### DIFF
--- a/web/src/pages/PricingPage/PricingPage.test.tsx
+++ b/web/src/pages/PricingPage/PricingPage.test.tsx
@@ -401,7 +401,7 @@ describe('PricingPage internal event tracking', () => {
 
     renderAt('/pricing', { isLoggedIn: true });
     fireEvent.click(
-      screen.getByRole('button', { name: 'Get Unlimited — billed yearly' })
+      screen.getByRole('button', { name: 'Get Unlimited — billed monthly' })
     );
 
     await waitFor(() => {
@@ -497,7 +497,7 @@ describe('PricingPage anonymous upgrade-click tracking', () => {
 
     renderAt('/pricing', { isLoggedIn: false });
     fireEvent.click(
-      screen.getByRole('button', { name: 'Get Unlimited — billed yearly' })
+      screen.getByRole('button', { name: 'Get Unlimited — billed monthly' })
     );
 
     expect(trackMock).toHaveBeenCalledWith('paywall_upgrade_clicked', {
@@ -599,30 +599,28 @@ describe('PricingPage Unlimited billing toggle', () => {
     ).toBeInTheDocument();
   });
 
-  it('selects Yearly by default with the annual per-month hero price', () => {
+  it('selects Monthly by default with the monthly hero price', () => {
     renderAt('/pricing');
+    expect(screen.getByRole('radio', { name: 'Monthly' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    expect(screen.getByText('$7.99')).toBeInTheDocument();
     expect(
-      screen.getByRole('radio', { name: 'Yearly · save 33%' })
-    ).toHaveAttribute('aria-checked', 'true');
+      screen.getByText('$7.99 billed today, then monthly')
+    ).toBeInTheDocument();
+  });
+
+  it('switches the hero to the annual price and terms after selecting Yearly', () => {
+    renderAt('/pricing');
+    fireEvent.click(screen.getByRole('radio', { name: 'Yearly · save 33%' }));
     expect(screen.getByText('$5.33')).toBeInTheDocument();
     expect(
       screen.getByText('$64 billed today, then yearly · save 33%')
     ).toBeInTheDocument();
   });
 
-  it('switches the hero to the monthly price and terms after selecting Monthly', () => {
-    renderAt('/pricing');
-    fireEvent.click(screen.getByRole('radio', { name: 'Monthly' }));
-    expect(screen.getByText('$7.99')).toBeInTheDocument();
-    expect(
-      screen.getByText('$7.99 billed today, then monthly')
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText('$7.99 billed today, renews monthly. Cancel anytime.')
-    ).toBeInTheDocument();
-  });
-
-  it('calls startUnlimitedCheckout with month when Monthly is selected', async () => {
+  it('calls startUnlimitedCheckout with month by default', async () => {
     mockStartUnlimitedCheckout.mockResolvedValue({
       url: 'https://checkout.stripe.com/month',
     });
@@ -632,7 +630,6 @@ describe('PricingPage Unlimited billing toggle', () => {
     });
 
     renderAt('/pricing', { isLoggedIn: true });
-    fireEvent.click(screen.getByRole('radio', { name: 'Monthly' }));
     fireEvent.click(
       screen.getByRole('button', { name: 'Get Unlimited — billed monthly' })
     );
@@ -646,7 +643,7 @@ describe('PricingPage Unlimited billing toggle', () => {
     });
   });
 
-  it('calls startUnlimitedCheckout with year by default', async () => {
+  it('calls startUnlimitedCheckout with year when Yearly is selected', async () => {
     mockStartUnlimitedCheckout.mockResolvedValue({
       url: 'https://checkout.stripe.com/year',
     });
@@ -656,6 +653,7 @@ describe('PricingPage Unlimited billing toggle', () => {
     });
 
     renderAt('/pricing', { isLoggedIn: true });
+    fireEvent.click(screen.getByRole('radio', { name: 'Yearly · save 33%' }));
     fireEvent.click(
       screen.getByRole('button', { name: 'Get Unlimited — billed yearly' })
     );
@@ -676,7 +674,7 @@ describe('PricingPage Unlimited billing toggle', () => {
     });
     renderAt('/pricing', { isLoggedIn: false });
     fireEvent.click(
-      screen.getByRole('button', { name: 'Get Unlimited — billed yearly' })
+      screen.getByRole('button', { name: 'Get Unlimited — billed monthly' })
     );
     expect(globalThis.location.href).toBe('/login?redirect=/pricing');
   });

--- a/web/src/pages/PricingPage/PricingPage.tsx
+++ b/web/src/pages/PricingPage/PricingPage.tsx
@@ -42,7 +42,7 @@ export default function PricingPage({
   const lifetimeLink = getLifetimeLink();
   const [dayPassState, setDayPassState] = useState<PassState>('idle');
   const [weekPassState, setWeekPassState] = useState<PassState>('idle');
-  const [billingCycle, setBillingCycle] = useState<'month' | 'year'>('year');
+  const [billingCycle, setBillingCycle] = useState<'month' | 'year'>('month');
   const [producerModalOpen, setProducerModalOpen] = useState(false);
   const educatorsRef = useInViewOnce<HTMLElement>(() =>
     track('producer_entry_viewed', { source: 'pricing_page' })

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-21-monthly-first.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-21-monthly-first.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-21-monthly-first",
+  "date": "2026-07-21",
+  "type": "style",
+  "title": "Pricing starts on the monthly plan — yearly stays one tap away with its 33% saving"
+}


### PR DESCRIPTION
Implements #3758 (closes it on merge).

## Gates (per the issue body)
- **Funnel read done:** 6 weeks of `plan_interval_selected` — users click away from the annual default to monthly **2:1** (283 month vs 133 year). The default fights user intent at the exact commitment moment the issue identified. checkout_started flat-to-declining across the window; the leak is at this step, not upstream at signup.
- **Trio:** pm case is the issue itself + the read above; designer direction: keep the toggle, monthly preselected, yearly keeps its "save 33%" promotion label as the upsell (no layout change); engineer: one-line default flip. No conflicts.

## What
`billingCycle` default `'year'` → `'month'` on /pricing. Yearly stays fully offered and promoted via the save-33% toggle label. Tests updated to the new contract (monthly default hero/checkout, yearly via toggle).

## Metric
page→checkout and new-paid/week at `/api/ops/metrics` + Stripe. Day-7 check (2026-07-28): new-paid off the floor, page→checkout ≥10%, failed payments not climbing — reads at the weekly retro.

## Tests
Pricing suite 83/83, web typecheck + tree-wide format clean. Sonar not run locally (no SONAR_TOKEN on this box); Automatic Analysis covers the push.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: machine-backed via `pnpm --filter 2anki-web test:golden-path` (2 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018J3WrD4pRWsCFM1XxcTasX