### PR TITLE
fix: surface a calm message when Anki needs a full resync

### DIFF
--- a/src/controllers/AnkifyController.cockpit.test.ts
+++ b/src/controllers/AnkifyController.cockpit.test.ts
@@ -1,7 +1,10 @@
 import { Request, Response } from 'express';
 
 import AnkifyController from './AnkifyController';
-import { AnkiConnectUnreachableError } from '../services/ankify/AnkiConnectClient';
+import {
+  AnkiConnectUnreachableError,
+  AnkiFullSyncRequiredError,
+} from '../services/ankify/AnkiConnectClient';
 import { NoActiveAnkifyClientForProfileError } from '../usecases/ankify/GetAnkifyActiveProfileUseCase';
 import { NoActiveAnkifyClientForSyncError } from '../usecases/ankify/SyncToAnkiWebUseCase';
 import { DeckNotOwnedError } from '../usecases/ankify/OpenDeckInAnkiUseCase';
@@ -115,6 +118,24 @@ describe('AnkifyController cockpit handlers', () => {
     await controller.syncToAnkiWeb({} as Request, capture.res);
 
     expect(capture.statusCode).toBe(409);
+  });
+
+  test('syncToAnkiWeb maps a required full sync to a calm 409, not a raw error', async () => {
+    const execute = jest.fn(async () => {
+      throw new AnkiFullSyncRequiredError(
+        'Sync status 2 not one of [0, 1] - see SyncCollectionResponse.ChangesRequired for list of sync statuses: https://github.com/ankitects/anki/blob/e41c4573d789afe8b020fab5d9d1eede50c3fa3d/proto/anki/sync.proto#L57-L65'
+      );
+    });
+    const controller = makeController(SYNC_INDEX, { execute });
+    const capture = makeResponse();
+
+    await controller.syncToAnkiWeb({} as Request, capture.res);
+
+    expect(capture.statusCode).toBe(409);
+    expect(capture.body).toEqual({
+      message:
+        'Anki wants to fully resync this collection. Open Anki desktop, resolve the sync prompt there, then try again.',
+    });
   });
 
   test('openDeckInAnki 400 when deck is missing', async () => {

--- a/src/controllers/AnkifyController.ts
+++ b/src/controllers/AnkifyController.ts
@@ -53,7 +53,10 @@ import {
   DockerUnavailableError,
   NoAvailablePortError,
 } from '../services/ankify/RacService';
-import { AnkiConnectUnreachableError } from '../services/ankify/AnkiConnectClient';
+import {
+  AnkiConnectUnreachableError,
+  AnkiFullSyncRequiredError,
+} from '../services/ankify/AnkiConnectClient';
 import { sanitizeDeckPath } from '../lib/ankify/transforms/tags';
 import { GetAnkifyStatsUseCase } from '../usecases/ankify/GetAnkifyStatsUseCase';
 import {
@@ -780,6 +783,13 @@ class AnkifyController {
       if (error instanceof NoActiveAnkifyClientForSyncError) {
         res.status(409).json({
           message: 'No active Ankify client. Provision one first.',
+        });
+        return;
+      }
+      if (error instanceof AnkiFullSyncRequiredError) {
+        res.status(409).json({
+          message:
+            'Anki wants to fully resync this collection. Open Anki desktop, resolve the sync prompt there, then try again.',
         });
         return;
       }

--- a/src/services/ankify/AnkiConnectClient.test.ts
+++ b/src/services/ankify/AnkiConnectClient.test.ts
@@ -4,6 +4,7 @@ import {
   AnkiConnectError,
   AnkiConnectTimeoutError,
   AnkiConnectUnreachableError,
+  AnkiFullSyncRequiredError,
 } from './AnkiConnectClient';
 
 const makeFetch = (
@@ -537,6 +538,32 @@ describe('AnkiConnectClient', () => {
     } finally {
       jest.useRealTimers();
     }
+  });
+
+  test('sync throws AnkiFullSyncRequiredError when AnkiConnect reports ChangesRequired=FULL_SYNC', async () => {
+    const fetchImpl = makeFetch({
+      result: null,
+      error:
+        'Sync status 2 not one of [0, 1] - see SyncCollectionResponse.ChangesRequired for list of sync statuses: https://github.com/ankitects/anki/blob/e41c4573d789afe8b020fab5d9d1eede50c3fa3d/proto/anki/sync.proto#L57-L65',
+    });
+    const client = new AnkiConnectClient('http://x', fetchImpl);
+
+    const err = await client.sync().catch((e) => e);
+
+    expect(err).toBeInstanceOf(AnkiFullSyncRequiredError);
+    // Existing generic-error handling should still recognize it.
+    expect(err).toBeInstanceOf(AnkiConnectError);
+  });
+
+  test('sync rethrows an unrelated AnkiConnectError unchanged', async () => {
+    const fetchImpl = makeFetch({ result: null, error: 'deck not found' });
+    const client = new AnkiConnectClient('http://x', fetchImpl);
+
+    const err = await client.sync().catch((e) => e);
+
+    expect(err).toBeInstanceOf(AnkiConnectError);
+    expect(err).not.toBeInstanceOf(AnkiFullSyncRequiredError);
+    expect(err.message).toBe('deck not found');
   });
 
   test('getActiveProfile posts getActiveProfile and returns the profile name', async () => {

--- a/src/services/ankify/AnkiConnectClient.ts
+++ b/src/services/ankify/AnkiConnectClient.ts
@@ -31,6 +31,17 @@ export class AnkiConnectError extends Error {
   }
 }
 
+// AnkiConnect's `sync` action surfaced Anki's own sync protocol saying a
+// one-way full sync is required (ChangesRequired != NO_CHANGES/NORMAL_SYNC).
+// Anki can't safely auto-pick a direction (risk of overwriting one side), so
+// this can only be resolved by a human via the Anki desktop app.
+export class AnkiFullSyncRequiredError extends AnkiConnectError {
+  constructor(cause: string) {
+    super(cause);
+    this.name = 'AnkiFullSyncRequiredError';
+  }
+}
+
 export class AnkiConnectUnreachableError extends Error {
   constructor(url: string, cause: unknown) {
     super(`AnkiConnect unreachable at ${url}`);
@@ -186,7 +197,17 @@ export class AnkiConnectClient {
   }
 
   async sync(): Promise<null> {
-    return this.invoke('sync', undefined, ANKI_CONNECT_SYNC_TIMEOUT_MS);
+    try {
+      return await this.invoke('sync', undefined, ANKI_CONNECT_SYNC_TIMEOUT_MS);
+    } catch (error) {
+      if (
+        error instanceof AnkiConnectError &&
+        error.message.includes('ChangesRequired')
+      ) {
+        throw new AnkiFullSyncRequiredError(error.message);
+      }
+      throw error;
+    }
   }
 
   async ping(): Promise<number> {

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-24-ankify-full-sync-message.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-24-ankify-full-sync-message.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-24-ankify-full-sync-message",
+  "date": "2026-07-24",
+  "type": "fix",
+  "title": "Auto-Sync tells you when Anki needs a full resync instead of a raw error"
+}


### PR DESCRIPTION
## Summary
- Root-caused a prod error group: `AnkiConnectError: Sync status 2 not one of [0, 1] - see SyncCollectionResponse.ChangesRequired...`. `AnkiConnectClient.invoke` rethrows AnkiConnect's JSON-RPC error verbatim; here it's Anki's own sync protocol reporting `ChangesRequired = FULL_SYNC`, which `sync()` didn't special-case, so it fell through to a generic 500 with a raw proto link and stack leaking to the client/logs.
- No way to safely auto-resolve sync direction headlessly (risks overwriting one side of the collection) — this is a copy/error-handling fix, not a sync-logic fix.
- Added `AnkiFullSyncRequiredError` (subclass of `AnkiConnectError`) detected in `AnkiConnectClient.sync()`, mapped in `AnkifyController.syncToAnkiWeb` to a 409 with an actionable message, mirroring the existing `AnkiConnectUnreachableError` → 503 pattern.

## Browser check
Browser check: not applicable — the only `web/src/` file in this diff is a changelog JSON entry (`web/src/pages/WhatsNewPage/changelog/2026-07-24-ankify-full-sync-message.json`); no rendered component changed.

## Test plan
- [x] New failing tests written first (`AnkiConnectClient.test.ts`, `AnkifyController.cockpit.test.ts`), confirmed they failed for the right reason, then implemented
- [x] `pnpm test -- src/controllers/AnkifyController.cockpit.test.ts src/services/ankify/AnkiConnectClient.test.ts` — 50 passing
- [x] `tsc -p . --noEmit` clean
- [x] `pnpm format:check` clean
- Sonar not run locally (no `SONAR_TOKEN` on this box); Automatic Analysis covers the push.