### PR TITLE
test: align checkout e2e with monthly-default pricing

### DIFF
--- a/web/tests/checkout.spec.ts
+++ b/web/tests/checkout.spec.ts
@@ -52,24 +52,34 @@ test.describe('Unlimited checkout', () => {
     );
   });
 
-  test('flag-off prices show the legacy per-month hero and no v2 numbers', async ({
+  test('legacy prices show the monthly hero and no v2 numbers', async ({
     page,
   }) => {
     await routePrices(page, legacyPrices);
     await page.goto('/pricing');
 
-    await expect(page.getByText('$5.00').first()).toBeVisible();
-    await expect(
-      page.getByText('$60 billed today, then yearly · save 17%')
-    ).toBeVisible();
+    await expect(page.getByText('$6 billed today, then monthly')).toBeVisible();
     await expect(page.getByText('$5.33')).toBeHidden();
   });
 
-  test('annual is selected by default with the v2 per-month hero price', async ({
+  test('monthly is selected by default with the v2 monthly hero price', async ({
     page,
   }) => {
     await routePrices(page, v2Prices);
     await page.goto('/pricing');
+
+    await expect(
+      page.getByText('$7.99 billed today, then monthly')
+    ).toBeVisible();
+  });
+
+  test('selecting yearly reveals the annual per-month upsell', async ({
+    page,
+  }) => {
+    await routePrices(page, v2Prices);
+    await page.goto('/pricing');
+
+    await page.getByRole('radio', { name: /Yearly/ }).click();
 
     await expect(page.getByText('$5.33')).toBeVisible();
     await expect(
@@ -77,7 +87,7 @@ test.describe('Unlimited checkout', () => {
     ).toBeVisible();
   });
 
-  test('Get Unlimited starts an annual checkout and redirects to Stripe', async ({
+  test('Get Unlimited starts a monthly checkout by default', async ({
     page,
   }) => {
     await routePrices(page, v2Prices);
@@ -92,6 +102,29 @@ test.describe('Unlimited checkout', () => {
     });
 
     await page.goto('/pricing');
+    await page
+      .getByRole('button', { name: 'Get Unlimited — billed monthly' })
+      .click();
+
+    await expect.poll(() => checkoutBody.interval).toBe('month');
+  });
+
+  test('selecting yearly starts an annual checkout and redirects to Stripe', async ({
+    page,
+  }) => {
+    await routePrices(page, v2Prices);
+    let checkoutBody: { interval?: string } = {};
+    await page.route('**/api/checkout/unlimited', async (route) => {
+      checkoutBody = JSON.parse(route.request().postData() ?? '{}');
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ url: 'https://checkout.stripe.com/c/pay/test' }),
+      });
+    });
+
+    await page.goto('/pricing');
+    await page.getByRole('radio', { name: /Yearly/ }).click();
     await page
       .getByRole('button', { name: 'Get Unlimited — billed yearly' })
       .click();


### PR DESCRIPTION
## What

Rewrites `web/tests/checkout.spec.ts` to match the monthly-default pricing shipped in #3793.

## Why

#3793 ("default checkout to monthly, yearly stays the promoted upsell") flipped `billingCycle` to `month` but left the checkout e2e asserting the old annual-default:
- hero `$5.00`/`$5.33` (annual per-month) — now only shown after toggling yearly
- `Get Unlimited — billed yearly` button and `interval: year` — now monthly by default

So **playwright has been red on `main`** since #3793 merged, which blocks the green-gate on every subsequent PR (found while trying to merge an unrelated fix).

## How

- Legacy cohort → `$6 billed today, then monthly` hero, no v2 numbers leak.
- v2 cohort → `$7.99 billed today, then monthly` hero by default.
- `Get Unlimited — billed monthly` posts `interval: month`.
- New spec: selecting Yearly reveals the `$5.33` annual per-month hero and posts `interval: year`, so the upsell path stays covered.

Strings verified against the `common.json` unlimited-card copy and `formatDollars`/`formatAnnualPerMonth` (600¢→`$6`, 799¢→`$7.99`, 6400¢/12→`$5.33`).

## Testing

Test-only. Web tsc clean, `pnpm format:check` clean. Playwright runs green in CI on this branch (the point of the change).

Browser check: not applicable — Playwright e2e change only, no app source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018J3WrD4pRWsCFM1XxcTasX