### PR TITLE
feat: add Notion gallery badge and links to /notion-to-anki

### DIFF
--- a/web/src/pages/LandingPage/LandingPage.test.tsx
+++ b/web/src/pages/LandingPage/LandingPage.test.tsx
@@ -230,6 +230,28 @@ describe('LandingPage', () => {
     }
   });
 
+  it('links the Notion Integration Gallery badge to the public gallery listing', () => {
+    renderLandingPage(
+      <LandingPage copy={notionCopy} setErrorMessage={vi.fn()} />
+    );
+    const badgeLink = screen.getByRole('link', {
+      name: 'Notion Integration Gallery',
+    });
+    expect(badgeLink).toHaveAttribute(
+      'href',
+      'https://www.notion.com/connections/2anki'
+    );
+    expect(badgeLink).toHaveAttribute('target', '_blank');
+    expect(badgeLink).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('omits the gallery badge when the copy has no galleryBadge flag', () => {
+    renderLandingPage(<LandingPage copy={pdfCopy} setErrorMessage={vi.fn()} />);
+    expect(
+      screen.queryByRole('link', { name: 'Notion Integration Gallery' })
+    ).not.toBeInTheDocument();
+  });
+
   it('omits the Related nav when the copy has no relatedLinks', () => {
     const copyWithoutRelated = { ...notionCopy, relatedLinks: undefined };
     renderLandingPage(

--- a/web/src/pages/LandingPage/LandingPage.tsx
+++ b/web/src/pages/LandingPage/LandingPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, type ReactNode } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import UploadForm from '../UploadPage/components/UploadForm/UploadForm';
 import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
@@ -146,6 +146,24 @@ function LandingPage({
           <p className={styles.heroSubhead}>
             {t(`pages.${pageKey}.subhead`, { defaultValue: copy.subhead })}
           </p>
+          {copy.galleryBadge === true && (
+            <p className={styles.secondaryLink}>
+              <Trans
+                t={t}
+                i18nKey="badges.notionGallery"
+                defaults="Listed in the <galleryLink>Notion Integration Gallery</galleryLink>."
+                components={{
+                  galleryLink: (
+                    <a
+                      href="https://www.notion.com/connections/2anki"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    />
+                  ),
+                }}
+              />
+            </p>
+          )}
           {renderHeroAction({
             heroSlot,
             ctaHref: copy.ctaHref,

--- a/web/src/pages/LandingPage/copy/notion.ts
+++ b/web/src/pages/LandingPage/copy/notion.ts
@@ -2,10 +2,16 @@ import type { LandingCopy } from '../types';
 import { ankiFidelityProof } from './ankiFidelityProof';
 
 const notionCopy: LandingCopy = {
+  galleryBadge: true,
   relatedLinks: [
     {
       label: 'Convert Notion tables to Anki',
       href: '/convert/notion-tables-to-anki',
+    },
+    { label: 'Keep decks in sync with Notion', href: '/pricing' },
+    {
+      label: 'Which Notion blocks convert',
+      href: '/documentation/cards/notion-blocks',
     },
     {
       label: 'Convert Markdown and Obsidian notes to Anki',

--- a/web/src/pages/LandingPage/types.ts
+++ b/web/src/pages/LandingPage/types.ts
@@ -24,4 +24,5 @@ export interface LandingCopy {
   ctaHref?: string;
   whatComesAcross?: WhatComesAcrossItem[];
   relatedLinks?: ReadonlyArray<RelatedLink>;
+  galleryBadge?: boolean;
 }


### PR DESCRIPTION
## What
Two additive changes to the `/notion-to-anki` landing page only. A quiet trust line under the hero subhead — "Listed in the Notion Integration Gallery." — linking the phrase to the public listing at https://www.notion.com/connections/2anki (new tab, `rel="noopener noreferrer"`). And two Notion-native entries added to the page's Related links: "Keep decks in sync with Notion" -> `/pricing` (where Auto Sync is described publicly), and "Which Notion blocks convert" -> `/documentation/cards/notion-blocks`.

## Why
2anki was published in Notion's official Integration Gallery on 2026-07-21. This capitalizes on that acquisition channel: a gallery visitor arrives already Notion-familiar, so the page now (1) confirms the listing is real with an honest, exactly-true "Listed in" framing (no "Featured", no user/year count — the listing is 2 days old), and (2) links the two destinations most likely to convert that visitor. Trio-scoped (pm + designer + seo-content). Issue: https://github.com/Laer-Smart/2anki.net/issues/3774.

The badge uses the existing `.secondaryLink` muted/small treatment rather than a boxed chip so it doesn't fight the page's restrained visual weight. No Notion logo lockup (brand-guideline risk, unverified).

## How
- `LandingPage` renders the badge under the subhead, gated on a new optional `copy.galleryBadge` flag so it appears on `/notion-to-anki` only. The linked brand phrase is a real anchor rendered via `Trans` (`badges.notionGallery`) with an inline English `defaults`, so it goes through i18n and renders correctly on every locale via English fallback without a 10-file fan-out — future-translatable by adding the key.
- `notion.ts` sets `galleryBadge: true` and adds the two related links. Related-link labels follow the existing hardcoded-English convention in that array (the five siblings are not routed through `t()`); introducing a per-string i18n pattern for two links would drift from the file.
- H1/hero-subhead copy, homepage, and meta/title/JSON-LD were left untouched (explicitly out of scope).

Destination note: `/ankify` is auth-gated (a logged-out gallery visitor bounces to login), so "Keep decks in sync with Notion" points at `/pricing`, the public surface that describes Auto Sync — consistent with the page's own FAQ ("see Auto Sync on the pricing page"). Both destinations were verified to exist and render (`/pricing` route in `App.tsx`; `content/cards/notion-blocks.md` under `/documentation/*`).

## Measuring success
Landing -> checkout/signup on `/notion-to-anki` at `/api/ops/metrics`, read against next week's baseline funnel pull. The gallery is a new referral source; the near-term signal is referral traffic from `notion.com/connections/2anki` in analytics and any lift in `/notion-to-anki` -> `/pricing` / `/register` clickthrough.

## Testing
- Unit tests added (vitest): badge links to the public gallery listing with `target="_blank"` + `rel="noopener noreferrer"`; badge is omitted when `copy.galleryBadge` is unset (pdf copy). The existing "renders the Related nav with every relatedLink" test iterates the array and now asserts the two new links' hrefs.
- `LandingPage.test.tsx` 22/22 pass; `LandingPage.i18n.test.tsx` 3/3 pass; web `tsc --noEmit` clean; `oxfmt --check` + `oxlint` clean on changed files.
- Sonar not run locally (no Docker / no `SONAR_TOKEN` on this box); Automatic Analysis covers the push.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: `pnpm --filter 2anki-web test:golden-path` green (2/2) at 375px, no page console errors (the only output is a benign vite-dev Hotjar-over-HTTP warning). Badge + both related links verified rendering with correct hrefs via the component tests.

## Changelog
no changelog entry — the What's New page is read by logged-in app users, and this is SEO/marketing microcopy on a public landing page aimed at logged-out gallery visitors; it is not a product capability those users would look for there.

## Risks
Low. Purely additive presentational copy + two internal links, gated to one page. If the badge ever reads as overclaiming, deleting the `galleryBadge` flag from `notion.ts` removes it with zero other impact. Both link targets are existing, in-repo routes — no 404 risk.

## Goal alignment
Acquisition lane: converts Notion Integration Gallery referral traffic. Trust signal + two conversion-relevant internal links should move `/notion-to-anki` -> signup/checkout clickthrough (read at `/api/ops/metrics`), assessed against next week's baseline. Simpler/faster/more beautiful: one quiet line, no added visual weight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018J3WrD4pRWsCFM1XxcTasX