### PR TITLE
fix: time out the ops performance-metrics fetch, don't hang forever

### DIFF
--- a/web/src/pages/OpsPage/usePerformanceMetrics.test.ts
+++ b/web/src/pages/OpsPage/usePerformanceMetrics.test.ts
@@ -101,6 +101,30 @@ describe('usePerformanceMetrics', () => {
     expect(result.current.error?.message).toBe('malformed response body');
   });
 
+  test('aborts and surfaces a timeout error when the request hangs', async () => {
+    vi.useFakeTimers();
+    try {
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockImplementation(
+        (_url: string, init?: { signal?: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () =>
+              reject(new DOMException('aborted', 'AbortError'))
+            );
+          })
+      );
+
+      const { result } = renderHook(() => usePerformanceMetrics(), {
+        wrapper: wrap(noRetryClient()),
+      });
+
+      await vi.advanceTimersByTimeAsync(20_000);
+      await vi.waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.error?.message).toBe('request timed out after 20s');
+    } finally {
+      vi.useRealTimers();
+    }
+  }, 10_000);
+
   test('surfaces status text on a non-ok response', async () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: false,

--- a/web/src/pages/OpsPage/usePerformanceMetrics.ts
+++ b/web/src/pages/OpsPage/usePerformanceMetrics.ts
@@ -3,13 +3,29 @@ import { useQuery } from '@tanstack/react-query';
 import { PerformanceMetricsResponse } from './performanceTypes';
 
 const REFRESH_MS = 30_000;
+const REQUEST_TIMEOUT_MS = 20_000;
 
 const fetchPerformanceMetrics =
   async (): Promise<PerformanceMetricsResponse> => {
-    const response = await fetch('/api/ops/performance/metrics', {
-      credentials: 'include',
-      cache: 'no-store',
-    });
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    let response: Response;
+    try {
+      response = await fetch('/api/ops/performance/metrics', {
+        credentials: 'include',
+        cache: 'no-store',
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (controller.signal.aborted) {
+        throw new Error(
+          `request timed out after ${REQUEST_TIMEOUT_MS / 1000}s`
+        );
+      }
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
     if (!response.ok) {
       throw new Error(`${response.status} ${response.statusText}`);
     }


### PR DESCRIPTION
## Summary
- Live screenshot of /ops/system showed the Performance tab's four panels permanently stuck on their loading skeleton, "Updated —", no error banner — despite the component already having an error-banner code path.
- Root cause: `usePerformanceMetrics`'s `fetch()` call had no timeout/AbortController. If the backend response stalls (e.g. the event loop blocked by a slow upload — see `/api/upload/file`'s observed 35s p95 latency), the fetch promise never settles, so React Query never leaves `isLoading`, and the error banner (which only renders once the query actually rejects) never has a chance to fire.
- Added a 20s client-side timeout via `AbortController`; on abort it now throws `request timed out after 20s`, which surfaces through the existing error banner instead of an indefinite skeleton.

## Browser check
Browser check: not applicable — internal ops-only page (Alexander only); no dev server available in this session to drive it live. Verified via the new Vitest timeout test plus the existing suite.

## Test plan
- [x] New test written first (`aborts and surfaces a timeout error when the request hangs`), confirmed it hung/failed before the fix (fake-timer + `vi.waitFor` based, no real 20s wait)
- [x] `npx vitest run src/pages/OpsPage` (from `web/`) — 202 passing
- [x] `tsc --noEmit` (web) clean
- [x] `pnpm format:check` clean
- No changelog entry — internal ops-only surface, not user-facing.
