### PR TITLE
fix: sync AI conversion preference across devices from upload toggle

### DIFF
--- a/web/src/pages/UploadPage/UploadPage.test.tsx
+++ b/web/src/pages/UploadPage/UploadPage.test.tsx
@@ -20,6 +20,11 @@ vi.mock('../../lib/analytics/track', () => ({
   track: (...args: unknown[]) => trackMock(...args),
 }));
 
+const scheduleSyncMock = vi.fn();
+vi.mock('../../lib/data_layer/userPreferencesSync', () => ({
+  scheduleSync: (...args: unknown[]) => scheduleSyncMock(...args),
+}));
+
 type FakeUser = {
   id?: number;
   created_at?: string | null;
@@ -177,6 +182,7 @@ describe('UploadPage AI badge placement', () => {
 describe('UploadPage AI toggle', () => {
   beforeEach(() => {
     trackMock.mockClear();
+    scheduleSyncMock.mockClear();
     fakeUser = null;
     fakeLocals = undefined;
     globalThis.localStorage.clear();
@@ -187,6 +193,20 @@ describe('UploadPage AI toggle', () => {
     fakeUser = null;
     fakeLocals = undefined;
     globalThis.localStorage.clear();
+  });
+
+  it('syncs the AI preference to the server so it follows the user across devices', async () => {
+    fakeUser = { id: 42 };
+    fakeLocals = { patreon: true, subscriber: false };
+    renderPage();
+    const toggle = screen.getByRole('button', { name: /turn ai on/i });
+    toggle.click();
+    await waitFor(() => {
+      expect(globalThis.localStorage.getItem('claude-ai-flashcards')).toBe(
+        'true'
+      );
+    });
+    expect(scheduleSyncMock).toHaveBeenCalled();
   });
 
   it('shows an upgrade link and no toggle for a signed-in non-paying user', () => {

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -7,6 +7,7 @@ import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessag
 import { PassLadderCard } from '../../components/PassLadderCard/PassLadderCard';
 import { track } from '../../lib/analytics/track';
 import { storePassToken } from '../../lib/anonymousPass';
+import { saveValueInLocalStorage } from '../../lib/data_layer/saveValueInLocalStorage';
 import useQuery from '../../lib/hooks/useQuery';
 import { useUserLocals } from '../../lib/hooks/useUserLocals';
 import styles from '../../styles/shared.module.css';
@@ -83,7 +84,7 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
 
   const toggleAi = () => {
     const next = !isAiOn;
-    globalThis.localStorage?.setItem(AI_FLAG_KEY, String(next));
+    saveValueInLocalStorage(AI_FLAG_KEY, String(next), null);
     setAiFlag(next);
     track(next ? 'upload_ai_turned_on' : 'upload_ai_turned_off');
   };

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-23-ai-conversion-preference-sync.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-23-ai-conversion-preference-sync.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-23-ai-conversion-preference-sync",
+  "date": "2026-07-23",
+  "type": "fix",
+  "title": "AI conversion preference follows you across devices and browsers when signed in"
+}


### PR DESCRIPTION
## What
The upload page AI toggle wrote `claude-ai-flashcards` straight to `localStorage` without triggering the per-user preferences sync. This routes the toggle through `saveValueInLocalStorage` — the same sanctioned helper the card-options form, theme, and language picker already use — so the AI-conversion choice syncs to the server and follows a signed-in user across devices.

## Why
Fixes 2anki/server#3810. A paying user who switched devices, cleared storage, or used a different browser silently lost the AI setting and reverted to the default heuristic path with no indication anything changed. Scope is intentionally narrow: only WHERE the preference is stored changes. The `isPaying && aiFlag` paywall gate is untouched, and the discoverability/prominence question the issue raises is explicitly out of scope (open product decision).

## How
`claude-ai-flashcards` is already a server-side preference — it lives in the `users.card_options` JSON blob (in `ALLOWED_CARD_OPTION_KEYS`, collected by `collectCardOptions`, restored by `hydrateFromServer`). So no migration and no new column are needed; the only gap was the client write path. The one-line change swaps the raw `localStorage.setItem` in `toggleAi` for `saveValueInLocalStorage(key, value, null)`, which writes localStorage AND calls `scheduleSync()` (debounced `PATCH /api/users/me/preferences`). Anonymous/logged-out users keep the localStorage-only fallback exactly as before — `scheduleSync` no-ops when there's no token cookie.

## Measuring success
The existing `upload_ai_turned_on` / `upload_ai_turned_off` analytics events still fire on toggle; a subsequent `PATCH /api/users/me/preferences` with `cardOptions["claude-ai-flashcards"]` in the body (visible in server request logs) confirms the sync now reaches the server from the upload path. Cross-device: the flag hydrates from `users.card_options` on the next signed-in session.

## Testing
- Unit test added (`UploadPage.test.tsx`): a paying user clicking the AI toggle now triggers `scheduleSync` (the server-sync mechanism), asserted alongside the existing localStorage write. Verified it fails without the fix (scheduleSync never called) and passes with it.
- Full web vitest suite green (2702 tests), server tsc clean, web typecheck clean, `pnpm format:check` clean.
- Sonar not run locally (no Docker/SONAR_TOKEN on this box) — Automatic Analysis covers the push.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: `pnpm --filter 2anki-web test:golden-path` passed (2/2, no console errors at 375px). The toggle UI and badge states are unchanged — only the storage destination of the existing click handler moved.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-07-23-ai-conversion-preference-sync.json` — "AI conversion preference follows you across devices and browsers when signed in"

## Risks
Low. The change reuses the established sync helper; the only new outbound call on toggle is the same debounced preferences PATCH that theme/language/card-options already make. Rollback is a one-line revert. No server, schema, or paywall change.

## Goal alignment
Retention/per-user value lever: paying users keep the denser AI-conversion mode they're paying for instead of silently dropping back to the default path on a new device — the mode is 2anki's best output. No new funnel surface; this protects an existing paid setting from silent loss.
