### PR TITLE
fix: cc the owner on parser canary alert emails

### DIFF
--- a/src/services/EmailService/EmailService.test.ts
+++ b/src/services/EmailService/EmailService.test.ts
@@ -291,4 +291,17 @@ describe('EmailService support notifications cc the owner', () => {
     expect(msg.to).toBe('support@2anki.net');
     expect(msg.cc).toBe('alexander@alemayhu.com');
   });
+
+  it('ccs the owner on parser canary alerts', async () => {
+    const service = getDefaultEmailService();
+
+    await service.sendParserCanaryAlert(
+      'support@2anki.net',
+      'fixture count mismatch'
+    );
+
+    const msg = lastMessage();
+    expect(msg.to).toBe('support@2anki.net');
+    expect(msg.cc).toBe('alexander@alemayhu.com');
+  });
 });

--- a/src/services/EmailService/EmailService.ts
+++ b/src/services/EmailService/EmailService.ts
@@ -755,6 +755,7 @@ export class EmailService implements IEmailService {
   async sendParserCanaryAlert(to: string, summary: string): Promise<void> {
     const msg = {
       to,
+      cc: SUPPORT_CC_ADDRESS,
       from: this.defaultSender,
       subject: '[2anki] Parser canary failure — fixture count mismatch',
       text: summary,


### PR DESCRIPTION
## What

Adds `cc: alexander@alemayhu.com` to `sendParserCanaryAlert`, the last remaining self-send (support@ → support@) without a cc.

## Why

Audit of every place the system emails itself:

| Send | Trigger | CC | DB trace if email lost |
|------|---------|----|------------------------|
| `sendContactEmail` | contact form + bug reports | owner (#3777) | `feedback` table row |
| `sendHostedAnkiAccessRequestEmail` | Auto Sync access request | owner (#3777) | `users.hosted_anki_requested_at` |
| `sendParserCanaryAlert` | parser + export-drift canaries | **none** | none — console only |

Same-domain self-sends via SendGrid have already proven unreliable (the developer access request that never arrived). A parser canary alert vanishing silently means a broken conversion pipeline goes unnoticed. The cc to an external mailbox is the proven reliable path.

## Testing

New EmailService test asserting the cc on canary alerts; watched it fail first. Full EmailService suite 72/72, tsc clean, `pnpm format:check` clean.

Sonar not run locally (no SONAR_TOKEN on this box); Automatic Analysis covers the push.

No changelog entry — internal ops notification routing, no user-visible behavior change.

## Goal alignment

None — internal reliability. Protects the parser-canary safety net that guards the core conversion experience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018J3WrD4pRWsCFM1XxcTasX