### PR TITLE
fix: add columns_guessed_notice_shown to server KNOWN_EVENTS

### DIFF
--- a/src/controllers/EventsController.test.ts
+++ b/src/controllers/EventsController.test.ts
@@ -273,6 +273,19 @@ describe('EventsController', () => {
       expect.objectContaining({ name: eventName, unknown: false })
     );
   });
+
+  it('accepts columns_guessed_notice_shown as known, not unknown', () => {
+    const { controller, req, res, executeSpy } = buildMocks({ userId: 1 });
+    req.body = { name: 'columns_guessed_notice_shown' };
+    controller.track(req, res);
+    expect(res.status).toHaveBeenCalledWith(202);
+    expect(executeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'columns_guessed_notice_shown',
+        unknown: false,
+      })
+    );
+  });
 });
 
 describe('EventsController — regression: all client events return 202 (AC #5)', () => {

--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -86,6 +86,7 @@ export const KNOWN_EVENTS = new Set([
   'ankify_review_completed',
   'ankify_review_session_exited',
   'image_drop_notice_shown',
+  'columns_guessed_notice_shown',
   'unsupported_blocks_notice_shown',
   'image_only_no_text_shown',
   'conversion_pathology_shown',


### PR DESCRIPTION
## Summary
`columns_guessed_notice_shown` (fired by `ColumnsGuessedNotice.tsx`, added for #3617) was present in the web `KnownEvent` set but missing from the server-side `KNOWN_EVENTS` allowlist in `src/types/AnalyticsEvents.ts`. Every occurrence recorded server-side with `unknown: true`, undercounting the notice in analytics.

## Fix
One-line addition to `KNOWN_EVENTS`, plus a regression test asserting the event now records `unknown: false`.

Fixes #3825

Browser check: not applicable — server-only analytics allowlist, no rendered output change.

No changelog entry — internal analytics fix, not user-visible.

Sonar not run locally (no Docker/SONAR_TOKEN on this box tonight); Automatic Analysis will cover the push.
