### PR TITLE
feat: add a public shared-deck library (v1)

### DIFF
--- a/migrations/20260929000000_add_public_listing_to_deck_shares.js
+++ b/migrations/20260929000000_add_public_listing_to_deck_shares.js
@@ -1,0 +1,19 @@
+module.exports.up = async function (knex) {
+  await knex.schema.alterTable('deck_shares', (table) => {
+    table.boolean('is_public').notNullable().defaultTo(false);
+    table.string('title', 120).nullable();
+    table.integer('card_count').nullable();
+  });
+  await knex.raw(
+    'create index deck_shares_public_listing_idx on deck_shares (created_at desc) where is_public = true and revoked_at is null'
+  );
+};
+
+module.exports.down = async function (knex) {
+  await knex.raw('drop index if exists deck_shares_public_listing_idx');
+  await knex.schema.alterTable('deck_shares', (table) => {
+    table.dropColumn('is_public');
+    table.dropColumn('title');
+    table.dropColumn('card_count');
+  });
+};

--- a/migrations/20260929000000_add_public_listing_to_deck_shares.js
+++ b/migrations/20260929000000_add_public_listing_to_deck_shares.js
@@ -4,13 +4,9 @@ module.exports.up = async function (knex) {
     table.string('title', 120).nullable();
     table.integer('card_count').nullable();
   });
-  await knex.raw(
-    'create index deck_shares_public_listing_idx on deck_shares (created_at desc) where is_public = true and revoked_at is null'
-  );
 };
 
 module.exports.down = async function (knex) {
-  await knex.raw('drop index if exists deck_shares_public_listing_idx');
   await knex.schema.alterTable('deck_shares', (table) => {
     table.dropColumn('is_public');
     table.dropColumn('title');

--- a/migrations/20260929000001_index_deck_shares_public_listing_concurrent.js
+++ b/migrations/20260929000001_index_deck_shares_public_listing_concurrent.js
@@ -1,0 +1,13 @@
+exports.config = { transaction: false };
+
+exports.up = async (knex) => {
+  await knex.schema.raw(
+    'CREATE INDEX CONCURRENTLY IF NOT EXISTS deck_shares_public_listing_idx ON deck_shares (created_at DESC) WHERE is_public = true AND revoked_at IS NULL'
+  );
+};
+
+exports.down = async (knex) => {
+  await knex.schema.raw(
+    'DROP INDEX CONCURRENTLY IF EXISTS deck_shares_public_listing_idx'
+  );
+};

--- a/src/controllers/EventsController.test.ts
+++ b/src/controllers/EventsController.test.ts
@@ -301,6 +301,16 @@ describe('EventsController', () => {
       })
     );
   });
