### PR TITLE
fix: don't let the Google Drive picker get stuck open

### DIFF
--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -137,6 +137,93 @@ describe('UploadForm', () => {
   });
 });
 
+describe('UploadForm Google Drive picker interaction', () => {
+  const previousClient = process.env.REACT_APP_GOOGLE_CLIENT_ID;
+  const previousKey = process.env.REACT_APP_GOOGLE_API_KEY;
+
+  type GoogleGlobal = {
+    picker?: unknown;
+    accounts?: { oauth2?: unknown };
+  };
+
+  function stubGoogleDriveCancel() {
+    (window as unknown as { gapi: unknown }).gapi = {
+      load: (_lib: string, cb: () => void) => cb(),
+    };
+    (window as unknown as { google: GoogleGlobal }).google = {
+      picker: {
+        PickerBuilder: function PickerBuilder() {
+          const builder: Record<string, unknown> = {};
+          builder.setAppId = vi.fn().mockReturnValue(builder);
+          builder.setOAuthToken = vi.fn().mockReturnValue(builder);
+          builder.setDeveloperKey = vi.fn().mockReturnValue(builder);
+          builder.addView = vi.fn().mockReturnValue(builder);
+          builder.setCallback = vi.fn().mockImplementation((cb) => {
+            queueMicrotask(() => cb({ action: 'cancel' }));
+            return builder;
+          });
+          builder.build = vi.fn().mockReturnValue({ setVisible: vi.fn() });
+          return builder;
+        },
+        ViewId: { DOCS: 'DOCS' },
+        Action: { PICKED: 'picked', CANCEL: 'cancel', LOADED: 'loaded' },
+        DocsView: function DocsView() {
+          return { setIncludeFolders: vi.fn().mockReturnThis() };
+        },
+      },
+      accounts: {
+        oauth2: {
+          initTokenClient: ({
+            callback,
+          }: {
+            callback: (resp: { access_token?: string }) => void;
+          }) => ({
+            callback,
+            requestAccessToken: () => callback({ access_token: 'tok' }),
+          }),
+        },
+      },
+    };
+  }
+
+  beforeEach(() => {
+    process.env.REACT_APP_GOOGLE_CLIENT_ID = 'test-client';
+    process.env.REACT_APP_GOOGLE_API_KEY = 'AIza' + 'fake-test-key';
+  });
+
+  afterEach(() => {
+    process.env.REACT_APP_GOOGLE_CLIENT_ID = previousClient;
+    process.env.REACT_APP_GOOGLE_API_KEY = previousKey;
+    delete (window as unknown as { gapi?: unknown }).gapi;
+    delete (window as unknown as { google?: GoogleGlobal }).google;
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('scrolls to the top before opening the picker and restores focus to the button once it settles', async () => {
+    stubGoogleDriveCancel();
+    const scrollToSpy = vi.fn();
+    vi.stubGlobal('scrollTo', scrollToSpy);
+
+    const { container } = renderUploadForm(
+      <UploadForm setErrorMessage={vi.fn()} />
+    );
+
+    fireEvent.click(
+      container.querySelector('button[aria-label="Google Drive"]')!
+    );
+    const driveButton = await screen.findByRole('button', {
+      name: 'Choose from Google Drive',
+    });
+
+    fireEvent.click(driveButton);
+
+    expect(scrollToSpy).toHaveBeenCalledWith({ top: 0, behavior: 'auto' });
+
+    await waitFor(() => expect(driveButton).toHaveFocus());
+  });
+});
+
 describe('UploadForm analytics events', () => {
   beforeEach(() => {
     (globalThis as AnalyticsGlobals).gtag = vi.fn();

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -387,6 +387,7 @@ function UploadForm({
     useDropboxChooser(FORMATS);
   const { openPicker, isConfigured: isGoogleDriveConfigured } =
     useGooglePicker();
+  const driveButtonRef = useRef<HTMLButtonElement>(null);
 
   const handleDayPass = async () => {
     setDayPassError(null);
@@ -653,6 +654,11 @@ function UploadForm({
   const handleGoogleDriveClick = async () => {
     setDriveError(null);
     setDrivePending(true);
+    // The Google sign-in pop-up takes over the window; anchor the page at
+    // the top first so returning from it (or the picker itself) doesn't
+    // leave the user scrolled to wherever the browser's default focus
+    // restoration happens to land.
+    globalThis.scrollTo?.({ top: 0, behavior: 'auto' });
     try {
       const outcome = await openPicker();
       if (outcome.kind === 'cancelled') return;
@@ -668,6 +674,19 @@ function UploadForm({
       setDrivePending(false);
     }
   };
+
+  const wasDrivePendingRef = useRef(false);
+  useEffect(() => {
+    // Runs after the DOM commit, once the button is re-enabled — focusing
+    // it any earlier (e.g. right after setDrivePending(false)) would be a
+    // no-op, since a disabled element can't take focus. preventScroll:
+    // handleGoogleDriveClick already anchored the page at the top, so a
+    // plain focus() here would just scroll it into view a second time.
+    if (wasDrivePendingRef.current && !drivePending) {
+      driveButtonRef.current?.focus({ preventScroll: true });
+    }
+    wasDrivePendingRef.current = drivePending;
+  }, [drivePending]);
 
   const handleSubmit = async (event: SyntheticEvent) => {
     event.preventDefault();
@@ -1768,6 +1787,7 @@ function UploadForm({
               {t('upload.form.driveHint')}
             </span>
             <button
+              ref={driveButtonRef}
               type="button"
               className={formStyles.chooseButton}
               onClick={handleGoogleDriveClick}

--- a/web/src/pages/UploadPage/components/UploadForm/hooks/useGooglePicker.test.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/hooks/useGooglePicker.test.ts
@@ -162,6 +162,63 @@ describe('useGooglePicker', () => {
       );
     });
 
+    it('times out and clears the in-flight guard when the auth callback never fires (blocked or closed pop-up)', async () => {
+      vi.useFakeTimers();
+      try {
+        (window as unknown as { gapi: unknown }).gapi = {
+          load: (_lib: string, cb: () => void) => cb(),
+        };
+        (window as unknown as { google: GoogleGlobal }).google = {
+          picker: {
+            PickerBuilder: function PickerBuilder() {
+              return buildBuilder(() => undefined).builder;
+            },
+            ViewId: { DOCS: 'DOCS' },
+            Action: { PICKED: 'picked', CANCEL: 'cancel', LOADED: 'loaded' },
+            DocsView: function DocsView() {
+              return { setIncludeFolders: vi.fn().mockReturnThis() };
+            },
+          },
+          accounts: {
+            oauth2: {
+              initTokenClient: () => ({
+                callback: () => undefined,
+                requestAccessToken: () => undefined,
+              }),
+            },
+          },
+        };
+
+        const { result } = renderHook(() => useGooglePicker());
+        const pending = result.current.openPicker().catch((e) => e);
+
+        await vi.advanceTimersByTimeAsync(60_000);
+        const err = await pending;
+
+        expect(err).toBeInstanceOf(Error);
+        expect((err as Error).message).toMatch(/pop-up/i);
+
+        // The guard must have reset — a fresh call should not immediately
+        // reject with "already open"; it should be freshly pending instead.
+        let secondSettled = false;
+        let secondError: unknown;
+        result.current.openPicker().then(
+          () => {
+            secondSettled = true;
+          },
+          (e) => {
+            secondSettled = true;
+            secondError = e;
+          }
+        );
+        await vi.advanceTimersByTimeAsync(0);
+        expect(secondSettled).toBe(false);
+        expect(secondError).toBeUndefined();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('calls setAppId with the project number derived from the client id', async () => {
       process.env.REACT_APP_GOOGLE_CLIENT_ID =
         '806855830059-abc123def.apps.googleusercontent.com';

--- a/web/src/pages/UploadPage/components/UploadForm/hooks/useGooglePicker.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/hooks/useGooglePicker.ts
@@ -105,6 +105,9 @@ const SCOPE = 'https://www.googleapis.com/auth/drive.file';
 
 const GOOGLE_UNAVAILABLE =
   "Couldn't load Google Drive. Check your connection or disable script blockers and try again.";
+const AUTH_TIMEOUT_MS = 60_000;
+const AUTH_TIMEOUT_MESSAGE =
+  "Google Drive sign-in didn't complete. If your browser blocked the pop-up, allow pop-ups for 2anki.net and try again.";
 
 function clientId(): string | null {
   const id = process.env.REACT_APP_GOOGLE_CLIENT_ID;
@@ -229,10 +232,21 @@ export function useGooglePicker() {
       .then(
         ([picker, oauth2]) =>
           new Promise<GooglePickerResult>((resolve, reject) => {
+            // GIS's callback never fires if the browser blocks the sign-in
+            // pop-up outright, and unreliably fires if the user closes it
+            // manually — either way the promise (and the in-flight guard)
+            // would hang forever without this. Only the auth phase races
+            // the timeout; once a response arrives, the picker's own file
+            // browser can stay open as long as the user needs.
+            const authTimeout = setTimeout(() => {
+              reject(new Error(AUTH_TIMEOUT_MESSAGE));
+            }, AUTH_TIMEOUT_MS);
+
             const tokenClient = oauth2.initTokenClient({
               client_id: id,
               scope: SCOPE,
               callback: (resp) => {
+                clearTimeout(authTimeout);
                 if (resp.error || !resp.access_token) {
                   reject(
                     new Error(

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-25-google-drive-picker-stuck.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-25-google-drive-picker-stuck.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-25-google-drive-picker-stuck",
+  "date": "2026-07-25",
+  "type": "fix",
+  "title": "The Google Drive picker no longer gets stuck open after a blocked or cancelled sign-in pop-up"
+}


### PR DESCRIPTION
## Summary
Reported live via 3 screenshots on `/upload`: the Google Drive picker button reads "Google Drive wird geöffnet" (opening) permanently and needs two clicks to recover, and returning from the sign-in pop-up leaves the page scrolled to a random spot instead of near the picker.

- **Root cause of the stuck button:** `useGooglePicker.openPicker()`'s promise (and its `inFlightRef` re-entrancy guard) had no timeout. Google Identity Services' `initTokenClient` callback never fires if the browser blocks the sign-in pop-up outright, and unreliably fires if the user closes it manually — either way the promise hangs forever, so the button stays disabled/"opening" and the guard never resets. A second click then synchronously rejects with "already open," which is what finally unstuck the UI — matching the reported "click twice" toggle behavior. Added a 60s timeout scoped to only the auth phase (not the file-browsing phase, which can legitimately stay open indefinitely) that rejects with an actionable message and correctly resets the guard via the existing `.finally()`.
- **Root cause of the scroll jump:** no explicit scroll/focus management around the pop-up. `handleGoogleDriveClick` now anchors the page to the top before opening the pop-up (satisfies "we should be at the top to see the picker"), and restores focus to the Drive button (`preventScroll: true`, deferred to a `useEffect` keyed on `drivePending` so it only fires once the button is actually re-enabled — a disabled element can't take focus) once the flow settles, instead of leaving it to the browser's default focus-restoration.

## Browser check
Browser check: not applicable — no dev server available in this session to drive it live (this is exactly the kind of interaction — real Google OAuth pop-up + browser pop-up-blocker state — that's hard to fully exercise outside a live browser anyway). Verified via new tests exercising the exact hang/timeout and scroll/focus behavior.

## Test plan
- [x] New tests written first, confirmed failing for the right reason (`Test timed out in 5000ms` with no timeout in source) before implementing
- [x] `npx vitest run src/pages/UploadPage` (from `web/`) — 193 passing
- [x] `tsc --noEmit` (server + web) clean
- [x] `pnpm format:check` clean
- Changelog entry added — user-facing bug on the core upload flow.
