### PR TITLE
chore: add ops command to provision Stripe Semester Pass

### DIFF
--- a/src/controllers/OpsController.test.ts
+++ b/src/controllers/OpsController.test.ts
@@ -9,6 +9,7 @@ import { GetLandingPageYieldUseCase } from '../usecases/ops/GetLandingPageYieldU
 import { GetCustomerSignalsUseCase } from '../usecases/ops/GetCustomerSignalsUseCase';
 import { GetPassUnlockMonitorUseCase } from '../usecases/ops/GetPassUnlockMonitorUseCase';
 import { GetCancelFunnelUseCase } from '../usecases/ops/GetCancelFunnelUseCase';
+import { CreateSemesterPassUseCase } from '../usecases/ops/CreateSemesterPassUseCase';
 
 const buildRes = () => {
   const json = jest.fn();
@@ -588,6 +589,87 @@ describe('OpsController.getCancelFunnel', () => {
       .mockImplementation(() => undefined);
 
     await controller.getCancelFunnel(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    errSpy.mockRestore();
+  });
+});
+
+describe('OpsController.createSemesterPass', () => {
+  const buildController = (useCase?: CreateSemesterPassUseCase) =>
+    new OpsController(
+      {} as unknown as GetOpsMetricsUseCase,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      useCase
+    );
+
+  it('returns the provisioned product/price with status 200', async () => {
+    const payload = {
+      stripe_product_id: 'prod_semester',
+      stripe_price_id: 'price_semester',
+      created_product: true,
+      created_price: true,
+    };
+    const useCase = {
+      execute: jest.fn().mockResolvedValue(payload),
+    } as unknown as CreateSemesterPassUseCase;
+    const controller = buildController(useCase);
+    const req = {} as unknown as express.Request;
+    const res = buildRes();
+
+    await controller.createSemesterPass(req, res);
+
+    expect(useCase.execute as jest.Mock).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(payload);
+  });
+
+  it('responds 500 when the use case is not configured', async () => {
+    const controller = buildController(undefined);
+    const req = {} as unknown as express.Request;
+    const res = buildRes();
+
+    await controller.createSemesterPass(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.any(String) })
+    );
+  });
+
+  it('responds 500 when the use case throws', async () => {
+    const useCase = {
+      execute: jest.fn().mockRejectedValue(new Error('stripe down')),
+    } as unknown as CreateSemesterPassUseCase;
+    const controller = buildController(useCase);
+    const req = {} as unknown as express.Request;
+    const res = buildRes();
+    const errSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    await controller.createSemesterPass(req, res);
 
     expect(res.status).toHaveBeenCalledWith(500);
     errSpy.mockRestore();

--- a/src/controllers/OpsController.ts
+++ b/src/controllers/OpsController.ts
@@ -25,6 +25,7 @@ import { GetLandingPageYieldUseCase } from '../usecases/ops/GetLandingPageYieldU
 import { GetCustomerSignalsUseCase } from '../usecases/ops/GetCustomerSignalsUseCase';
 import { GetPassUnlockMonitorUseCase } from '../usecases/ops/GetPassUnlockMonitorUseCase';
 import { CreateDeveloperTiersUseCase } from '../usecases/ops/CreateDeveloperTiersUseCase';
+import { CreateSemesterPassUseCase } from '../usecases/ops/CreateSemesterPassUseCase';
 import GrantDeveloperAccessUseCase, {
   InvalidEmailError,
 } from '../usecases/developer/GrantDeveloperAccessUseCase';
@@ -53,7 +54,8 @@ class OpsController {
     private readonly sendPassWinbackUseCase?: SendPassWinbackUseCase,
     private readonly grantDeveloperAccessUseCase?: GrantDeveloperAccessUseCase,
     private readonly getCancelFunnelUseCase?: GetCancelFunnelUseCase,
-    private readonly createDeveloperTiersUseCase?: CreateDeveloperTiersUseCase
+    private readonly createDeveloperTiersUseCase?: CreateDeveloperTiersUseCase,
+    private readonly createSemesterPassUseCase?: CreateSemesterPassUseCase
   ) {}
 
   async createDeveloperTiers(_req: express.Request, res: express.Response) {
@@ -67,6 +69,22 @@ class OpsController {
     } catch (error) {
       console.error('[ops] createDeveloperTiers failed', error);
       res.status(500).json({ message: 'Failed to create developer tiers' });
+    }
+  }
+
+  async createSemesterPass(_req: express.Request, res: express.Response) {
+    if (this.createSemesterPassUseCase == null) {
+      res
+        .status(500)
+        .json({ message: 'Semester pass provisioning not configured' });
+      return;
+    }
+    try {
+      const result = await this.createSemesterPassUseCase.execute();
+      res.status(200).json(result);
+    } catch (error) {
+      console.error('[ops] createSemesterPass failed', error);
+      res.status(500).json({ message: 'Failed to provision semester pass' });
     }
   }
 

--- a/src/routes/OpsRouter.test.ts
+++ b/src/routes/OpsRouter.test.ts
@@ -8,7 +8,10 @@ jest.mock('../lib/integrations/stripe', () => ({
       list: jest.fn().mockResolvedValue({
         data: [{ id: 'prod_unlimited', name: 'Unlimited' }],
       }),
-      create: jest.fn(),
+      create: jest.fn().mockImplementation(async (params) => ({
+        id: 'prod_created',
+        metadata: params?.metadata ?? {},
+      })),
     },
     prices: {
       list: jest.fn().mockResolvedValue({ data: [] }),
@@ -399,6 +402,43 @@ describe('OpsRouter /api/ops/send-abandoned-checkout-recovery', () => {
         }
       );
       expect(response.status).toBe(404);
+    } finally {
+      await close();
+    }
+  });
+});
+
+describe('OpsRouter /api/ops/commands/create-semester-pass', () => {
+  it('returns 404 for non-owner callers', async () => {
+    const { url, close } = await startServer(false);
+    try {
+      const response = await fetch(
+        `${url}/api/ops/commands/create-semester-pass`,
+        { method: 'POST' }
+      );
+      expect(response.status).toBe(404);
+    } finally {
+      await close();
+    }
+  });
+
+  it('returns 200 with the provisioned product/price for the ops owner', async () => {
+    const { url, close } = await startServer(true);
+    try {
+      const response = await fetch(
+        `${url}/api/ops/commands/create-semester-pass`,
+        { method: 'POST' }
+      );
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body).toEqual(
+        expect.objectContaining({
+          stripe_product_id: expect.any(String),
+          stripe_price_id: expect.any(String),
+          created_product: expect.any(Boolean),
+          created_price: expect.any(Boolean),
+        })
+      );
     } finally {
       await close();
     }

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -69,6 +69,7 @@ import { ListFeatureFlagsUseCase } from '../usecases/ops/ListFeatureFlagsUseCase
 import { SetFeatureFlagUseCase } from '../usecases/ops/SetFeatureFlagUseCase';
 import { getStripe } from '../lib/integrations/stripe';
 import { CreateDeveloperTiersUseCase } from '../usecases/ops/CreateDeveloperTiersUseCase';
+import { CreateSemesterPassUseCase } from '../usecases/ops/CreateSemesterPassUseCase';
 import DeveloperTiersRepository from '../data_layer/DeveloperTiersRepository';
 import { OrphanedSubscriptionsRepository } from '../data_layer/OrphanedSubscriptionsRepository';
 import { SubscriptionRecoveryNotificationsRepository } from '../data_layer/SubscriptionRecoveryNotificationsRepository';
@@ -201,7 +202,8 @@ const OpsRouter = () => {
     new CreateDeveloperTiersUseCase(
       getStripe(),
       new DeveloperTiersRepository(database)
-    )
+    ),
+    new CreateSemesterPassUseCase(getStripe())
   );
 
   /**
@@ -643,6 +645,32 @@ const OpsRouter = () => {
     '/api/ops/commands/create-developer-tiers',
     RequireOpsAccess,
     (req, res) => controller.createDeveloperTiers(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ops/commands/create-semester-pass:
+   *   post:
+   *     summary: Provision the Stripe Semester Pass product and one-time price
+   *     description: |
+   *       Internal endpoint locked to the ops owner. Idempotently ensures a single
+   *       "2anki Semester Pass" Stripe product (found by product metadata) and one
+   *       one-time $14.99 USD price (no recurring interval) exist. Safe to re-run.
+   *       This only provisions the Stripe product/price — it does NOT enable any
+   *       checkout path. A human must copy the returned stripe_price_id into the
+   *       PASS_4MO_PRICE_ID env var before any purchase flow can reference it, and
+   *       no such flow exists yet. Returns 404 for everyone else.
+   *     tags: [Ops]
+   *     responses:
+   *       200:
+   *         description: The provisioned product/price ids with created/found flags
+   *       404:
+   *         description: Not the ops owner
+   */
+  router.post(
+    '/api/ops/commands/create-semester-pass',
+    RequireOpsAccess,
+    (req, res) => controller.createSemesterPass(req, res)
   );
 
   /**

--- a/src/usecases/ops/CreateSemesterPassUseCase.test.ts
+++ b/src/usecases/ops/CreateSemesterPassUseCase.test.ts
@@ -1,0 +1,136 @@
+import { CreateSemesterPassUseCase } from './CreateSemesterPassUseCase';
+
+interface FakeStripeSeed {
+  products?: Array<{ id: string; metadata: Record<string, string> }>;
+  prices?: Array<{
+    id: string;
+    product: string;
+    unit_amount: number;
+    currency: string;
+    recurring: { interval: string } | null;
+  }>;
+}
+
+function makeStripe(seed: FakeStripeSeed = {}) {
+  const products = seed.products ?? [];
+  const prices = seed.prices ?? [];
+  return {
+    products: {
+      list: jest.fn().mockResolvedValue({ data: products }),
+      create: jest.fn().mockImplementation(async (params) => ({
+        id: 'prod_created_semester',
+        metadata: params.metadata,
+      })),
+    },
+    prices: {
+      list: jest.fn().mockImplementation(async ({ product }) => ({
+        data: prices.filter((price) => price.product === product),
+      })),
+      create: jest.fn().mockImplementation(async (params) => ({
+        id: `price_created_${params.product}`,
+        unit_amount: params.unit_amount,
+        currency: params.currency,
+        recurring: params.recurring ?? null,
+      })),
+    },
+  };
+}
+
+describe('CreateSemesterPassUseCase', () => {
+  it('creates the product and a one-time price when neither exists', async () => {
+    const stripe = makeStripe();
+    const useCase = new CreateSemesterPassUseCase(stripe as never);
+
+    const result = await useCase.execute();
+
+    expect(stripe.products.create).toHaveBeenCalledTimes(1);
+    expect(stripe.prices.create).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      stripe_product_id: 'prod_created_semester',
+      stripe_price_id: 'price_created_prod_created_semester',
+      created_product: true,
+      created_price: true,
+    });
+  });
+
+  it('creates a one-time price with no recurring field', async () => {
+    const stripe = makeStripe();
+    const useCase = new CreateSemesterPassUseCase(stripe as never);
+
+    await useCase.execute();
+
+    const priceParams = stripe.prices.create.mock.calls[0][0];
+    expect(priceParams.unit_amount).toBe(1499);
+    expect(priceParams.currency).toBe('usd');
+    expect(priceParams.recurring).toBeUndefined();
+  });
+
+  it('reuses an existing product found by pass-kind metadata', async () => {
+    const stripe = makeStripe({
+      products: [
+        { id: 'prod_semester', metadata: { '2anki_pass_kind': 'semester' } },
+      ],
+    });
+    const useCase = new CreateSemesterPassUseCase(stripe as never);
+
+    const result = await useCase.execute();
+
+    expect(stripe.products.create).not.toHaveBeenCalled();
+    expect(stripe.prices.create).toHaveBeenCalledTimes(1);
+    expect(result.stripe_product_id).toBe('prod_semester');
+    expect(result.created_product).toBe(false);
+    expect(result.created_price).toBe(true);
+  });
+
+  it('reuses an existing one-time price by amount and currency', async () => {
+    const stripe = makeStripe({
+      products: [
+        { id: 'prod_semester', metadata: { '2anki_pass_kind': 'semester' } },
+      ],
+      prices: [
+        {
+          id: 'price_semester',
+          product: 'prod_semester',
+          unit_amount: 1499,
+          currency: 'usd',
+          recurring: null,
+        },
+      ],
+    });
+    const useCase = new CreateSemesterPassUseCase(stripe as never);
+
+    const result = await useCase.execute();
+
+    expect(stripe.products.create).not.toHaveBeenCalled();
+    expect(stripe.prices.create).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      stripe_product_id: 'prod_semester',
+      stripe_price_id: 'price_semester',
+      created_product: false,
+      created_price: false,
+    });
+  });
+
+  it('ignores a recurring price at the same amount and creates a one-time price', async () => {
+    const stripe = makeStripe({
+      products: [
+        { id: 'prod_semester', metadata: { '2anki_pass_kind': 'semester' } },
+      ],
+      prices: [
+        {
+          id: 'price_recurring',
+          product: 'prod_semester',
+          unit_amount: 1499,
+          currency: 'usd',
+          recurring: { interval: 'month' },
+        },
+      ],
+    });
+    const useCase = new CreateSemesterPassUseCase(stripe as never);
+
+    const result = await useCase.execute();
+
+    expect(stripe.prices.create).toHaveBeenCalledTimes(1);
+    expect(result.created_price).toBe(true);
+  });
+});

--- a/src/usecases/ops/CreateSemesterPassUseCase.ts
+++ b/src/usecases/ops/CreateSemesterPassUseCase.ts
@@ -1,0 +1,68 @@
+import type Stripe from 'stripe';
+
+export const PASS_KIND_METADATA_KEY = '2anki_pass_kind';
+export const SEMESTER_PASS_KIND = 'semester';
+export const SEMESTER_PASS_PRODUCT_NAME = '2anki Semester Pass';
+export const SEMESTER_PASS_AMOUNT_CENTS = 1499;
+
+export interface ProvisionedSemesterPass {
+  stripe_product_id: string;
+  stripe_price_id: string;
+  created_product: boolean;
+  created_price: boolean;
+}
+
+export class CreateSemesterPassUseCase {
+  constructor(private readonly stripe: Stripe) {}
+
+  async execute(): Promise<ProvisionedSemesterPass> {
+    const existingProducts = await this.stripe.products.list({
+      active: true,
+      limit: 100,
+    });
+
+    let createdProduct = false;
+    let product = existingProducts.data.find(
+      (candidate) =>
+        candidate.metadata?.[PASS_KIND_METADATA_KEY] === SEMESTER_PASS_KIND
+    );
+    if (product == null) {
+      product = await this.stripe.products.create({
+        name: SEMESTER_PASS_PRODUCT_NAME,
+        metadata: { [PASS_KIND_METADATA_KEY]: SEMESTER_PASS_KIND },
+      });
+      createdProduct = true;
+    }
+
+    const prices = await this.stripe.prices.list({
+      product: product.id,
+      active: true,
+      limit: 100,
+    });
+    let createdPrice = false;
+    let price = prices.data.find(
+      (candidate) =>
+        candidate.unit_amount === SEMESTER_PASS_AMOUNT_CENTS &&
+        candidate.currency === 'usd' &&
+        candidate.recurring == null
+    );
+    if (price == null) {
+      price = await this.stripe.prices.create({
+        product: product.id,
+        unit_amount: SEMESTER_PASS_AMOUNT_CENTS,
+        currency: 'usd',
+        metadata: { [PASS_KIND_METADATA_KEY]: SEMESTER_PASS_KIND },
+      });
+      createdPrice = true;
+    }
+
+    return {
+      stripe_product_id: product.id,
+      stripe_price_id: price.id,
+      created_product: createdProduct,
+      created_price: createdPrice,
+    };
+  }
+}
+
+export default CreateSemesterPassUseCase;


### PR DESCRIPTION
## What
Adds an internal ops command, `POST /api/ops/commands/create-semester-pass`, that idempotently provisions the Stripe product and one-time price the Semester Pass needs. It find-or-creates a single "2anki Semester Pass" product (tagged with metadata `2anki_pass_kind: 'semester'`) and one one-time $14.99 USD price (no `recurring` field), then returns `{ stripe_product_id, stripe_price_id, created_product, created_price }`. Safe to re-run. Mirrors the existing `create-developer-tiers` provisioning pattern.

## Why
Precursor tooling for the Semester Pass spec in 2anki/server#3621 — **not** an implementation of that spec. #3621 stays open and gated exactly as it is (behind a prod cannibalization-pull read and a `/security-review` on the eventual checkout/webhook wiring). Creating a Stripe Product + Price does not enable any purchase path, so this inert provisioning is safe to ship ahead of those gates. It hands Alexander a price ID to copy into a `PASS_4MO_PRICE_ID` env var, exactly like `PASS_24H_PRICE_ID` / `PASS_7D_PRICE_ID` already work.

## How
- `CreateSemesterPassUseCase` — one product, one one-time price; find-by-metadata for the product, find-by-`unit_amount`+`currency`+absence-of-`recurring` for the price. No DB table (the spec decided pass `kind` is plain text, config + code only — no migration).
- Wired into `OpsController.createSemesterPass` (optional-use-case injection, 500 if unconfigured, try/catch → generic 500) and `OpsRouter` (`RequireOpsAccess`-gated route + swagger doc that states plainly it only provisions Stripe and a human must copy the returned price ID into `PASS_4MO_PRICE_ID`).

## Measuring success
Not a user-facing funnel change. Verify by running the command once after deploy and confirming the JSON returns a `stripe_price_id`; confirm the product/price exist in the Stripe dashboard. Re-running returns `created_product: false, created_price: false` (idempotency).

## Invocation (after merge + deploy)
`RequireOpsAccess` authenticates via the ops-owner session `token` cookie (email `alexander@alemayhu.com`), returning 404 to anyone else. Invoke from a logged-in browser session, e.g.:
`curl -X POST https://2anki.net/api/ops/commands/create-semester-pass -H "Cookie: token=<your ops session token>"`
Copy the returned `stripe_price_id` into the `PASS_4MO_PRICE_ID` env var. No checkout path reads it yet.

## Testing
- Unit tests added: `CreateSemesterPassUseCase.test.ts` — creates product+price when neither exists; reuses existing product by metadata; reuses existing one-time price by amount/currency; asserts the created price has no `recurring` field; ignores a recurring price at the same amount and creates a one-time one.
- Controller tests: 200 with the provisioned result, 500 when the use case is not configured, 500 when it throws.
- Route tests: 404 for non-ops-owner (via `RequireOpsAccess`), 200 with the provisioned shape for the ops owner.
- `pnpm test` (touched suites), `tsc -p . --noEmit`, `pnpm format:check`, and oxlint on changed files all green. Sonar not run locally (no Docker/SONAR_TOKEN on this box); Automatic Analysis covers the push.

## Browser check
Browser check: not applicable — no `web/src/` files touched; backend ops tooling only.

## Changelog
No changelog entry — internal ops tool, not user-visible.

## What this PR does NOT do
- No `CheckoutRouter.ts` wiring for the Semester Pass.
- No `WebhookRouter.ts` handling of a semester-pass purchase event.
- No `'semester'`/`'120d'` addition to the `PassKind` union in `src/data_layer/UserPassRepository.ts`.
- Nothing that lets a real user buy a Semester Pass today.
These are gated in the spec behind the prod cannibalization read and a `/security-review` on the checkout/webhook PR specifically. This PR is the ops-tooling precursor only.

## Risks
Low. The command only calls Stripe `products.list/create` and `prices.list/create`; idempotent, no DB writes, gated to the ops owner. Rollback is reverting the branch — no runtime behavior changes for any user. If run against test-mode Stripe keys it creates test-mode objects; run against the intended (live) key.

## Goal alignment
None — internal ops tooling. It unblocks the Semester Pass revenue experiment (#3621) without committing to it; the revenue metric moves only when the gated checkout PR ships later.
