### PR TITLE
fix: persist collapsed Ankify decks across page refresh

### DIFF
--- a/web/src/pages/AnkifyPage/components/ReviewPanel.test.tsx
+++ b/web/src/pages/AnkifyPage/components/ReviewPanel.test.tsx
@@ -3,9 +3,9 @@ import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-import ReviewPanel from './ReviewPanel';
+import ReviewPanel, { DeckPicker } from './ReviewPanel';
 import { Backend, ReviewQueueCard } from '../../../lib/backend/Backend';
-import { AnkifyStats } from '../stats/types';
+import { AnkifyStats, AnkifyStatsDeck } from '../stats/types';
 
 const trackMock = vi.fn();
 vi.mock('../../../lib/analytics/track', () => ({
@@ -562,5 +562,54 @@ describe('ReviewPanel', () => {
 
     const reviewButton = await screen.findByRole('button', { name: 'Review' });
     expect(reviewButton).not.toBeDisabled();
+  });
+});
+
+describe('DeckPicker collapse persistence', () => {
+  const decksWithChild: AnkifyStatsDeck[] = [
+    {
+      fullName: 'MS3',
+      name: 'MS3',
+      depth: 0,
+      new: 0,
+      learning: 0,
+      review: 0,
+      total: 0,
+    },
+    {
+      fullName: 'MS3::Pharmacology',
+      name: 'Pharmacology',
+      depth: 1,
+      new: 2,
+      learning: 0,
+      review: 3,
+      total: 10,
+    },
+  ];
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  test('collapsing a deck persists across remounts', () => {
+    const { unmount } = render(
+      <DeckPicker decks={decksWithChild} onReview={vi.fn()} />
+    );
+
+    expect(screen.getByText('Pharmacology')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse MS3' }));
+    expect(screen.queryByText('Pharmacology')).not.toBeInTheDocument();
+
+    unmount();
+    render(<DeckPicker decks={decksWithChild} onReview={vi.fn()} />);
+
+    expect(screen.queryByText('Pharmacology')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Expand MS3' })
+    ).toBeInTheDocument();
   });
 });

--- a/web/src/pages/AnkifyPage/components/ReviewPanel.tsx
+++ b/web/src/pages/AnkifyPage/components/ReviewPanel.tsx
@@ -18,6 +18,10 @@ import { Backend, ReviewCard } from '../../../lib/backend/Backend';
 import { AnkifyStatsDeck } from '../stats/types';
 import { buildDeckTree } from './buildDeckTree';
 import { track } from '../../../lib/analytics/track';
+import {
+  getStoredCollapsedDecks,
+  setStoredCollapsedDecks,
+} from '../lib/collapsedDecksStorage';
 
 interface Props {
   readonly backend?: Backend;
@@ -72,7 +76,9 @@ export function DeckPicker({
 }) {
   const { t } = useTranslation('ankify');
   const tree = buildDeckTree(decks);
-  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  const [collapsed, setCollapsed] = useState<Set<string>>(() =>
+    getStoredCollapsedDecks()
+  );
 
   const toggle = (fullName: string) => {
     setCollapsed((prev) => {
@@ -82,6 +88,7 @@ export function DeckPicker({
       } else {
         next.add(fullName);
       }
+      setStoredCollapsedDecks(next);
       return next;
     });
   };

--- a/web/src/pages/AnkifyPage/lib/collapsedDecksStorage.test.ts
+++ b/web/src/pages/AnkifyPage/lib/collapsedDecksStorage.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  getStoredCollapsedDecks,
+  setStoredCollapsedDecks,
+} from './collapsedDecksStorage';
+
+describe('collapsedDecksStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns an empty set when nothing is stored', () => {
+    expect(getStoredCollapsedDecks()).toEqual(new Set());
+  });
+
+  it('round-trips a set of collapsed deck names', () => {
+    setStoredCollapsedDecks(new Set(['MS3::Pharmacology', 'MS3::Anatomy']));
+    expect(getStoredCollapsedDecks()).toEqual(
+      new Set(['MS3::Pharmacology', 'MS3::Anatomy'])
+    );
+  });
+
+  it('returns an empty set for corrupted stored JSON', () => {
+    localStorage.setItem('2anki-ankify-collapsed-decks', 'not json');
+    expect(getStoredCollapsedDecks()).toEqual(new Set());
+  });
+
+  it('ignores non-string entries in a malformed stored array', () => {
+    localStorage.setItem(
+      '2anki-ankify-collapsed-decks',
+      JSON.stringify(['MS3::Pharmacology', 42, null])
+    );
+    expect(getStoredCollapsedDecks()).toEqual(new Set(['MS3::Pharmacology']));
+  });
+});

--- a/web/src/pages/AnkifyPage/lib/collapsedDecksStorage.ts
+++ b/web/src/pages/AnkifyPage/lib/collapsedDecksStorage.ts
@@ -1,0 +1,20 @@
+const STORAGE_KEY = '2anki-ankify-collapsed-decks';
+
+export function getStoredCollapsedDecks(): Set<string> {
+  try {
+    const raw = globalThis.localStorage?.getItem(STORAGE_KEY);
+    if (raw == null) return new Set();
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((x): x is string => typeof x === 'string'));
+  } catch {
+    return new Set();
+  }
+}
+
+export function setStoredCollapsedDecks(collapsed: Set<string>): void {
+  globalThis.localStorage?.setItem(
+    STORAGE_KEY,
+    JSON.stringify(Array.from(collapsed))
+  );
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-24-ankify-collapsed-decks-persist.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-24-ankify-collapsed-decks-persist.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-24-ankify-collapsed-decks-persist",
+  "date": "2026-07-24",
+  "type": "fix",
+  "title": "Collapsed decks in Ankify review stay collapsed after refreshing the page"
+}


### PR DESCRIPTION
## Summary

`DeckPicker` (the deck tree on `/ankify`'s review panel) held collapsed-deck state in plain `useState<Set<string>>`, so refreshing the page reset every collapsed deck back to expanded. Reported directly: "ankify does not remember which decks are collapsed on refresh."

## Fix

Persist the collapsed set to `localStorage` (`2anki-ankify-collapsed-decks`), read on mount, written on every toggle. This is the sanctioned pattern for this exact case per `code-quality.md` ("localStorage is acceptable only for genuinely ephemeral UI state (collapsed panel, theme toggle)") — same shape as the existing theme-toggle persistence in `web/src/lib/theme.ts`.

Global (not per-account) storage, matching the theme toggle — deck collapse state is a local viewing preference, not data that needs cross-device sync.

## Testing

- New `collapsedDecksStorage.test.ts` — round-trip, empty-default, and corrupted-JSON fallback cases.
- New `DeckPicker collapse persistence` test in `ReviewPanel.test.tsx` — collapses a deck, unmounts, remounts, confirms the child stays hidden and the toggle shows "expand."
- Full web suite: 2725/2725 green, `tsc --noEmit` clean, `pnpm format:check` / `pnpm lint` clean on touched files.

Browser check: not applicable — no interactive browser available in this environment. The new automated test exercises the exact reported symptom end-to-end (collapse a deck → unmount/remount, simulating a refresh → deck stays collapsed), which is the substance behind the claim; a human visual pass on `/ankify` is still worth doing before merge since this is real UI, not a type-only change.