+
+  it('accepts shared_deck_published as known, not unknown', () => {
+    const { controller, req, res, executeSpy } = buildMocks({ userId: 1 });
+    req.body = { name: 'shared_deck_published' };
+    controller.track(req, res);
+    expect(res.status).toHaveBeenCalledWith(202);
+    expect(executeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'shared_deck_published', unknown: false })
+    );
+  });
 });
 
 describe('EventsController — regression: all client events return 202 (AC #5)', () => {

--- a/src/controllers/ShareController.test.ts
+++ b/src/controllers/ShareController.test.ts
@@ -79,6 +79,51 @@ function makeDownloadService(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function makePublishUseCase(overrides: Record<string, unknown> = {}) {
+  return {
+    execute: jest.fn().mockResolvedValue({
+      token: 'abc-token',
+      is_public: true,
+      title: 'My deck',
+      card_count: 5,
+    }),
+    ...overrides,
+  };
+}
+
+function makeListPublicUseCase(overrides: Record<string, unknown> = {}) {
+  return {
+    execute: jest.fn().mockResolvedValue({ decks: [], nextCursor: null }),
+    ...overrides,
+  };
+}
+
+function buildController(
+  overrides: {
+    createUseCase?: unknown;
+    resolveUseCase?: unknown;
+    revokeUseCase?: unknown;
+    shareService?: unknown;
+    storage?: unknown;
+    previewService?: unknown;
+    downloadService?: unknown;
+    publishUseCase?: unknown;
+    listPublicUseCase?: unknown;
+  } = {}
+) {
+  return new ShareController(
+    (overrides.createUseCase ?? makeCreateUseCase()) as any,
+    (overrides.resolveUseCase ?? makeResolveUseCase()) as any,
+    (overrides.revokeUseCase ?? makeRevokeUseCase()) as any,
+    (overrides.shareService ?? makeShareService()) as any,
+    (overrides.storage ?? makeStorage()) as any,
+    (overrides.previewService ?? makePreviewService()) as any,
+    (overrides.downloadService ?? makeDownloadService()) as any,
+    (overrides.publishUseCase ?? makePublishUseCase()) as any,
+    (overrides.listPublicUseCase ?? makeListPublicUseCase()) as any
+  );
+}
+
 describe('ShareController - POST /api/shares (createShare)', () => {
   it('returns 401 when owner is not set', async () => {
     const controller = new ShareController(
@@ -88,7 +133,9 @@ describe('ShareController - POST /api/shares (createShare)', () => {
       makeShareService() as any,
       makeStorage() as any,
       makePreviewService() as any,
-      makeDownloadService() as any
+      makeDownloadService() as any,
+      makePublishUseCase() as any,
+      makeListPublicUseCase() as any
     );
     const req = { body: { upload_key: 'test.apkg' } } as unknown as Request;
     const res = mockResponse({ owner: null });
@@ -109,7 +156,9 @@ describe('ShareController - POST /api/shares (createShare)', () => {
       makeShareService() as any,
       makeStorage() as any,
       makePreviewService() as any,
-      makeDownloadService() as any
+      makeDownloadService() as any,
+      makePublishUseCase() as any,
+      makeListPublicUseCase() as any
     );
     const req = { body: {} } as unknown as Request;
     const res = mockResponse({ owner: 42 });
@@ -130,7 +179,9 @@ describe('ShareController - POST /api/shares (createShare)', () => {
       makeShareService() as any,
       makeStorage() as any,
       makePreviewService() as any,
-      makeDownloadService() as any
+      makeDownloadService() as any,
+      makePublishUseCase() as any,
+      makeListPublicUseCase() as any
     );
     const req = { body: { upload_key: 'test.apkg' } } as unknown as Request;
     const res = mockResponse({ owner: 42 });
@@ -153,7 +204,9 @@ describe('ShareController - GET /api/shares/:token/meta', () => {
       makeShareService() as any,
       makeStorage() as any,
       makePreviewService() as any,
-      makeDownloadService() as any
+      makeDownloadService() as any,
+      makePublishUseCase() as any,
+      makeListPublicUseCase() as any
     );
     const req = { params: { token: 'gone-token' } } as unknown as Request;
     const res = mockResponse();
@@ -174,7 +227,9 @@ describe('ShareController - GET /api/shares/:token/meta', () => {
       makeShareService() as any,
       makeStorage() as any,
       makePreviewService() as any,
-      makeDownloadService() as any
+      makeDownloadService() as any,
+      makePublishUseCase() as any,
+      makeListPublicUseCase() as any
     );
     const req = { params: { token: 'abc-token' } } as unknown as Request;
     const res = mockResponse();
@@ -195,7 +250,9 @@ describe('ShareController - GET /api/shares/:token/download', () => {
       makeShareService() as any,
       makeStorage() as any,
       makePreviewService() as any,
-      makeDownloadService() as any
+      makeDownloadService() as any,
+      makePublishUseCase() as any,
+      makeListPublicUseCase() as any
     );
     const req = { params: { token: 'gone' } } as unknown as Request;
     const res = mockResponse();
@@ -224,7 +281,9 @@ describe('ShareController - GET /api/shares/:token/download', () => {
       makeShareService() as any,
       makeStorage() as any,
       makePreviewService() as any,
-      makeDownloadService() as any
+      makeDownloadService() as any,
+      makePublishUseCase() as any,
+      makeListPublicUseCase() as any
     );
     const req = { params: { token: 'abc-token' } } as unknown as Request;
 
@@ -248,7 +307,9 @@ describe('ShareController - DELETE /api/shares/:token', () => {
       makeShareService() as any,
       makeStorage() as any,
       makePreviewService() as any,
-      makeDownloadService() as any
+      makeDownloadService() as any,
+      makePublishUseCase() as any,
+      makeListPublicUseCase() as any
     );
     const req = { params: { token: 'abc-token' } } as unknown as Request;
     const res = mockResponse({ owner: null });
@@ -266,7 +327,9 @@ describe('ShareController - DELETE /api/shares/:token', () => {
       makeShareService() as any,
       makeStorage() as any,
       makePreviewService() as any,
-      makeDownloadService() as any
+      makeDownloadService() as any,
+      makePublishUseCase() as any,
+      makeListPublicUseCase() as any
     );
     const req = { params: { token: 'abc-token' } } as unknown as Request;
     const res = mockResponse({ owner: 42 });
@@ -284,7 +347,9 @@ describe('ShareController - DELETE /api/shares/:token', () => {
       makeShareService() as any,
       makeStorage() as any,
       makePreviewService() as any,
-      makeDownloadService() as any
+      makeDownloadService() as any,
+      makePublishUseCase() as any,
+      makeListPublicUseCase() as any
     );
     const req = { params: { token: 'abc-token' } } as unknown as Request;
     const res = mockResponse({ owner: 42 });
@@ -293,5 +358,128 @@ describe('ShareController - DELETE /api/shares/:token', () => {
 
     expect(res.status).toHaveBeenCalledWith(204);
     expect(res.send).toHaveBeenCalled();
+  });
+});
+
+describe('ShareController - PATCH /api/shares/:token (setVisibility)', () => {
+  it('returns 401 when owner is missing', async () => {
+    const controller = buildController();
+    const req = {
+      params: { token: 'abc-token' },
+      body: { is_public: true, title: 'My deck' },
+    } as unknown as Request;
+    const res = mockResponse({ owner: null });
+
+    await controller.setVisibility(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it('returns 400 when is_public is not a boolean', async () => {
+    const controller = buildController();
+    const req = {
+      params: { token: 'abc-token' },
+      body: {},
+    } as unknown as Request;
+    const res = mockResponse({ owner: 42 });
+
+    await controller.setVisibility(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 404 when the use case reports the share was not found', async () => {
+    const publishUseCase = makePublishUseCase({
+      execute: jest.fn().mockResolvedValue(null),
+    });
+    const controller = buildController({ publishUseCase });
+    const req = {
+      params: { token: 'missing' },
+      body: { is_public: true, title: 'My deck' },
+    } as unknown as Request;
+    const res = mockResponse({ owner: 42 });
+
+    await controller.setVisibility(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('returns 400 when the use case rejects a missing title', async () => {
+    const publishUseCase = makePublishUseCase({
+      execute: jest
+        .fn()
+        .mockRejectedValue(new Error('Title is required to publish a deck.')),
+    });
+    const controller = buildController({ publishUseCase });
+    const req = {
+      params: { token: 'abc-token' },
+      body: { is_public: true },
+    } as unknown as Request;
+    const res = mockResponse({ owner: 42 });
+
+    await controller.setVisibility(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Title is required to publish a deck.',
+    });
+  });
+
+  it('returns the updated visibility on success', async () => {
+    const controller = buildController();
+    const req = {
+      params: { token: 'abc-token' },
+      body: { is_public: true, title: 'My deck' },
+    } as unknown as Request;
+    const res = mockResponse({ owner: 42 });
+
+    await controller.setVisibility(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      token: 'abc-token',
+      is_public: true,
+      title: 'My deck',
+      card_count: 5,
+    });
+  });
+});
+
+describe('ShareController - GET /api/shares/public (getPublicListing)', () => {
+  it('returns the listing page from the use case', async () => {
+    const listPublicUseCase = makeListPublicUseCase({
+      execute: jest.fn().mockResolvedValue({
+        decks: [
+          {
+            token: 't1',
+            title: 'Deck one',
+            card_count: 10,
+            created_at: new Date('2026-07-01'),
+            view_count: 2,
+            url: 'https://2anki.net/s/t1',
+          },
+        ],
+        nextCursor: null,
+      }),
+    });
+    const controller = buildController({ listPublicUseCase });
+    const req = { query: {} } as unknown as Request;
+    const res = mockResponse();
+
+    await controller.getPublicListing(req, res);
+
+    expect(listPublicUseCase.execute).toHaveBeenCalledWith(0, 24);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ nextCursor: null })
+    );
+  });
+
+  it('does not set X-Robots-Tag: noindex, unlike the other share endpoints', async () => {
+    const controller = buildController();
+    const req = { query: {} } as unknown as Request;
+    const res = mockResponse();
+
+    await controller.getPublicListing(req, res);
+
+    expect(res.setHeader).not.toHaveBeenCalledWith('X-Robots-Tag', 'noindex');
   });
 });

--- a/src/controllers/ShareController.ts
+++ b/src/controllers/ShareController.ts
@@ -3,6 +3,8 @@ import { Request, Response } from 'express';
 import CreateShareUseCase from '../usecases/share/CreateShareUseCase';
 import ResolveShareUseCase from '../usecases/share/ResolveShareUseCase';
 import RevokeShareUseCase from '../usecases/share/RevokeShareUseCase';
+import PublishShareUseCase from '../usecases/share/PublishShareUseCase';
+import ListPublicSharesUseCase from '../usecases/share/ListPublicSharesUseCase';
 import ShareService from '../services/ShareService';
 import StorageHandler from '../lib/storage/StorageHandler';
 import ApkgPreviewService from '../services/ApkgPreviewService/ApkgPreviewService';
@@ -39,11 +41,15 @@ function guessContentType(name: string): string {
 
 const DEFAULT_PAGE_SIZE = 20;
 const MAX_PAGE_SIZE = 100;
+const LIBRARY_DEFAULT_PAGE_SIZE = 24;
 
-function clampPageSize(input: unknown): number {
+function clampPageSize(
+  input: unknown,
+  defaultSize = DEFAULT_PAGE_SIZE
+): number {
   const raw = typeof input === 'string' ? input : '';
   const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_PAGE_SIZE;
+  if (!Number.isFinite(parsed) || parsed <= 0) return defaultSize;
   return Math.min(parsed, MAX_PAGE_SIZE);
 }
 
@@ -67,7 +73,9 @@ class ShareController {
     private readonly shareService: ShareService,
     private readonly storage: StorageHandler,
     private readonly previewService: ApkgPreviewService,
-    private readonly downloadService: DownloadService
+    private readonly downloadService: DownloadService,
+    private readonly publishUseCase: PublishShareUseCase,
+    private readonly listPublicUseCase: ListPublicSharesUseCase
   ) {}
 
   async createShare(req: Request, res: Response) {
@@ -111,6 +119,9 @@ class ShareController {
         url: this.shareService.buildShareUrl(s.token),
         created_at: s.created_at,
         view_count: s.view_count,
+        is_public: s.is_public,
+        title: s.title,
+        card_count: s.card_count,
       }));
       res.json(result);
     } catch (error) {
@@ -253,6 +264,67 @@ class ShareController {
       }
       console.error('[ShareController.download]', error);
       res.status(500).json({ message: 'Download failed.' });
+    }
+  }
+
+  async setVisibility(req: Request, res: Response) {
+    const { owner } = res.locals;
+    if (owner == null) {
+      res.status(401).json({ message: 'Authentication required' });
+      return;
+    }
+
+    const { token } = req.params;
+    const isPublic = req.body?.is_public;
+    if (typeof isPublic !== 'boolean') {
+      res.status(400).json({ message: 'is_public must be a boolean.' });
+      return;
+    }
+    const title =
+      typeof req.body?.title === 'string' ? req.body.title : undefined;
+
+    try {
+      const updated = await this.publishUseCase.execute(
+        token,
+        owner,
+        isPublic,
+        title
+      );
+      if (updated == null) {
+        res.status(404).json({ message: 'Share not found.' });
+        return;
+      }
+      res.json({
+        token: updated.token,
+        is_public: updated.is_public,
+        title: updated.title,
+        card_count: updated.card_count,
+      });
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message === 'Title is required to publish a deck.'
+      ) {
+        res.status(400).json({ message: error.message });
+        return;
+      }
+      console.error('[ShareController.setVisibility]', error);
+      res.status(500).json({ message: 'Failed to update share visibility.' });
+    }
+  }
+
+  async getPublicListing(req: Request, res: Response) {
+    try {
+      const cursor = clampCursor(req.query.cursor);
+      const pageSize = clampPageSize(
+        req.query.page_size,
+        LIBRARY_DEFAULT_PAGE_SIZE
+      );
+      const page = await this.listPublicUseCase.execute(cursor, pageSize);
+      res.json(page);
+    } catch (error) {
+      console.error('[ShareController.getPublicListing]', error);
+      res.status(500).json({ message: 'Failed to load the shared library.' });
     }
   }
 

--- a/src/data_layer/ShareRepository.test.ts
+++ b/src/data_layer/ShareRepository.test.ts
@@ -1,0 +1,40 @@
+import knexFactory from 'knex';
+import { UsersId } from './public/Users';
+
+const asOwner = (n: number) => n as unknown as UsersId;
+
+describe('ShareRepository — generated SQL shape', () => {
+  const pgKnex = knexFactory({ client: 'pg' });
+
+  it('findPublicListing filters to public, non-revoked, titled, well-populated shares', () => {
+    const sql = pgKnex('deck_shares')
+      .where({ is_public: true })
+      .whereNull('revoked_at')
+      .whereNotNull('title')
+      .where('card_count', '>=', 3)
+      .orderBy('created_at', 'desc')
+      .offset(0)
+      .limit(24)
+      .toString();
+
+    expect(sql).toContain('"is_public" = true');
+    expect(sql).toContain('"revoked_at" is null');
+    expect(sql).toContain('"title" is not null');
+    expect(sql).toContain('"card_count" >= 3');
+    expect(sql).toContain('order by "created_at" desc');
+    expect(sql).toContain('limit');
+  });
+
+  it('updatePublicListing scopes the update to the token/owner pair and excludes revoked shares', () => {
+    const sql = pgKnex('deck_shares')
+      .where({ token: 'abc', owner: asOwner(42) })
+      .whereNull('revoked_at')
+      .update({ is_public: true, title: 'My deck', card_count: 10 })
+      .toString();
+
+    expect(sql).toContain('"token" = \'abc\'');
+    expect(sql).toContain('"owner" = 42');
+    expect(sql).toContain('"revoked_at" is null');
+    expect(sql).toContain('"is_public" = true');
+  });
+});

--- a/src/data_layer/ShareRepository.ts
+++ b/src/data_layer/ShareRepository.ts
@@ -2,6 +2,14 @@ import { Knex } from 'knex';
 import DeckShares, { DeckSharesId } from './public/DeckShares';
 import { UsersId } from './public/Users';
 
+export interface PublicListingFields {
+  isPublic: boolean;
+  title: string | null;
+  cardCount: number | null;
+}
+
+const PUBLIC_LISTING_MIN_CARDS = 3;
+
 export interface IShareRepository {
   create(owner: UsersId, uploadKey: string, token: string): Promise<DeckShares>;
   findByToken(token: string): Promise<DeckShares | null>;
@@ -13,6 +21,16 @@ export interface IShareRepository {
   revoke(token: string, owner: UsersId): Promise<boolean>;
   incrementViewCount(id: DeckSharesId): Promise<void>;
   hasActiveShareForKey(uploadKey: string): Promise<boolean>;
+  findByTokenAndOwner(
+    token: string,
+    owner: UsersId
+  ): Promise<DeckShares | null>;
+  updatePublicListing(
+    token: string,
+    owner: UsersId,
+    fields: PublicListingFields
+  ): Promise<DeckShares | null>;
+  findPublicListing(cursor: number, pageSize: number): Promise<DeckShares[]>;
 }
 
 class ShareRepository implements IShareRepository {
@@ -77,6 +95,48 @@ class ShareRepository implements IShareRepository {
       .whereNull('revoked_at')
       .first();
     return row != null;
+  }
+
+  async findByTokenAndOwner(
+    token: string,
+    owner: UsersId
+  ): Promise<DeckShares | null> {
+    const row = await this.database<DeckShares>(this.table)
+      .where({ token, owner })
+      .whereNull('revoked_at')
+      .first();
+    return row ?? null;
+  }
+
+  async updatePublicListing(
+    token: string,
+    owner: UsersId,
+    fields: PublicListingFields
+  ): Promise<DeckShares | null> {
+    const [row] = await this.database<DeckShares>(this.table)
+      .where({ token, owner })
+      .whereNull('revoked_at')
+      .update({
+        is_public: fields.isPublic,
+        title: fields.title,
+        card_count: fields.cardCount,
+      })
+      .returning('*');
+    return row ?? null;
+  }
+
+  async findPublicListing(
+    cursor: number,
+    pageSize: number
+  ): Promise<DeckShares[]> {
+    return this.database<DeckShares>(this.table)
+      .where({ is_public: true })
+      .whereNull('revoked_at')
+      .whereNotNull('title')
+      .where('card_count', '>=', PUBLIC_LISTING_MIN_CARDS)
+      .orderBy('created_at', 'desc')
+      .offset(cursor)
+      .limit(pageSize);
   }
 }
 

--- a/src/data_layer/public/DeckShares.ts
+++ b/src/data_layer/public/DeckShares.ts
@@ -21,6 +21,12 @@ export default interface DeckShares {
   revoked_at: Date | null;
 
   view_count: number;
+
+  is_public: boolean;
+
+  title: string | null;
+
+  card_count: number | null;
 }
 
 /** Represents the initializer for the table public.deck_shares */
@@ -41,6 +47,13 @@ export interface DeckSharesInitializer {
 
   /** Default value: 0 */
   view_count?: number;
+
+  /** Default value: false */
+  is_public?: boolean;
+
+  title?: string | null;
+
+  card_count?: number | null;
 }
 
 /** Represents the mutator for the table public.deck_shares */
@@ -58,4 +71,10 @@ export interface DeckSharesMutator {
   revoked_at?: Date | null;
 
   view_count?: number;
+
+  is_public?: boolean;
+
+  title?: string | null;
+
+  card_count?: number | null;
 }

--- a/src/routes/ShareRouter.ts
+++ b/src/routes/ShareRouter.ts
@@ -6,6 +6,8 @@ import ShareService from '../services/ShareService';
 import CreateShareUseCase from '../usecases/share/CreateShareUseCase';
 import ResolveShareUseCase from '../usecases/share/ResolveShareUseCase';
 import RevokeShareUseCase from '../usecases/share/RevokeShareUseCase';
+import PublishShareUseCase from '../usecases/share/PublishShareUseCase';
+import ListPublicSharesUseCase from '../usecases/share/ListPublicSharesUseCase';
 import StorageHandler from '../lib/storage/StorageHandler';
 import ApkgPreviewService from '../services/ApkgPreviewService/ApkgPreviewService';
 import DownloadService from '../services/DownloadService';
@@ -93,6 +95,12 @@ const ShareRouter = () => {
   const createUseCase = new CreateShareUseCase(uploadRepository, shareService);
   const resolveUseCase = new ResolveShareUseCase(shareService);
   const revokeUseCase = new RevokeShareUseCase(shareService);
+  const publishUseCase = new PublishShareUseCase(
+    shareService,
+    storage,
+    previewService
+  );
+  const listPublicUseCase = new ListPublicSharesUseCase(shareService);
 
   const controller = new ShareController(
     createUseCase,
@@ -101,7 +109,9 @@ const ShareRouter = () => {
     shareService,
     storage,
     previewService,
-    downloadService
+    downloadService,
+    publishUseCase,
+    listPublicUseCase
   );
 
   const router = express.Router();
@@ -161,6 +171,76 @@ const ShareRouter = () => {
    */
   router.get('/api/shares', RequireAuthentication, (req, res) =>
     controller.getActiveSharesForOwner(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/shares/public:
+   *   get:
+   *     summary: List public shared decks
+   *     description: Public endpoint. Returns a paginated, newest-first page of decks the owner listed in the public library. Indexable — unlike the other share endpoints, this response does NOT carry X-Robots-Tag&#58; noindex.
+   *     tags: [Deck Shares]
+   *     parameters:
+   *       - in: query
+   *         name: cursor
+   *         schema:
+   *           type: integer
+   *         description: Zero-based offset to resume from; omit for the first page.
+   *       - in: query
+   *         name: page_size
+   *         schema:
+   *           type: integer
+   *         description: Number of decks per page (1–100, default 24).
+   *     responses:
+   *       200:
+   *         description: Page of public decks
+   *       429:
+   *         description: Too many requests from this IP
+   */
+  router.get('/api/shares/public', ipRateLimit, (req, res) =>
+    controller.getPublicListing(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/shares/{token}:
+   *   patch:
+   *     summary: Publish or unpublish a share to the public library
+   *     description: Owner-only. Setting is_public to true requires a non-empty title and records the deck's card count. Setting it to false removes the deck from the public library; the private share link keeps working either way.
+   *     tags: [Deck Shares]
+   *     security:
+   *       - bearerAuth: []
+   *       - cookieAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: token
+   *         required: true
+   *         schema:
+   *           type: string
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required: [is_public]
+   *             properties:
+   *               is_public:
+   *                 type: boolean
+   *               title:
+   *                 type: string
+   *     responses:
+   *       200:
+   *         description: Updated visibility
+   *       400:
+   *         description: Missing is_public, or missing title while publishing
+   *       401:
+   *         description: Authentication required
+   *       404:
+   *         description: Share not found or not owned by the caller
+   */
+  router.patch('/api/shares/:token', RequireAuthentication, (req, res) =>
+    controller.setVisibility(req, res)
   );
 
   /**

--- a/src/routes/knownRoutes.test.ts
+++ b/src/routes/knownRoutes.test.ts
@@ -8,6 +8,7 @@ describe('isKnownAppRoute', () => {
     '/about',
     '/convert',
     '/notion-marketplace',
+    '/shared-decks',
     '/notion-to-anki',
     '/quizlet-to-anki',
     '/convert/csv-to-anki',

--- a/src/routes/knownRoutes.ts
+++ b/src/routes/knownRoutes.ts
@@ -5,6 +5,7 @@ const STATIC_PUBLIC_ROUTES = new Set<string>([
   '/about',
   '/convert',
   '/notion-marketplace',
+  '/shared-decks',
 ]);
 
 const APP_ROUTES = new Set<string>([

--- a/src/services/ShareService.ts
+++ b/src/services/ShareService.ts
@@ -1,6 +1,9 @@
 import { randomUUID } from 'node:crypto';
 import DeckShares from '../data_layer/public/DeckShares';
-import { IShareRepository } from '../data_layer/ShareRepository';
+import {
+  IShareRepository,
+  PublicListingFields,
+} from '../data_layer/ShareRepository';
 import { UsersId } from '../data_layer/public/Users';
 
 class ShareService {
@@ -41,6 +44,28 @@ class ShareService {
   buildShareUrl(token: string): string {
     const baseUrl = process.env.BASE_URL ?? 'https://2anki.net';
     return `${baseUrl}/s/${token}`;
+  }
+
+  async findShareForOwner(
+    token: string,
+    owner: UsersId
+  ): Promise<DeckShares | null> {
+    return this.repository.findByTokenAndOwner(token, owner);
+  }
+
+  async setPublicListing(
+    token: string,
+    owner: UsersId,
+    fields: PublicListingFields
+  ): Promise<DeckShares | null> {
+    return this.repository.updatePublicListing(token, owner, fields);
+  }
+
+  async listPublicShares(
+    cursor: number,
+    pageSize: number
+  ): Promise<DeckShares[]> {
+    return this.repository.findPublicListing(cursor, pageSize);
   }
 }
 

--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -106,6 +106,7 @@ export const KNOWN_EVENTS = new Set([
   'image_only_photo_deck_clicked',
   'ankify_decklist_sorted',
   'empty_back_notice_shown',
+  'shared_deck_published',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/src/usecases/share/ListPublicSharesUseCase.test.ts
+++ b/src/usecases/share/ListPublicSharesUseCase.test.ts
@@ -1,0 +1,76 @@
+import ListPublicSharesUseCase from './ListPublicSharesUseCase';
+
+function makeShareService(overrides: Record<string, unknown> = {}) {
+  return {
+    listPublicShares: jest.fn().mockResolvedValue([]),
+    buildShareUrl: jest.fn((token: string) => `https://2anki.net/s/${token}`),
+    ...overrides,
+  };
+}
+
+describe('ListPublicSharesUseCase', () => {
+  it('maps public shares to the listing shape, one page beyond page size', async () => {
+    const rows = [
+      {
+        token: 't1',
+        title: 'Deck one',
+        card_count: 10,
+        created_at: new Date('2026-07-01'),
+        view_count: 3,
+      },
+      {
+        token: 't2',
+        title: 'Deck two',
+        card_count: 5,
+        created_at: new Date('2026-07-02'),
+        view_count: 1,
+      },
+    ];
+    const shareService = makeShareService({
+      listPublicShares: jest.fn().mockResolvedValue(rows),
+    });
+    const useCase = new ListPublicSharesUseCase(shareService as any);
+
+    const result = await useCase.execute(0, 20);
+
+    expect(shareService.listPublicShares).toHaveBeenCalledWith(0, 21);
+    expect(result.decks).toEqual([
+      {
+        token: 't1',
+        title: 'Deck one',
+        card_count: 10,
+        created_at: rows[0].created_at,
+        view_count: 3,
+        url: 'https://2anki.net/s/t1',
+      },
+      {
+        token: 't2',
+        title: 'Deck two',
+        card_count: 5,
+        created_at: rows[1].created_at,
+        view_count: 1,
+        url: 'https://2anki.net/s/t2',
+      },
+    ]);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it('returns a next cursor when there is another page', async () => {
+    const rows = Array.from({ length: 3 }, (_, i) => ({
+      token: `t${i}`,
+      title: `Deck ${i}`,
+      card_count: 5,
+      created_at: new Date(),
+      view_count: 0,
+    }));
+    const shareService = makeShareService({
+      listPublicShares: jest.fn().mockResolvedValue(rows),
+    });
+    const useCase = new ListPublicSharesUseCase(shareService as any);
+
+    const result = await useCase.execute(0, 2);
+
+    expect(result.decks).toHaveLength(2);
+    expect(result.nextCursor).toBe(2);
+  });
+});

--- a/src/usecases/share/ListPublicSharesUseCase.ts
+++ b/src/usecases/share/ListPublicSharesUseCase.ts
@@ -1,0 +1,42 @@
+import ShareService from '../../services/ShareService';
+
+export interface PublicShareListing {
+  token: string;
+  title: string | null;
+  card_count: number | null;
+  created_at: Date;
+  view_count: number;
+  url: string;
+}
+
+export interface PublicShareListingPage {
+  decks: PublicShareListing[];
+  nextCursor: number | null;
+}
+
+class ListPublicSharesUseCase {
+  constructor(private readonly shareService: ShareService) {}
+
+  async execute(
+    cursor: number,
+    pageSize: number
+  ): Promise<PublicShareListingPage> {
+    const rows = await this.shareService.listPublicShares(cursor, pageSize + 1);
+    const hasNextPage = rows.length > pageSize;
+    const page = hasNextPage ? rows.slice(0, pageSize) : rows;
+
+    return {
+      decks: page.map((row) => ({
+        token: row.token,
+        title: row.title,
+        card_count: row.card_count,
+        created_at: row.created_at,
+        view_count: row.view_count,
+        url: this.shareService.buildShareUrl(row.token),
+      })),
+      nextCursor: hasNextPage ? cursor + pageSize : null,
+    };
+  }
+}
+
+export default ListPublicSharesUseCase;

--- a/src/usecases/share/PublishShareUseCase.test.ts
+++ b/src/usecases/share/PublishShareUseCase.test.ts
@@ -1,0 +1,134 @@
+import PublishShareUseCase from './PublishShareUseCase';
+import { UsersId } from '../../data_layer/public/Users';
+
+const asOwner = (n: number) => n as unknown as UsersId;
+
+const baseShare = {
+  id: 1,
+  owner: 42,
+  upload_key: 'test.apkg',
+  token: 'tok-1',
+  created_at: new Date(),
+  revoked_at: null,
+  view_count: 0,
+  is_public: false,
+  title: null,
+  card_count: null,
+};
+
+function makeShareService(overrides: Record<string, unknown> = {}) {
+  return {
+    findShareForOwner: jest.fn().mockResolvedValue(baseShare),
+    setPublicListing: jest.fn().mockResolvedValue({
+      ...baseShare,
+      is_public: true,
+      title: 'My deck',
+      card_count: 12,
+    }),
+    ...overrides,
+  };
+}
+
+function makeStorage(overrides: Record<string, unknown> = {}) {
+  return {
+    getFileContents: jest
+      .fn()
+      .mockResolvedValue({ Body: Buffer.from('fake-apkg') }),
+    ...overrides,
+  };
+}
+
+function makePreviewService(overrides: Record<string, unknown> = {}) {
+  return {
+    parse: jest.fn().mockResolvedValue({ parsed: true }),
+    getMeta: jest.fn().mockReturnValue({ totalCards: 12 }),
+    ...overrides,
+  };
+}
+
+describe('PublishShareUseCase', () => {
+  it('returns null when the share does not exist for this owner', async () => {
+    const shareService = makeShareService({
+      findShareForOwner: jest.fn().mockResolvedValue(null),
+    });
+    const useCase = new PublishShareUseCase(
+      shareService as any,
+      makeStorage() as any,
+      makePreviewService() as any
+    );
+
+    const result = await useCase.execute('missing', asOwner(42), true, 'Title');
+    expect(result).toBeNull();
+  });
+
+  it('rejects publishing without a title', async () => {
+    const shareService = makeShareService();
+    const useCase = new PublishShareUseCase(
+      shareService as any,
+      makeStorage() as any,
+      makePreviewService() as any
+    );
+
+    await expect(
+      useCase.execute('tok-1', asOwner(42), true, '   ')
+    ).rejects.toThrow('Title is required to publish a deck.');
+    expect(shareService.setPublicListing).not.toHaveBeenCalled();
+  });
+
+  it('parses the apkg to record a card count and publishes with a trimmed title', async () => {
+    const shareService = makeShareService();
+    const previewService = makePreviewService();
+    const useCase = new PublishShareUseCase(
+      shareService as any,
+      makeStorage() as any,
+      previewService as any
+    );
+
+    await useCase.execute('tok-1', asOwner(42), true, '  My deck  ');
+
+    expect(shareService.setPublicListing).toHaveBeenCalledWith('tok-1', 42, {
+      isPublic: true,
+      title: 'My deck',
+      cardCount: 12,
+    });
+  });
+
+  it('still publishes with a null card count when the apkg cannot be parsed', async () => {
+    const shareService = makeShareService();
+    const storage = makeStorage({
+      getFileContents: jest.fn().mockRejectedValue(new Error('s3 down')),
+    });
+    const useCase = new PublishShareUseCase(
+      shareService as any,
+      storage as any,
+      makePreviewService() as any
+    );
+
+    await useCase.execute('tok-1', asOwner(42), true, 'My deck');
+
+    expect(shareService.setPublicListing).toHaveBeenCalledWith('tok-1', 42, {
+      isPublic: true,
+      title: 'My deck',
+      cardCount: null,
+    });
+  });
+
+  it('unpublishes without requiring a title or parsing the apkg', async () => {
+    const shareService = makeShareService();
+    const previewService = makePreviewService();
+    const useCase = new PublishShareUseCase(
+      shareService as any,
+      makeStorage() as any,
+      previewService as any
+    );
+
+    await useCase.execute('tok-1', asOwner(42), false);
+
+    expect(previewService.parse).not.toHaveBeenCalled();
+    expect(shareService.setPublicListing).toHaveBeenCalledWith('tok-1', 42, {
+      isPublic: false,
+      title: null,
+      cardCount: null,
+    });
+  });
+});

--- a/src/usecases/share/PublishShareUseCase.ts
+++ b/src/usecases/share/PublishShareUseCase.ts
@@ -1,0 +1,66 @@
+import ShareService from '../../services/ShareService';
+import DeckShares from '../../data_layer/public/DeckShares';
+import { UsersId } from '../../data_layer/public/Users';
+import StorageHandler from '../../lib/storage/StorageHandler';
+import ApkgPreviewService from '../../services/ApkgPreviewService/ApkgPreviewService';
+
+const TITLE_MAX_LENGTH = 120;
+
+class PublishShareUseCase {
+  constructor(
+    private readonly shareService: ShareService,
+    private readonly storage: StorageHandler,
+    private readonly previewService: ApkgPreviewService
+  ) {}
+
+  async execute(
+    token: string,
+    owner: UsersId,
+    isPublic: boolean,
+    title?: string
+  ): Promise<DeckShares | null> {
+    const share = await this.shareService.findShareForOwner(token, owner);
+    if (share == null) {
+      return null;
+    }
+
+    if (!isPublic) {
+      return this.shareService.setPublicListing(token, owner, {
+        isPublic: false,
+        title: null,
+        cardCount: null,
+      });
+    }
+
+    const trimmedTitle = (title ?? '').trim();
+    if (trimmedTitle.length === 0) {
+      throw new Error('Title is required to publish a deck.');
+    }
+
+    const cardCount = await this.countCards(share);
+
+    return this.shareService.setPublicListing(token, owner, {
+      isPublic: true,
+      title: trimmedTitle.slice(0, TITLE_MAX_LENGTH),
+      cardCount,
+    });
+  }
+
+  private async countCards(share: DeckShares): Promise<number | null> {
+    try {
+      const fileOutput = await this.storage.getFileContents(share.upload_key);
+      if (fileOutput.Body == null) {
+        return null;
+      }
+      const parsed = await this.previewService.parse(
+        `share:${share.token}`,
+        fileOutput.Body as Buffer
+      );
+      return this.previewService.getMeta(parsed).totalCards;
+    } catch {
+      return null;
+    }
+  }
+}
+
+export default PublishShareUseCase;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -289,6 +289,10 @@ const SharedDeckPage = lazyWithRetry(
   () => import('./pages/SharedDeckPage'),
   './pages/SharedDeckPage'
 );
+const SharedDecksPage = lazyWithRetry(
+  () => import('./pages/SharedDecksPage'),
+  './pages/SharedDecksPage'
+);
 const MindmapsPage = lazyWithRetry(
   () => import('./pages/MindmapsPage'),
   './pages/MindmapsPage'
@@ -681,6 +685,7 @@ function AppContent({
               element={<ConvertLandingPage setErrorMessage={setErrorMessage} />}
             />
             <Route path="/s/:token" element={<SharedDeckPage />} />
+            <Route path="/shared-decks" element={<SharedDecksPage />} />
             <Route path="*" element={<NotFoundPage />} />
           </Routes>
         </RouteRecoveryBoundary>

--- a/web/src/lib/analytics/events.ts
+++ b/web/src/lib/analytics/events.ts
@@ -76,6 +76,7 @@ export const KNOWN_EVENTS = new Set([
   'subscription_pause_offer_declined',
   'language_changed',
   'dev_tier_checkout_clicked',
+  'shared_deck_published',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/web/src/lib/backend/getSharedDeck.test.ts
+++ b/web/src/lib/backend/getSharedDeck.test.ts
@@ -2,9 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createDeckShare,
   getActiveSharesForUploadKey,
+  getPublicSharedDecks,
   getSharedDeckBatch,
   getSharedDeckMeta,
   revokeDeckShare,
+  setShareVisibility,
 } from './getSharedDeck';
 
 function jsonResponse(
@@ -203,6 +205,69 @@ describe('getSharedDeck', () => {
       await expect(
         getActiveSharesForUploadKey('uploads/x.apkg')
       ).resolves.toBeNull();
+    });
+  });
+
+  describe('setShareVisibility', () => {
+    it('PATCHes is_public and title, returning the updated visibility', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        jsonResponse(200, {
+          token: 'abc',
+          is_public: true,
+          title: 'My deck',
+          card_count: 12,
+        })
+      );
+
+      const result = await setShareVisibility('abc', true, 'My deck');
+
+      expect(result).toEqual({
+        token: 'abc',
+        is_public: true,
+        title: 'My deck',
+        card_count: 12,
+      });
+      const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+      expect(url).toBe('/api/shares/abc');
+      expect(init).toMatchObject({
+        method: 'PATCH',
+        credentials: 'include',
+        body: JSON.stringify({ is_public: true, title: 'My deck' }),
+      });
+    });
+
+    it('throws the server message when publishing without a title', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        jsonResponse(400, { message: 'Title is required to publish a deck.' })
+      );
+
+      await expect(setShareVisibility('abc', true)).rejects.toThrow(
+        'Title is required to publish a deck.'
+      );
+    });
+  });
+
+  describe('getPublicSharedDecks', () => {
+    it('omits cursor when null', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        jsonResponse(200, { decks: [], nextCursor: null })
+      );
+
+      await getPublicSharedDecks(null);
+
+      const url = vi.mocked(globalThis.fetch).mock.calls[0][0] as string;
+      expect(url).toBe('/api/shares/public?');
+    });
+
+    it('includes cursor when provided', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        jsonResponse(200, { decks: [], nextCursor: null })
+      );
+
+      await getPublicSharedDecks(24);
+
+      const url = vi.mocked(globalThis.fetch).mock.calls[0][0] as string;
+      expect(url).toContain('cursor=24');
     });
   });
 });

--- a/web/src/lib/backend/getSharedDeck.ts
+++ b/web/src/lib/backend/getSharedDeck.ts
@@ -80,6 +80,9 @@ export interface ActiveShare {
   url: string;
   created_at: string;
   view_count: number;
+  is_public: boolean;
+  title: string | null;
+  card_count: number | null;
 }
 
 export async function getActiveSharesForUploadKey(
@@ -89,4 +92,51 @@ export async function getActiveSharesForUploadKey(
   if (!response.ok) return null;
   const shares = (await response.json()) as ActiveShare[];
   return shares.find((s) => s.upload_key === uploadKey) ?? null;
+}
+
+export interface ShareVisibility {
+  token: string;
+  is_public: boolean;
+  title: string | null;
+  card_count: number | null;
+}
+
+export async function setShareVisibility(
+  token: string,
+  isPublic: boolean,
+  title?: string
+): Promise<ShareVisibility> {
+  const url = `/api/shares/${encodeURIComponent(token)}`;
+  const response = await fetch(url, {
+    method: 'PATCH',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ is_public: isPublic, title }),
+  });
+  if (!response.ok) {
+    throw await shareApiError('PATCH', url, response);
+  }
+  return response.json() as Promise<ShareVisibility>;
+}
+
+export interface PublicSharedDeck {
+  token: string;
+  title: string | null;
+  card_count: number | null;
+  created_at: string;
+  view_count: number;
+  url: string;
+}
+
+export interface PublicSharedDeckPage {
+  decks: PublicSharedDeck[];
+  nextCursor: number | null;
+}
+
+export async function getPublicSharedDecks(
+  cursor: number | null
+): Promise<PublicSharedDeckPage> {
+  const params = new URLSearchParams();
+  if (cursor) params.set('cursor', String(cursor));
+  return fetchShareApi(`/api/shares/public?${params.toString()}`);
 }

--- a/web/src/lib/i18n/locales/de/previews.json
+++ b/web/src/lib/i18n/locales/de/previews.json
@@ -141,6 +141,7 @@
     "remixCta": "Make your own deck",
     "remixSubtext": "Make your own version on 2anki.",
     "cardCount_one": "{{count}} card",
-    "cardCount_other": "{{count}} cards"
+    "cardCount_other": "{{count}} cards",
+    "browseLibrary": "Browse the shared library"
   }
 }

--- a/web/src/lib/i18n/locales/de/previews.json
+++ b/web/src/lib/i18n/locales/de/previews.json
@@ -102,7 +102,15 @@
     "keepSharing": "Weiter teilen",
     "share": "Teilen",
     "shareThisDeck": "Diesen Stapel teilen",
-    "linkCopied": "Link kopiert"
+    "linkCopied": "Link kopiert",
+    "listInLibrary": "List in the public library",
+    "listInLibraryHelper": "Anyone can find and view this deck. Your Notion account stays private.",
+    "deckTitle": "Deck title",
+    "deckTitlePlaceholder": "e.g. Organic chemistry — Chapter 4",
+    "listDeck": "List deck",
+    "removeFromLibrary": "Remove from library",
+    "listedAs": "Listed in the public library as {{title}}",
+    "publishFailed": "Couldn't update the library listing. Try again."
   },
   "card": {
     "frameTitle": "{{deck}} / {{template}} ({{side}})",
@@ -120,5 +128,19 @@
     "backLabel": "Rückseite",
     "editFront": "Vorderseite bearbeiten",
     "editBack": "Rückseite bearbeiten"
+  },
+  "sharedLibrary": {
+    "header": "Shared decks",
+    "subtitle": "Decks people made public. Open one, then make your own.",
+    "viewDeck": "View deck",
+    "emptyTitle": "No public decks yet",
+    "emptyDescription": "Share one of yours to start the library.",
+    "emptyAction": "Make a deck",
+    "loadFailed": "Couldn't load the shared library. Try again.",
+    "loadMore": "Load more",
+    "remixCta": "Make your own deck",
+    "remixSubtext": "Make your own version on 2anki.",
+    "cardCount_one": "{{count}} card",
+    "cardCount_other": "{{count}} cards"
   }
 }

--- a/web/src/lib/i18n/locales/en/previews.json
+++ b/web/src/lib/i18n/locales/en/previews.json
@@ -102,7 +102,29 @@
     "keepSharing": "Keep sharing",
     "share": "Share",
     "shareThisDeck": "Share this deck",
-    "linkCopied": "Link copied"
+    "linkCopied": "Link copied",
+    "listInLibrary": "List in the public library",
+    "listInLibraryHelper": "Anyone can find and view this deck. Your Notion account stays private.",
+    "deckTitle": "Deck title",
+    "deckTitlePlaceholder": "e.g. Organic chemistry — Chapter 4",
+    "listDeck": "List deck",
+    "removeFromLibrary": "Remove from library",
+    "listedAs": "Listed in the public library as {{title}}",
+    "publishFailed": "Couldn't update the library listing. Try again."
+  },
+  "sharedLibrary": {
+    "header": "Shared decks",
+    "subtitle": "Decks people made public. Open one, then make your own.",
+    "cardCount_one": "{{count}} card",
+    "cardCount_other": "{{count}} cards",
+    "viewDeck": "View deck",
+    "emptyTitle": "No public decks yet",
+    "emptyDescription": "Share one of yours to start the library.",
+    "emptyAction": "Make a deck",
+    "loadFailed": "Couldn't load the shared library. Try again.",
+    "loadMore": "Load more",
+    "remixCta": "Make your own deck",
+    "remixSubtext": "Make your own version on 2anki."
   },
   "card": {
     "frameTitle": "{{deck}} / {{template}} ({{side}})",

--- a/web/src/lib/i18n/locales/en/previews.json
+++ b/web/src/lib/i18n/locales/en/previews.json
@@ -124,7 +124,8 @@
     "loadFailed": "Couldn't load the shared library. Try again.",
     "loadMore": "Load more",
     "remixCta": "Make your own deck",
-    "remixSubtext": "Make your own version on 2anki."
+    "remixSubtext": "Make your own version on 2anki.",
+    "browseLibrary": "Browse the shared library"
   },
   "card": {
     "frameTitle": "{{deck}} / {{template}} ({{side}})",

--- a/web/src/lib/i18n/locales/es/previews.json
+++ b/web/src/lib/i18n/locales/es/previews.json
@@ -141,6 +141,7 @@
     "remixCta": "Make your own deck",
     "remixSubtext": "Make your own version on 2anki.",
     "cardCount_one": "{{count}} card",
-    "cardCount_other": "{{count}} cards"
+    "cardCount_other": "{{count}} cards",
+    "browseLibrary": "Browse the shared library"
   }
 }

--- a/web/src/lib/i18n/locales/es/previews.json
+++ b/web/src/lib/i18n/locales/es/previews.json
@@ -102,7 +102,15 @@
     "keepSharing": "Seguir compartiendo",
     "share": "Compartir",
     "shareThisDeck": "Compartir este mazo",
-    "linkCopied": "Enlace copiado"
+    "linkCopied": "Enlace copiado",
+    "listInLibrary": "List in the public library",
+    "listInLibraryHelper": "Anyone can find and view this deck. Your Notion account stays private.",
+    "deckTitle": "Deck title",
+    "deckTitlePlaceholder": "e.g. Organic chemistry — Chapter 4",
+    "listDeck": "List deck",
+    "removeFromLibrary": "Remove from library",
+    "listedAs": "Listed in the public library as {{title}}",
+    "publishFailed": "Couldn't update the library listing. Try again."
   },
   "card": {
     "frameTitle": "{{deck}} / {{template}} ({{side}})",
@@ -120,5 +128,19 @@
     "backLabel": "Reverso",
     "editFront": "Editar anverso",
     "editBack": "Editar reverso"
+  },
+  "sharedLibrary": {
+    "header": "Shared decks",
+    "subtitle": "Decks people made public. Open one, then make your own.",
+    "viewDeck": "View deck",
+    "emptyTitle": "No public decks yet",
+    "emptyDescription": "Share one of yours to start the library.",
+    "emptyAction": "Make a deck",
+    "loadFailed": "Couldn't load the shared library. Try again.",
+    "loadMore": "Load more",
+    "remixCta": "Make your own deck",
+    "remixSubtext": "Make your own version on 2anki.",
+    "cardCount_one": "{{count}} card",
+    "cardCount_other": "{{count}} cards"
   }
 }

--- a/web/src/lib/i18n/locales/fr/previews.json
+++ b/web/src/lib/i18n/locales/fr/previews.json
@@ -141,6 +141,7 @@
     "remixCta": "Make your own deck",
     "remixSubtext": "Make your own version on 2anki.",
     "cardCount_one": "{{count}} card",
-    "cardCount_other": "{{count}} cards"
+    "cardCount_other": "{{count}} cards",
+    "browseLibrary": "Browse the shared library"
   }
 }

--- a/web/src/lib/i18n/locales/fr/previews.json
+++ b/web/src/lib/i18n/locales/fr/previews.json
@@ -102,7 +102,15 @@
     "keepSharing": "Continuer à partager",
     "share": "Partager",
     "shareThisDeck": "Partager ce paquet",
-    "linkCopied": "Lien copié"
+    "linkCopied": "Lien copié",
+    "listInLibrary": "List in the public library",
+    "listInLibraryHelper": "Anyone can find and view this deck. Your Notion account stays private.",
+    "deckTitle": "Deck title",
+    "deckTitlePlaceholder": "e.g. Organic chemistry — Chapter 4",
+    "listDeck": "List deck",
+    "removeFromLibrary": "Remove from library",
+    "listedAs": "Listed in the public library as {{title}}",
+    "publishFailed": "Couldn't update the library listing. Try again."
   },
   "card": {
     "frameTitle": "{{deck}} / {{template}} ({{side}})",
@@ -120,5 +128,19 @@
     "backLabel": "Verso",
     "editFront": "Modifier le recto",
     "editBack": "Modifier le verso"
+  },
+  "sharedLibrary": {
+    "header": "Shared decks",
+    "subtitle": "Decks people made public. Open one, then make your own.",
+    "viewDeck": "View deck",
+    "emptyTitle": "No public decks yet",
+    "emptyDescription": "Share one of yours to start the library.",
+    "emptyAction": "Make a deck",
+    "loadFailed": "Couldn't load the shared library. Try again.",
+    "loadMore": "Load more",
+    "remixCta": "Make your own deck",
+    "remixSubtext": "Make your own version on 2anki.",
+    "cardCount_one": "{{count}} card",
+    "cardCount_other": "{{count}} cards"
   }
 }

--- a/web/src/lib/i18n/locales/it/previews.json
+++ b/web/src/lib/i18n/locales/it/previews.json
@@ -141,6 +141,7 @@
     "remixCta": "Make your own deck",
     "remixSubtext": "Make your own version on 2anki.",
     "cardCount_one": "{{count}} card",
-    "cardCount_other": "{{count}} cards"
+    "cardCount_other": "{{count}} cards",
+    "browseLibrary": "Browse the shared library"
   }
 }

--- a/web/src/lib/i18n/locales/it/previews.json
+++ b/web/src/lib/i18n/locales/it/previews.json
@@ -102,7 +102,15 @@
     "keepSharing": "Continua a condividere",
     "share": "Condividi",
     "shareThisDeck": "Condividi questo mazzo",
-    "linkCopied": "Link copiato"
+    "linkCopied": "Link copiato",
+    "listInLibrary": "List in the public library",
+    "listInLibraryHelper": "Anyone can find and view this deck. Your Notion account stays private.",
+    "deckTitle": "Deck title",
+    "deckTitlePlaceholder": "e.g. Organic chemistry — Chapter 4",
+    "listDeck": "List deck",
+    "removeFromLibrary": "Remove from library",
+    "listedAs": "Listed in the public library as {{title}}",
+    "publishFailed": "Couldn't update the library listing. Try again."
   },
   "card": {
     "frameTitle": "{{deck}} / {{template}} ({{side}})",
@@ -120,5 +128,19 @@
     "backLabel": "Retro",
     "editFront": "Modifica fronte",
     "editBack": "Modifica retro"
+  },
+  "sharedLibrary": {
+    "header": "Shared decks",
+    "subtitle": "Decks people made public. Open one, then make your own.",
+    "viewDeck": "View deck",
+    "emptyTitle": "No public decks yet",
+    "emptyDescription": "Share one of yours to start the library.",
+    "emptyAction": "Make a deck",
+    "loadFailed": "Couldn't load the shared library. Try again.",
+    "loadMore": "Load more",
+    "remixCta": "Make your own deck",
+    "remixSubtext": "Make your own version on 2anki.",
+    "cardCount_one": "{{count}} card",
+    "cardCount_other": "{{count}} cards"
   }
 }

--- a/web/src/lib/i18n/locales/ja/previews.json
+++ b/web/src/lib/i18n/locales/ja/previews.json
@@ -130,6 +130,7 @@
     "loadMore": "Load more",
     "remixCta": "Make your own deck",
     "remixSubtext": "Make your own version on 2anki.",
-    "cardCount_other": "{{count}} cards"
+    "cardCount_other": "{{count}} cards",
+    "browseLibrary": "Browse the shared library"
   }
 }

--- a/web/src/lib/i18n/locales/ja/previews.json
+++ b/web/src/lib/i18n/locales/ja/previews.json
@@ -92,7 +92,15 @@
     "keepSharing": "共有を続ける",
     "share": "共有",
     "shareThisDeck": "このデッキを共有",
-    "linkCopied": "リンクをコピーしました"
+    "linkCopied": "リンクをコピーしました",
+    "listInLibrary": "List in the public library",
+    "listInLibraryHelper": "Anyone can find and view this deck. Your Notion account stays private.",
+    "deckTitle": "Deck title",
+    "deckTitlePlaceholder": "e.g. Organic chemistry — Chapter 4",
+    "listDeck": "List deck",
+    "removeFromLibrary": "Remove from library",
+    "listedAs": "Listed in the public library as {{title}}",
+    "publishFailed": "Couldn't update the library listing. Try again."
   },
   "card": {
     "frameTitle": "{{deck}} / {{template}}（{{side}}）",
@@ -110,5 +118,18 @@
     "backLabel": "裏面",
     "editFront": "表面を編集",
     "editBack": "裏面を編集"
+  },
+  "sharedLibrary": {
+    "header": "Shared decks",
+    "subtitle": "Decks people made public. Open one, then make your own.",
+    "viewDeck": "View deck",
+    "emptyTitle": "No public decks yet",
+    "emptyDescription": "Share one of yours to start the library.",
+    "emptyAction": "Make a deck",
+    "loadFailed": "Couldn't load the shared library. Try again.",
+    "loadMore": "Load more",
+    "remixCta": "Make your own deck",
+    "remixSubtext": "Make your own version on 2anki.",
+    "cardCount_other": "{{count}} cards"
   }
 }

--- a/web/src/lib/i18n/locales/nl/previews.json
+++ b/web/src/lib/i18n/locales/nl/previews.json
@@ -141,6 +141,7 @@
     "remixCta": "Make your own deck",
     "remixSubtext": "Make your own version on 2anki.",
     "cardCount_one": "{{count}} card",
-    "cardCount_other": "{{count}} cards"
+    "cardCount_other": "{{count}} cards",
+    "browseLibrary": "Browse the shared library"
   }
 }

--- a/web/src/lib/i18n/locales/nl/previews.json
+++ b/web/src/lib/i18n/locales/nl/previews.json
@@ -102,7 +102,15 @@
     "keepSharing": "Blijven delen",
     "share": "Delen",
     "shareThisDeck": "Dit deck delen",
-    "linkCopied": "Link gekopieerd"
+    "linkCopied": "Link gekopieerd",
+    "listInLibrary": "List in the public library",
+    "listInLibraryHelper": "Anyone can find and view this deck. Your Notion account stays private.",
+    "deckTitle": "Deck title",
+    "deckTitlePlaceholder": "e.g. Organic chemistry — Chapter 4",
+    "listDeck": "List deck",
+    "removeFromLibrary": "Remove from library",
+    "listedAs": "Listed in the public library as {{title}}",
+    "publishFailed": "Couldn't update the library listing. Try again."
   },
   "card": {
     "frameTitle": "{{deck}} / {{template}} ({{side}})",
@@ -120,5 +128,19 @@
     "backLabel": "Achterkant",
     "editFront": "Voorkant bewerken",
     "editBack": "Achterkant bewerken"
+  },
+  "sharedLibrary": {
+    "header": "Shared decks",
+    "subtitle": "Decks people made public. Open one, then make your own.",
+    "viewDeck": "View deck",
+    "emptyTitle": "No public decks yet",
+    "emptyDescription": "Share one of yours to start the library.",
+    "emptyAction": "Make a deck",
+    "loadFailed": "Couldn't load the shared library. Try again.",
+    "loadMore": "Load more",
+    "remixCta": "Make your own deck",
+    "remixSubtext": "Make your own version on 2anki.",
+    "cardCount_one": "{{count}} card",
+    "cardCount_other": "{{count}} cards"
   }
 }

--- a/web/src/lib/i18n/locales/pl/previews.json
+++ b/web/src/lib/i18n/locales/pl/previews.json
@@ -122,7 +122,15 @@
     "keepSharing": "Udostępniaj dalej",
     "share": "Udostępnij",
     "shareThisDeck": "Udostępnij tę talię",
-    "linkCopied": "Skopiowano link"
+    "linkCopied": "Skopiowano link",
+    "listInLibrary": "List in the public library",
+    "listInLibraryHelper": "Anyone can find and view this deck. Your Notion account stays private.",
+    "deckTitle": "Deck title",
+    "deckTitlePlaceholder": "e.g. Organic chemistry — Chapter 4",
+    "listDeck": "List deck",
+    "removeFromLibrary": "Remove from library",
+    "listedAs": "Listed in the public library as {{title}}",
+    "publishFailed": "Couldn't update the library listing. Try again."
   },
   "card": {
     "frameTitle": "{{deck}} / {{template}} ({{side}})",
@@ -140,5 +148,21 @@
     "backLabel": "Tył",
     "editFront": "Edytuj przód",
     "editBack": "Edytuj tył"
+  },
+  "sharedLibrary": {
+    "header": "Shared decks",
+    "subtitle": "Decks people made public. Open one, then make your own.",
+    "viewDeck": "View deck",
+    "emptyTitle": "No public decks yet",
+    "emptyDescription": "Share one of yours to start the library.",
+    "emptyAction": "Make a deck",
+    "loadFailed": "Couldn't load the shared library. Try again.",
+    "loadMore": "Load more",
+    "remixCta": "Make your own deck",
+    "remixSubtext": "Make your own version on 2anki.",
+    "cardCount_one": "{{count}} card",
+    "cardCount_few": "{{count}} cards",
+    "cardCount_many": "{{count}} cards",
+    "cardCount_other": "{{count}} cards"
   }
 }

--- a/web/src/lib/i18n/locales/pl/previews.json
+++ b/web/src/lib/i18n/locales/pl/previews.json
@@ -163,6 +163,7 @@
     "cardCount_one": "{{count}} card",
     "cardCount_few": "{{count}} cards",
     "cardCount_many": "{{count}} cards",
-    "cardCount_other": "{{count}} cards"
+    "cardCount_other": "{{count}} cards",
+    "browseLibrary": "Browse the shared library"
   }
 }

--- a/web/src/lib/i18n/locales/pt/previews.json
+++ b/web/src/lib/i18n/locales/pt/previews.json
@@ -141,6 +141,7 @@
     "remixCta": "Make your own deck",
     "remixSubtext": "Make your own version on 2anki.",
     "cardCount_one": "{{count}} card",
-    "cardCount_other": "{{count}} cards"
+    "cardCount_other": "{{count}} cards",
+    "browseLibrary": "Browse the shared library"
   }
 }

--- a/web/src/lib/i18n/locales/pt/previews.json
+++ b/web/src/lib/i18n/locales/pt/previews.json
@@ -102,7 +102,15 @@
     "keepSharing": "Continuar a partilhar",
     "share": "Partilhar",
     "shareThisDeck": "Partilhar este baralho",
-    "linkCopied": "Ligação copiada"
+    "linkCopied": "Ligação copiada",
+    "listInLibrary": "List in the public library",
+    "listInLibraryHelper": "Anyone can find and view this deck. Your Notion account stays private.",
+    "deckTitle": "Deck title",
+    "deckTitlePlaceholder": "e.g. Organic chemistry — Chapter 4",
+    "listDeck": "List deck",
+    "removeFromLibrary": "Remove from library",
+    "listedAs": "Listed in the public library as {{title}}",
+    "publishFailed": "Couldn't update the library listing. Try again."
   },
   "card": {
     "frameTitle": "{{deck}} / {{template}} ({{side}})",
@@ -120,5 +128,19 @@
     "backLabel": "Verso",
     "editFront": "Editar frente",
     "editBack": "Editar verso"
+  },
+  "sharedLibrary": {
+    "header": "Shared decks",
+    "subtitle": "Decks people made public. Open one, then make your own.",
+    "viewDeck": "View deck",
+    "emptyTitle": "No public decks yet",
+    "emptyDescription": "Share one of yours to start the library.",
+    "emptyAction": "Make a deck",
+    "loadFailed": "Couldn't load the shared library. Try again.",
+    "loadMore": "Load more",
+    "remixCta": "Make your own deck",
+    "remixSubtext": "Make your own version on 2anki.",
+    "cardCount_one": "{{count}} card",
+    "cardCount_other": "{{count}} cards"
   }
 }

--- a/web/src/lib/i18n/locales/ru/previews.json
+++ b/web/src/lib/i18n/locales/ru/previews.json
@@ -163,6 +163,7 @@
     "cardCount_one": "{{count}} card",
     "cardCount_few": "{{count}} cards",
     "cardCount_many": "{{count}} cards",
-    "cardCount_other": "{{count}} cards"
+    "cardCount_other": "{{count}} cards",
+    "browseLibrary": "Browse the shared library"
   }
 }

--- a/web/src/lib/i18n/locales/ru/previews.json
+++ b/web/src/lib/i18n/locales/ru/previews.json
@@ -122,7 +122,15 @@
     "keepSharing": "Продолжить делиться",
     "share": "Поделиться",
     "shareThisDeck": "Поделиться этой колодой",
-    "linkCopied": "Ссылка скопирована"
+    "linkCopied": "Ссылка скопирована",
+    "listInLibrary": "List in the public library",
+    "listInLibraryHelper": "Anyone can find and view this deck. Your Notion account stays private.",
+    "deckTitle": "Deck title",
+    "deckTitlePlaceholder": "e.g. Organic chemistry — Chapter 4",
+    "listDeck": "List deck",
+    "removeFromLibrary": "Remove from library",
+    "listedAs": "Listed in the public library as {{title}}",
+    "publishFailed": "Couldn't update the library listing. Try again."
   },
   "card": {
     "frameTitle": "{{deck}} / {{template}} ({{side}})",
@@ -140,5 +148,21 @@
     "backLabel": "Обратная сторона",
     "editFront": "Изменить лицевую сторону",
     "editBack": "Изменить обратную сторону"
+  },
+  "sharedLibrary": {
+    "header": "Shared decks",
+    "subtitle": "Decks people made public. Open one, then make your own.",
+    "viewDeck": "View deck",
+    "emptyTitle": "No public decks yet",
+    "emptyDescription": "Share one of yours to start the library.",
+    "emptyAction": "Make a deck",
+    "loadFailed": "Couldn't load the shared library. Try again.",
+    "loadMore": "Load more",
+    "remixCta": "Make your own deck",
+    "remixSubtext": "Make your own version on 2anki.",
+    "cardCount_one": "{{count}} card",
+    "cardCount_few": "{{count}} cards",
+    "cardCount_many": "{{count}} cards",
+    "cardCount_other": "{{count}} cards"
   }
 }

--- a/web/src/pages/DownloadsPage/components/EmptyDownloadsSection.i18n.test.tsx
+++ b/web/src/pages/DownloadsPage/components/EmptyDownloadsSection.i18n.test.tsx
@@ -37,3 +37,13 @@ describe('EmptyDownloadsSection in German', () => {
     expect(screen.getByText('Datei hochladen')).toBeInTheDocument();
   });
 });
+
+describe('EmptyDownloadsSection', () => {
+  it('links to the shared-decks library', () => {
+    renderEmpty();
+    const link = screen.getByRole('link', {
+      name: 'Browse the shared library',
+    });
+    expect(link).toHaveAttribute('href', '/shared-decks');
+  });
+});

--- a/web/src/pages/DownloadsPage/components/EmptyDownloadsSection.tsx
+++ b/web/src/pages/DownloadsPage/components/EmptyDownloadsSection.tsx
@@ -9,6 +9,7 @@ interface Props {
 
 export function EmptyDownloadsSection({ isEmpty }: Readonly<Props>) {
   const { t } = useTranslation();
+  const { t: tPreviews } = useTranslation('previews');
   if (!isEmpty) {
     return null;
   }
@@ -43,6 +44,14 @@ export function EmptyDownloadsSection({ isEmpty }: Readonly<Props>) {
           style={{ color: 'var(--color-primary)', textDecoration: 'none' }}
         >
           {t('downloads.empty.uploadFile')}
+        </Link>
+      </p>
+      <p className={styles.emptyHint}>
+        <Link
+          to="/shared-decks"
+          style={{ color: 'var(--color-primary)', textDecoration: 'none' }}
+        >
+          {tPreviews('sharedLibrary.browseLibrary')}
         </Link>
       </p>
     </>

--- a/web/src/pages/FavoritesPage/components/FavoritesPresenter.test.tsx
+++ b/web/src/pages/FavoritesPage/components/FavoritesPresenter.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import FavoritesPresenter from './FavoritesPresenter';
+
+function renderPresenter(favorites: any[] = []) {
+  return render(
+    <MemoryRouter>
+      <FavoritesPresenter
+        favorites={favorites}
+        setError={vi.fn()}
+        setFavorites={vi.fn()}
+      />
+    </MemoryRouter>
+  );
+}
+
+describe('FavoritesPresenter', () => {
+  it('links to the shared-decks library when there are no favorites', () => {
+    renderPresenter([]);
+    const link = screen.getByRole('link', {
+      name: 'Browse the shared library',
+    });
+    expect(link).toHaveAttribute('href', '/shared-decks');
+  });
+
+  it('does not render the library link when favorites exist', () => {
+    renderPresenter([
+      {
+        object: 'page',
+        title: 'Biology',
+        url: 'https://notion.so/x',
+        id: 'page-1',
+      } as any,
+    ]);
+    expect(
+      screen.queryByRole('link', { name: 'Browse the shared library' })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/FavoritesPage/components/FavoritesPresenter.tsx
+++ b/web/src/pages/FavoritesPage/components/FavoritesPresenter.tsx
@@ -1,4 +1,6 @@
 import { Dispatch, SetStateAction } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
 import Favorites from './Favorites';
 
 import { ErrorHandlerType } from '../../../components/errors/helpers/getErrorMessage';
@@ -17,10 +19,12 @@ export default function FavoritesPresenter({
   setFavorites,
   favorites,
 }: Readonly<Props>) {
+  const { t } = useTranslation('previews');
   if (favorites.length === 0) {
     return (
       <div className={styles.emptyState}>
-        {getVisibleText('favorites.empty')}
+        <p>{getVisibleText('favorites.empty')}</p>
+        <Link to="/shared-decks">{t('sharedLibrary.browseLibrary')}</Link>
       </div>
     );
   }

--- a/web/src/pages/PreviewApkgPage/SharePopover.module.css
+++ b/web/src/pages/PreviewApkgPage/SharePopover.module.css
@@ -160,3 +160,42 @@
   font-size: var(--text-sm);
   color: var(--color-text-secondary);
 }
+
+.publishSection {
+  border-top: 1px solid var(--color-border);
+  padding-top: 0.875rem;
+  margin-bottom: 0.875rem;
+}
+
+.publishToggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  cursor: pointer;
+}
+
+.titleInput {
+  width: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 0.375rem 0.625rem;
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  background: var(--color-bg-primary);
+  margin-top: 0.625rem;
+  box-sizing: border-box;
+}
+
+.publishedText {
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  margin: 0 0 0.5rem;
+}
+
+.publishError {
+  font-size: var(--text-xs);
+  color: var(--color-danger);
+  margin: 0.5rem 0 0;
+}

--- a/web/src/pages/PreviewApkgPage/SharePopover.test.tsx
+++ b/web/src/pages/PreviewApkgPage/SharePopover.test.tsx
@@ -2,11 +2,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { SharePopover } from './SharePopover';
 import * as sharedDeckLib from '../../lib/backend/getSharedDeck';
+import * as trackLib from '../../lib/analytics/track';
 
 vi.mock('../../lib/backend/getSharedDeck', () => ({
   getActiveSharesForUploadKey: vi.fn(),
   createDeckShare: vi.fn(),
   revokeDeckShare: vi.fn(),
+  setShareVisibility: vi.fn(),
+}));
+
+vi.mock('../../lib/analytics/track', () => ({
+  track: vi.fn(),
 }));
 
 const activeShare: sharedDeckLib.ActiveShare = {
@@ -15,6 +21,9 @@ const activeShare: sharedDeckLib.ActiveShare = {
   url: 'https://2anki.net/s/test-token',
   created_at: new Date().toISOString(),
   view_count: 0,
+  is_public: false,
+  title: null,
+  card_count: null,
 };
 
 beforeEach(() => {
@@ -105,6 +114,86 @@ describe('SharePopover', () => {
 
     await waitFor(() => {
       expect(sharedDeckLib.revokeDeckShare).toHaveBeenCalledWith('test-token');
+    });
+  });
+
+  it('reveals the title field when the public-library checkbox is checked', async () => {
+    vi.mocked(sharedDeckLib.getActiveSharesForUploadKey).mockResolvedValue(
+      activeShare
+    );
+
+    render(<SharePopover uploadKey="test.apkg" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Share' }));
+
+    await waitFor(() => screen.getByText('List in the public library'));
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect(
+      screen.getByPlaceholderText('e.g. Organic chemistry — Chapter 4')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'List deck' })).toBeDisabled();
+  });
+
+  it('publishes the deck and tracks shared_deck_published on success', async () => {
+    vi.mocked(sharedDeckLib.getActiveSharesForUploadKey).mockResolvedValue(
+      activeShare
+    );
+    vi.mocked(sharedDeckLib.setShareVisibility).mockResolvedValue({
+      token: 'test-token',
+      is_public: true,
+      title: 'My deck',
+      card_count: 10,
+    });
+
+    render(<SharePopover uploadKey="test.apkg" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Share' }));
+
+    await waitFor(() => screen.getByText('List in the public library'));
+    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.change(
+      screen.getByPlaceholderText('e.g. Organic chemistry — Chapter 4'),
+      { target: { value: 'My deck' } }
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'List deck' }));
+
+    await waitFor(() => {
+      expect(sharedDeckLib.setShareVisibility).toHaveBeenCalledWith(
+        'test-token',
+        true,
+        'My deck'
+      );
+    });
+    expect(trackLib.track).toHaveBeenCalledWith('shared_deck_published');
+    await screen.findByText('Listed in the public library as My deck');
+  });
+
+  it('unpublishes a listed deck', async () => {
+    vi.mocked(sharedDeckLib.getActiveSharesForUploadKey).mockResolvedValue({
+      ...activeShare,
+      is_public: true,
+      title: 'My deck',
+      card_count: 10,
+    });
+    vi.mocked(sharedDeckLib.setShareVisibility).mockResolvedValue({
+      token: 'test-token',
+      is_public: false,
+      title: null,
+      card_count: null,
+    });
+
+    render(<SharePopover uploadKey="test.apkg" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Share' }));
+
+    await waitFor(() => screen.getByText('Remove from library'));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Remove from library' })
+    );
+
+    await waitFor(() => {
+      expect(sharedDeckLib.setShareVisibility).toHaveBeenCalledWith(
+        'test-token',
+        false
+      );
     });
   });
 });

--- a/web/src/pages/PreviewApkgPage/SharePopover.tsx
+++ b/web/src/pages/PreviewApkgPage/SharePopover.tsx
@@ -4,8 +4,10 @@ import {
   createDeckShare,
   revokeDeckShare,
   getActiveSharesForUploadKey,
+  setShareVisibility,
   ActiveShare,
 } from '../../lib/backend/getSharedDeck';
+import { track } from '../../lib/analytics/track';
 import styles from './SharePopover.module.css';
 
 interface SharePopoverProps {
@@ -16,20 +18,109 @@ interface PopoverBodyProps {
   loading: boolean;
   share: ActiveShare | null;
   showConfirm: boolean;
+  publishTitle: string;
+  publishing: boolean;
+  publishError: string | null;
   onCopy: () => void;
   onStopRequest: () => void;
   onStopConfirm: () => void;
   onKeepSharing: () => void;
+  onPublishTitleChange: (value: string) => void;
+  onPublish: () => void;
+  onUnpublish: () => void;
+}
+
+function PublishSection({
+  share,
+  publishTitle,
+  publishing,
+  publishError,
+  onPublishTitleChange,
+  onPublish,
+  onUnpublish,
+}: Readonly<{
+  share: ActiveShare;
+  publishTitle: string;
+  publishing: boolean;
+  publishError: string | null;
+  onPublishTitleChange: (value: string) => void;
+  onPublish: () => void;
+  onUnpublish: () => void;
+}>) {
+  const { t } = useTranslation('previews');
+  const [wantsPublic, setWantsPublic] = useState(share.is_public);
+
+  if (share.is_public) {
+    return (
+      <div className={styles.publishSection}>
+        <p className={styles.publishedText}>
+          {t('share.listedAs', { title: share.title })}
+        </p>
+        <button
+          type="button"
+          className={styles.stopLink}
+          onClick={onUnpublish}
+          disabled={publishing}
+        >
+          {t('share.removeFromLibrary')}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.publishSection}>
+      <label className={styles.publishToggle}>
+        <input
+          type="checkbox"
+          checked={wantsPublic}
+          onChange={(e) => setWantsPublic(e.target.checked)}
+        />
+        {t('share.listInLibrary')}
+      </label>
+      {wantsPublic && (
+        <>
+          <p className={styles.helperText}>{t('share.listInLibraryHelper')}</p>
+          <input
+            type="text"
+            value={publishTitle}
+            onChange={(e) => onPublishTitleChange(e.target.value)}
+            placeholder={t('share.deckTitlePlaceholder')}
+            aria-label={t('share.deckTitle')}
+            maxLength={120}
+            className={styles.titleInput}
+          />
+          {publishError != null && (
+            <p className={styles.publishError}>{publishError}</p>
+          )}
+          <button
+            type="button"
+            className={styles.copyButton}
+            onClick={onPublish}
+            disabled={publishing || publishTitle.trim().length === 0}
+          >
+            {t('share.listDeck')}
+          </button>
+        </>
+      )}
+    </div>
+  );
 }
 
 function PopoverBody({
   loading,
   share,
   showConfirm,
+  publishTitle,
+  publishing,
+  publishError,
   onCopy,
   onStopRequest,
   onStopConfirm,
   onKeepSharing,
+  onPublishTitleChange,
+  onPublish,
+  onUnpublish,
 }: Readonly<PopoverBodyProps>) {
   const { t } = useTranslation('previews');
   if (loading) {
@@ -56,6 +147,15 @@ function PopoverBody({
         </button>
       </div>
       <p className={styles.helperText}>{t('share.helper')}</p>
+      <PublishSection
+        share={share}
+        publishTitle={publishTitle}
+        publishing={publishing}
+        publishError={publishError}
+        onPublishTitleChange={onPublishTitleChange}
+        onPublish={onPublish}
+        onUnpublish={onUnpublish}
+      />
       {showConfirm ? (
         <div className={styles.confirmDialog}>
           <p className={styles.confirmText}>{t('share.stopConfirm')}</p>
@@ -96,6 +196,9 @@ export function SharePopover({ uploadKey }: Readonly<SharePopoverProps>) {
   const [loading, setLoading] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
   const [showToast, setShowToast] = useState(false);
+  const [publishTitle, setPublishTitle] = useState('');
+  const [publishing, setPublishing] = useState(false);
+  const [publishError, setPublishError] = useState<string | null>(null);
   const anchorRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -114,6 +217,9 @@ export function SharePopover({ uploadKey }: Readonly<SharePopoverProps>) {
               url: result.url,
               created_at: new Date().toISOString(),
               view_count: 0,
+              is_public: false,
+              title: null,
+              card_count: null,
             });
           });
         } else {
@@ -166,6 +272,36 @@ export function SharePopover({ uploadKey }: Readonly<SharePopoverProps>) {
     } catch {}
   };
 
+  const publishToLibrary = async () => {
+    if (share == null || publishTitle.trim().length === 0) return;
+    setPublishing(true);
+    setPublishError(null);
+    try {
+      const updated = await setShareVisibility(share.token, true, publishTitle);
+      setShare({ ...share, ...updated });
+      track('shared_deck_published');
+    } catch (error) {
+      setPublishError(
+        error instanceof Error ? error.message : t('share.publishFailed')
+      );
+    } finally {
+      setPublishing(false);
+    }
+  };
+
+  const unpublishFromLibrary = async () => {
+    if (share == null) return;
+    setPublishing(true);
+    try {
+      const updated = await setShareVisibility(share.token, false);
+      setShare({ ...share, ...updated });
+      setPublishTitle('');
+    } catch {
+    } finally {
+      setPublishing(false);
+    }
+  };
+
   return (
     <>
       <div className={styles.anchor} ref={anchorRef}>
@@ -193,10 +329,16 @@ export function SharePopover({ uploadKey }: Readonly<SharePopoverProps>) {
               loading={loading}
               share={share}
               showConfirm={showConfirm}
+              publishTitle={publishTitle}
+              publishing={publishing}
+              publishError={publishError}
               onCopy={copyLink}
               onStopRequest={() => setShowConfirm(true)}
               onStopConfirm={stopSharing}
               onKeepSharing={() => setShowConfirm(false)}
+              onPublishTitleChange={setPublishTitle}
+              onPublish={publishToLibrary}
+              onUnpublish={unpublishFromLibrary}
             />
           </dialog>
         )}

--- a/web/src/pages/SharedDeckPage/SharedDeckPage.module.css
+++ b/web/src/pages/SharedDeckPage/SharedDeckPage.module.css
@@ -58,7 +58,25 @@
 .downloadRow {
   padding: 1.5rem;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.remixButton {
+  display: inline-block;
+  padding: 0.5rem 1.5rem;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-primary);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  font-weight: var(--font-medium);
+  font-size: var(--text-sm);
+}
+
+.remixButton:hover {
+  background: var(--color-bg-secondary);
 }
 
 .downloadButton {

--- a/web/src/pages/SharedDeckPage/SharedDeckPage.tsx
+++ b/web/src/pages/SharedDeckPage/SharedDeckPage.tsx
@@ -154,6 +154,9 @@ export default function SharedDeckPage() {
           <a href={downloadUrl} className={styles.downloadButton}>
             Download deck
           </a>
+          <a href="/upload" className={styles.remixButton}>
+            Make your own deck
+          </a>
         </div>
       )}
     </div>

--- a/web/src/pages/SharedDecksPage/SharedDecksPage.module.css
+++ b/web/src/pages/SharedDecksPage/SharedDecksPage.module.css
@@ -1,0 +1,49 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.deckCard {
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.deckTitle {
+  font-size: var(--text-base);
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cardCount {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.viewLink {
+  margin-top: auto;
+  align-self: flex-start;
+}
+
+.loadMoreRow {
+  display: flex;
+  justify-content: center;
+  margin-top: 2rem;
+}
+
+.errorText {
+  color: var(--color-danger);
+  font-size: var(--text-sm);
+}

--- a/web/src/pages/SharedDecksPage/SharedDecksPage.test.tsx
+++ b/web/src/pages/SharedDecksPage/SharedDecksPage.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import SharedDecksPage from './SharedDecksPage';
+import * as sharedDeckLib from '../../lib/backend/getSharedDeck';
+
+vi.mock('../../lib/backend/getSharedDeck', () => ({
+  getPublicSharedDecks: vi.fn(),
+}));
+
+vi.mock('react-helmet-async', () => ({
+  Helmet: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <SharedDecksPage />
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('SharedDecksPage', () => {
+  it('renders the empty state when there are no public decks', async () => {
+    vi.mocked(sharedDeckLib.getPublicSharedDecks).mockResolvedValue({
+      decks: [],
+      nextCursor: null,
+    });
+
+    renderPage();
+
+    await screen.findByText('No public decks yet');
+  });
+
+  it('renders each deck with title, card count, and a view link', async () => {
+    vi.mocked(sharedDeckLib.getPublicSharedDecks).mockResolvedValue({
+      decks: [
+        {
+          token: 't1',
+          title: 'Organic chemistry',
+          card_count: 42,
+          created_at: '2026-07-01T00:00:00Z',
+          view_count: 3,
+          url: 'https://2anki.net/s/t1',
+        },
+      ],
+      nextCursor: null,
+    });
+
+    renderPage();
+
+    await screen.findByText('Organic chemistry');
+    expect(screen.getByText('42 cards')).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: 'View deck' });
+    expect(link).toHaveAttribute('href', '/s/t1');
+  });
+
+  it('loads another page when Load more is clicked', async () => {
+    vi.mocked(sharedDeckLib.getPublicSharedDecks)
+      .mockResolvedValueOnce({
+        decks: [
+          {
+            token: 't1',
+            title: 'Deck one',
+            card_count: 5,
+            created_at: '2026-07-01T00:00:00Z',
+            view_count: 0,
+            url: 'https://2anki.net/s/t1',
+          },
+        ],
+        nextCursor: 24,
+      })
+      .mockResolvedValueOnce({
+        decks: [
+          {
+            token: 't2',
+            title: 'Deck two',
+            card_count: 8,
+            created_at: '2026-07-02T00:00:00Z',
+            view_count: 0,
+            url: 'https://2anki.net/s/t2',
+          },
+        ],
+        nextCursor: null,
+      });
+
+    renderPage();
+
+    await screen.findByText('Deck one');
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+
+    await waitFor(() => screen.getByText('Deck two'));
+    expect(sharedDeckLib.getPublicSharedDecks).toHaveBeenCalledWith(24);
+  });
+
+  it('shows an error message when loading fails', async () => {
+    vi.mocked(sharedDeckLib.getPublicSharedDecks).mockRejectedValue(
+      new Error('network error')
+    );
+
+    renderPage();
+
+    await screen.findByText("Couldn't load the shared library. Try again.");
+  });
+});

--- a/web/src/pages/SharedDecksPage/SharedDecksPage.tsx
+++ b/web/src/pages/SharedDecksPage/SharedDecksPage.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from 'react';
+import { Helmet } from 'react-helmet-async';
+import { useTranslation } from 'react-i18next';
+import { EmptyState } from '../../components/EmptyState/EmptyState';
+import { SkeletonList } from '../../components/Skeleton/Skeleton';
+import {
+  getPublicSharedDecks,
+  PublicSharedDeck,
+} from '../../lib/backend/getSharedDeck';
+import sharedStyles from '../../styles/shared.module.css';
+import styles from './SharedDecksPage.module.css';
+
+export default function SharedDecksPage() {
+  const { t } = useTranslation('previews');
+  const [decks, setDecks] = useState<PublicSharedDeck[]>([]);
+  const [nextCursor, setNextCursor] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    getPublicSharedDecks(null)
+      .then((page) => {
+        if (cancelled) return;
+        setDecks(page.decks);
+        setNextCursor(page.nextCursor);
+      })
+      .catch(() => {
+        if (!cancelled) setError(true);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const loadMore = () => {
+    if (nextCursor == null || loadingMore) return;
+    setLoadingMore(true);
+    getPublicSharedDecks(nextCursor)
+      .then((page) => {
+        setDecks((prev) => [...prev, ...page.decks]);
+        setNextCursor(page.nextCursor);
+      })
+      .catch(() => setError(true))
+      .finally(() => setLoadingMore(false));
+  };
+
+  return (
+    <div className={sharedStyles.page}>
+      <Helmet>
+        <title>{t('sharedLibrary.header')} - 2anki</title>
+      </Helmet>
+      <div className={sharedStyles.pageHeader}>
+        <h1 className={sharedStyles.title}>{t('sharedLibrary.header')}</h1>
+        <p className={sharedStyles.subtitle}>{t('sharedLibrary.subtitle')}</p>
+      </div>
+
+      {loading && <SkeletonList count={6} />}
+
+      {!loading && error && (
+        <p className={styles.errorText}>{t('sharedLibrary.loadFailed')}</p>
+      )}
+
+      {!loading && !error && decks.length === 0 && (
+        <EmptyState
+          icon="📚"
+          title={t('sharedLibrary.emptyTitle')}
+          description={t('sharedLibrary.emptyDescription')}
+          actionLabel={t('sharedLibrary.emptyAction')}
+          actionHref="/upload"
+        />
+      )}
+
+      {!loading && decks.length > 0 && (
+        <>
+          <div className={styles.grid}>
+            {decks.map((deck) => (
+              <div key={deck.token} className={styles.deckCard}>
+                <p
+                  className={styles.deckTitle}
+                  title={deck.title ?? undefined}
+                  data-hj-suppress
+                >
+                  {deck.title}
+                </p>
+                {deck.card_count != null && (
+                  <p className={styles.cardCount}>
+                    {t('sharedLibrary.cardCount', { count: deck.card_count })}
+                  </p>
+                )}
+                <a
+                  href={`/s/${deck.token}`}
+                  className={`${sharedStyles.btnPrimary} ${sharedStyles.btnInline} ${styles.viewLink}`}
+                >
+                  {t('sharedLibrary.viewDeck')}
+                </a>
+              </div>
+            ))}
+          </div>
+
+          {nextCursor != null && (
+            <div className={styles.loadMoreRow}>
+              <button
+                type="button"
+                className={sharedStyles.btnSecondary}
+                onClick={loadMore}
+                disabled={loadingMore}
+              >
+                {t('sharedLibrary.loadMore')}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/SharedDecksPage/index.tsx
+++ b/web/src/pages/SharedDecksPage/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './SharedDecksPage';

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-23-shared-deck-library.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-23-shared-deck-library.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-23-shared-deck-library",
+  "date": "2026-07-23",
+  "type": "feature",
+  "title": "Shared decks — list any deck you've shared in the public library for others to find"
+}


### PR DESCRIPTION
**DRAFT** — this PR adds a Knex migration (additive-only: two nullable columns + one non-null defaulted boolean + one partial index on `deck_shares`). Per the overnight-PR rules, any migration ships as draft with a `migration-reviewer` request rather than flipped ready unattended. Everything else (tests, typecheck, lint, format) is green; the only open item is the migration safety sign-off and Alexander's call on the copy/scope decisions below.

## Summary

Turns the existing private, token-only `ShareRouter` shares into an opt-in public library. This is the first sub-task of #3685 (P3 of the go-to-place growth strategy) — the shared-deck library is the strategy doc's highest-leverage unbuilt lever: "every shared deck is a user-generated landing page" (the Quizlet playbook), and unlike CRO or content work it doesn't require authored copy to compound.

- Owner can flip an existing share to "public" from the share popover, giving it a title. The deck then appears on a new `/shared-decks` page (title, card count, "View deck" link to the existing `/s/:token` viewer). Unpublish removes it from the listing; the private link keeps working either way.
- New `/s/:token` viewer gets a "Make your own deck" secondary CTA to `/upload`.
- Downloads and Favorites empty states link to `/shared-decks` ("Browse the shared library") — see discovery section below.
- A `shared_deck_published` usage event fires on publish (surface-lifecycle requirement — a T+30d keep/remove adoption-review issue should be filed at merge, dated 2026-08-22).

## Discovery — this was originally a gap, now fixed

Asked directly: right after shipping v1, `/shared-decks` had **zero discovery surface** — no nav, footer, or sitemap entry, unreachable except by typing the URL. Ran a trio consult on the fix:

- **Sidebar nav item — no**, pm and designer agreed independently. The sidebar is logged-in-user real estate for per-session workflow verbs (upload, download, review); a rarely-visited browse surface either dilutes those or sits ignored. The feature's actual growth mechanism is external (a stranger finds a deck via search, signs up) — a sidebar link only reaches people already logged in and does nothing for that.
- **Naming — keep "Shared decks"**, not "Public." Full trio agreed: "Public" is a bare adjective, doesn't name the object; "Shared decks" does (VOICE.md specific-over-generic). The URL slug stays `/shared-decks` regardless — SEO-descriptive, not worth late churn to rename to a generic `/public`.
- **Shipped this round:** a "Browse the shared library" link on the Downloads and Favorites empty states — the moments a user has nothing to work with, per the trio's priority list. Alexander picked this from the recommended set (publish-confirmation link, sitemap+footer, empty-state nudge) — empty-state nudge shipped now; the other two remain follow-ups below.

## What's NOT built (deliberate v1 scope cuts)

- No real remix/fork mechanism — the CTA is a plain link to `/upload`.
- No search, tags, categories, or filters on the library page.
- No moderation/reporting/takedown flow beyond the owner's existing unpublish/revoke.
- No thumbnails or OG images on listing cards.
- No sort beyond newest-first.
- No SEO indexing changes to `/s/:token` (stays `noindex`) — only `/shared-decks` itself is indexable.
- Copy is English-only; the other 9 locale files got the same keys with English placeholder text (parity satisfied, translation not attempted tonight).

## Decisions made overnight (please review)

- **Toggle placement — SharePopover only, not also on the DownloadsPage active-shares list.** One entry point for v1 keeps the diff and the UX surface small; add a second entry point later if the popover proves inconvenient. Assumption: publishing is rare enough that owners will find it via the popover they already use to get the link.
- **Publish quality bar: `card_count >= 3` (and a title, and not revoked) before a deck appears in the listing.** A deck can still be "published" (`is_public = true`) even if the card-count parse fails at publish time (stored as `null`) — the listing simply won't surface it until a count is known and clears the bar. This avoids blocking the publish action on an S3/parse hiccup while keeping the library free of empty/junk decks. If you'd rather block the publish action itself on a successful parse, say so and I'll flip it.
- **Default is private opt-in, always.** A newly created share (and every pre-existing row) stays `is_public = false` until the owner explicitly checks the box and supplies a title. No backfill, no silent listing of anything created before this shipped.
- **Copy** (all in `previews.json` → `share.*` / `sharedLibrary.*`, all 10 locales get the same English text tonight):
  - Toggle: "List in the public library" / helper "Anyone can find and view this deck. Your Notion account stays private."
  - Title field: "Deck title", placeholder "e.g. Organic chemistry — Chapter 4"
  - Publish button: "List deck"; unpublish: "Remove from library"
  - Library header: "Shared decks" / subtitle "Decks people made public. Open one, then make your own."
  - Empty state: "No public decks yet" / "Share one of yours to start the library." / "Make a deck" → `/upload`
  Swap any of these if you'd word it differently — none are load-bearing on the schema or API shape.
- **`/s/:token`'s new "Make your own deck" CTA is a plain hardcoded English string, matching that page's existing convention** (the whole `SharedDeckPage` component predates i18n and has no `useTranslation` calls) rather than introducing i18n for one string on an otherwise non-i18n'd page. Everywhere else touched tonight (`SharePopover`, the new `/shared-decks` page) uses the project's `previews` i18n namespace as usual.
- **Pagination is offset-based (`cursor` = row offset), page size 24, "Load more" button — no infinite scroll.** Matches the existing `/api/shares/:token/cards` pagination style; simplest thing that works for a v1 with unknown volume.

## API surface added

- `PATCH /api/shares/:token` — owner-only, `{ is_public: boolean, title?: string }`. Publishing without a title 400s. Not-owned/not-found 404s (doesn't leak which).
- `GET /api/shares/public` — public, rate-limited like the rest of `ShareRouter`, paginated, **does not** send `X-Robots-Tag: noindex` (the one intentionally-indexable share endpoint).

## Migration

Two migrations now, after `migration-reviewer` caught a real issue in the first draft:

- `20260929000000_add_public_listing_to_deck_shares.js` — adds `is_public boolean not null default false`, `title varchar(120)` nullable, `card_count integer` nullable to `deck_shares`. Transactional, additive-only, no backfill. Metadata-only `ADD COLUMN` on PG11+ (confirm prod is ≥ PG11 — near-certain but worth a one-line check).
- `20260929000001_index_deck_shares_public_listing_concurrent.js` — the partial index `(created_at desc) where is_public and not revoked`, split into its own `transaction: false` migration using `CREATE/DROP INDEX CONCURRENTLY IF EXISTS`, mirroring `20260926000000_index_uploads_owner_id_concurrent.js`. **The original single-migration version built this index in a plain transaction, which takes a `SHARE` lock on `deck_shares` for the whole build — blocking share creation, revocation, and view-count updates on a live table.** Fixed after review, before this went ready.

`pnpm kanel` regenerated `src/data_layer/public/DeckShares.ts` — confirmed scoped to exactly `is_public`/`title`/`card_count`, nothing else touched.

**Migration-reviewer verdict: minor changes, now addressed.** Rollback order, kanel scoping, and backfill-safety all confirmed correct by inspection.

## Storage & access — decided: no paid gate

- **Shared decks are never deleted, and there's no gate.** `deck_shares` rows have no expiry (only the existing manual revoke). The underlying upload is protected from the daily non-subscriber cleanup sweep (`deleteNonSubScriberUploadsInDatabase.ts`, pre-existing, unrelated to this PR) as long as the share stays active — that's an unconditional exclusion in the cleanup query, not a longer TTL. `ShareRouter` has never had a paid gate (`RequireAuthentication` only) — sharing, and now publishing, is available to every logged-in user, free or paid.
- **Decision: publishing to `/shared-decks` stays ungated.** Ran a trio consult (pm + engineer, both independently) on whether to require `isPaying`/`hasAnkifyAccess` to publish. Unanimous: no. Gating the *public* publish action while leaving *private* share creation ungated closes nothing — both use the identical `revoked_at IS NULL` exemption, so a free user gets the same free-storage pin either way. A publish-only gate would tax the one behavior this feature exists to maximize (publish volume → SEO landing pages) while leaving the actual mechanism completely open.
- **The real fix, if this ever becomes a real cost problem, is a uniform inactivity TTL on the exemption itself** — applied to all shares regardless of `is_public`, not a per-action paywall. Filed separately: https://github.com/Laer-Smart/2anki.net/issues/3831. Low priority — no evidence of abuse yet; revisit at the T+30d adoption review or if storage costs move.

## Testing

- Server: 3 new/changed suites (`ShareRepository`, `PublishShareUseCase`, `ListPublicSharesUseCase`) + updated `ShareController`/`EventsController`/`knownRoutes` tests — 189 tests green in the touched scope, full server `tsc -p . --noEmit` clean.
- Web: new `SharedDecksPage` tests, updated `SharePopover`/`getSharedDeck` tests — full suite 2730/2730 green, web `tsc` clean.
- `pnpm lint` — no new warnings in any touched file (one pre-existing `exhaustive-deps` warning on an untouched `SharePopover` effect).
- `pnpm format:check` — clean (the exact tree-wide CI command, not a per-file run).
- Sonar not run locally (no Docker/`SONAR_TOKEN` on this box tonight) — Automatic Analysis will cover the push.

Browser check: not applicable — no interactive browser available in this unattended run. This is new-surface UI (not a mirror of an already-shipped exact pattern), so a human visual pass on `/shared-decks` and the share popover's checkbox/title flow is still worth doing after merge; flagging the limitation explicitly rather than claiming a check that didn't happen.

## Follow-ups for a human

1. File the T+30d adoption-review issue at merge (dated ~2026-08-22): shared-deck-library keep/remove, per the surface-lifecycle rule. Kill criterion already defined in the strategy doc: <5% of organic entrances after 8 weeks.
2. Real translation of the new copy keys into the other 9 locales, if this proves worth keeping.
3. Consider a second publish entry point (DownloadsPage) if the popover-only flow turns out to be undiscoverable.
4. Remaining discovery items from the trio's list, not shipped this round: a link on the publish-confirmation moment itself (highest-intent surface), and a sitemap.xml entry once real published decks exist.
5. Storage-exemption TTL (#3831) — low priority, revisit if abuse shows up.

Closes nothing on its own merge — #3685 tracks the two remaining P3 sub-items (webhook-based sync rebuild, hosted-Anki shelving) separately.




