### PR TITLE
feat: add ops-page button to provision the Semester Pass Stripe price

### DIFF
--- a/web/src/pages/OpsPage/CommandsTab.tsx
+++ b/web/src/pages/OpsPage/CommandsTab.tsx
@@ -4,6 +4,7 @@ import sharedStyles from '../../styles/shared.module.css';
 import styles from './OpsPage.module.css';
 import { syncStripeSubscriptions } from './syncStripeSubscriptions';
 import { createDeveloperTiers, ProvisionedTier } from './createDeveloperTiers';
+import { createSemesterPass } from './createSemesterPass';
 import { grantDeveloperAccess } from './grantDeveloperAccess';
 import {
   deleteInactiveUsers,
@@ -121,6 +122,26 @@ export default function CommandsTab() {
     } catch (error) {
       setTiersStatus('error');
       setTiersMessage(error instanceof Error ? error.message : 'Unknown error');
+    }
+  };
+
+  const [semesterStatus, setSemesterStatus] = useState<Status>('idle');
+  const [semesterMessage, setSemesterMessage] = useState('');
+
+  const runCreateSemesterPass = async () => {
+    setSemesterStatus('loading');
+    setSemesterMessage('');
+    try {
+      const result = await createSemesterPass();
+      setSemesterStatus('success');
+      setSemesterMessage(
+        `${result.created_product ? 'product created' : 'product found'}, ${result.created_price ? 'price created' : 'price found'} (${result.stripe_price_id}). Set PASS_4MO_PRICE_ID to this price id.`
+      );
+    } catch (error) {
+      setSemesterStatus('error');
+      setSemesterMessage(
+        error instanceof Error ? error.message : 'Unknown error'
+      );
     }
   };
 
@@ -305,6 +326,39 @@ export default function CommandsTab() {
       {tiersStatus === 'error' && tiersMessage && (
         <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
           {tiersMessage}
+        </div>
+      )}
+
+      <section className={`${sharedStyles.surface} ${styles.card}`}>
+        <h2 className={styles.cardTitle}>Semester pass</h2>
+        <p className={styles.panelSubtitle}>
+          Creates the Semester Pass one-time product and price in Stripe. No
+          database row — copy the returned price id into PASS_4MO_PRICE_ID.
+          Idempotent — re-running finds the existing product by metadata instead
+          of duplicating it. Checkout and webhook wiring are not built yet (see
+          spec-lifecycle gate in #3621) — provisioning this price does not
+          enable a purchase path.
+        </p>
+        <div className={styles.controls}>
+          <button
+            type="button"
+            className={sharedStyles.btnSmall}
+            onClick={runCreateSemesterPass}
+            disabled={semesterStatus === 'loading'}
+          >
+            {semesterStatus === 'loading' ? 'Provisioning…' : 'Create pass'}
+          </button>
+        </div>
+      </section>
+
+      {semesterStatus === 'success' && semesterMessage && (
+        <div className={`${sharedStyles.alertSuccess} ${styles.banner}`}>
+          {semesterMessage}
+        </div>
+      )}
+      {semesterStatus === 'error' && semesterMessage && (
+        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
+          {semesterMessage}
         </div>
       )}
 

--- a/web/src/pages/OpsPage/createSemesterPass.test.ts
+++ b/web/src/pages/OpsPage/createSemesterPass.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { createSemesterPass } from './createSemesterPass';
+
+describe('createSemesterPass', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test('POSTs to the create-semester-pass endpoint and returns the provisioned result', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () =>
+        Promise.resolve({
+          stripe_product_id: 'prod_123',
+          stripe_price_id: 'price_123',
+          created_product: true,
+          created_price: true,
+        }),
+    });
+
+    const result = await createSemesterPass();
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/ops/commands/create-semester-pass',
+      { method: 'POST', credentials: 'include' }
+    );
+    expect(result).toEqual({
+      stripe_product_id: 'prod_123',
+      stripe_price_id: 'price_123',
+      created_product: true,
+      created_price: true,
+    });
+  });
+
+  test('throws the server message on failure', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: () =>
+        Promise.resolve({ message: 'Failed to provision semester pass' }),
+    });
+
+    await expect(createSemesterPass()).rejects.toThrow(
+      'Failed to provision semester pass'
+    );
+  });
+
+  test('falls back to status text when the error body has no message', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: () => Promise.reject(new Error('no body')),
+    });
+
+    await expect(createSemesterPass()).rejects.toThrow(
+      '500 Internal Server Error'
+    );
+  });
+});

--- a/web/src/pages/OpsPage/createSemesterPass.ts
+++ b/web/src/pages/OpsPage/createSemesterPass.ts
@@ -1,0 +1,20 @@
+export interface ProvisionedSemesterPass {
+  stripe_product_id: string;
+  stripe_price_id: string;
+  created_product: boolean;
+  created_price: boolean;
+}
+
+export async function createSemesterPass(): Promise<ProvisionedSemesterPass> {
+  const response = await fetch('/api/ops/commands/create-semester-pass', {
+    method: 'POST',
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(
+      data.message ?? `${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+}


### PR DESCRIPTION
## What
PR #3820 shipped the backend command (`POST /api/ops/commands/create-semester-pass`) but never added a button for it on `/ops/commands`, unlike every other ops command there. Wires it in, mirroring the existing "Developer tiers" button exactly.

## Why
Reported directly: the command existed with no way to trigger it from the ops UI.

## How
- `createSemesterPass.ts` — client fetch wrapper, same shape as `createDeveloperTiers.ts`.
- `CommandsTab.tsx` — new "Semester pass" section/button, same status/message handling pattern as the developer-tiers section. Copy states plainly that checkout/webhook wiring isn't built yet (spec gate in #3621) and that the returned price id goes into `PASS_4MO_PRICE_ID`.

## Testing
- `createSemesterPass.test.ts` — 3 cases mirroring `syncStripeSubscriptions.test.ts`.
- Full web vitest suite green (2707 passed), `tsc --noEmit` clean, tree-wide `pnpm format:check` clean.

## Changelog
no changelog entry — internal ops-only admin page, not user-visible.

## Browser check
Browser check: not applicable — the interactive browser tool in this environment has no Chrome channel installed; a real interactive check wasn't completed. Alexander is merging directly and verifying on `/ops/commands` himself post-deploy. The change is a small mirror of the existing, already-proven "Developer tiers" section (identical component structure, styles, and status-handling pattern), and passes typecheck/lint/full test suite.
