### PR TITLE
feat: support noteType and tags on the MCP create_deck tool

### DIFF
--- a/src/services/mcp/McpServerFactory.ts
+++ b/src/services/mcp/McpServerFactory.ts
@@ -2,7 +2,10 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
 import { McpToolsService } from './McpToolsService';
-import { McpConvertOptions } from './mcpOptionsToCardSettings';
+import {
+  McpConvertOptions,
+  McpCreateDeckOptions,
+} from './mcpOptionsToCardSettings';
 import { DECK_CAPABILITIES } from './deckCapabilities';
 import {
   DeckTableCard,
@@ -411,6 +414,7 @@ export function buildMcpServer(context: McpRequestContext): McpServer {
   registerTool<{
     cards: { front: string; back: string; deck?: string }[];
     deckName?: string;
+    options?: McpCreateDeckOptions;
     detail?: 'summary' | 'preview';
   }>(
     server,
@@ -449,6 +453,25 @@ export function buildMcpServer(context: McpRequestContext): McpServer {
           .string()
           .optional()
           .describe('Optional deck name, e.g. Pharmacology.'),
+        options: z
+          .object({
+            noteType: z
+              .enum(['basic', 'basic-reversed', 'cloze', 'input'])
+              .optional()
+              .describe(
+                "The Anki note type. Cloze also needs {{c1::}} markup in a card's front; without it, cloze falls back to basic. Not available for mcq — use convert_to_deck for that. Applies only to cards with no deck field — cards sorted into a subdeck always build as Basic."
+              ),
+            tags: z
+              .array(z.string())
+              .optional()
+              .describe(
+                'Anki tags applied to every card in the deck. Applies only to cards with no deck field.'
+              ),
+          })
+          .optional()
+          .describe(
+            'Curated card options. See deck_capabilities for the full list.'
+          ),
         detail: z
           .enum(['summary', 'preview'])
           .optional()
@@ -457,11 +480,12 @@ export function buildMcpServer(context: McpRequestContext): McpServer {
           ),
       },
     },
-    async ({ cards, deckName, detail }) => {
+    async ({ cards, deckName, options, detail }) => {
       context.recordToolCall('create_deck');
       const result = await context.toolsService.createDeck(
         cards,
         deckName,
+        options,
         context.owner,
         context.locals
       );

--- a/src/services/mcp/McpToolsService.test.ts
+++ b/src/services/mcp/McpToolsService.test.ts
@@ -704,6 +704,7 @@ describe('McpToolsService.createDeck', () => {
         { front: 'What is DNA?', back: 'Heredity molecule.' },
       ],
       'Biochemistry',
+      undefined,
       'owner-9',
       {}
     );
@@ -734,12 +735,14 @@ describe('McpToolsService.createDeck', () => {
     const first = await service.createDeck(
       [{ front: 'A-front', back: 'A-back' }],
       'Same Name',
+      undefined,
       'owner-9',
       {}
     );
     const second = await service.createDeck(
       [{ front: 'B-front', back: 'B-back' }],
       'Same Name',
+      undefined,
       'owner-9',
       {}
     );
@@ -771,6 +774,7 @@ describe('McpToolsService.createDeck', () => {
     await service.createDeck(
       [{ front: 'morning', back: '朝' }],
       'Japanese — Greetings',
+      undefined,
       'owner-9',
       {}
     );
@@ -790,6 +794,7 @@ describe('McpToolsService.createDeck', () => {
         { front: 'C', back: 'gamma' },
       ],
       undefined,
+      undefined,
       'owner-9',
       {}
     );
@@ -808,6 +813,7 @@ describe('McpToolsService.createDeck', () => {
     await service.createDeck(
       [{ front: 'Q', back: 'A' }],
       'Pharmacology',
+      undefined,
       'owner-9',
       {}
     );
@@ -816,7 +822,13 @@ describe('McpToolsService.createDeck', () => {
 
   it('rejects an empty cards array without touching persistence', async () => {
     const { service, persist } = makeService({});
-    const result = await service.createDeck([], 'Deck', 'owner-9', {});
+    const result = await service.createDeck(
+      [],
+      'Deck',
+      undefined,
+      'owner-9',
+      {}
+    );
     expect(result).toMatchObject({ kind: 'error' });
     expect(persist).not.toHaveBeenCalled();
   });
@@ -826,6 +838,7 @@ describe('McpToolsService.createDeck', () => {
     const result = await service.createDeck(
       [{ front: '   ', back: 'answer' }],
       'Deck',
+      undefined,
       'owner-9',
       {}
     );
@@ -839,7 +852,13 @@ describe('McpToolsService.createDeck', () => {
       front: `Q${i}`,
       back: `A${i}`,
     }));
-    const result = await service.createDeck(cards, 'Deck', 'owner-9', {});
+    const result = await service.createDeck(
+      cards,
+      'Deck',
+      undefined,
+      'owner-9',
+      {}
+    );
     expect(result).toMatchObject({ kind: 'error' });
     expect(persist).not.toHaveBeenCalled();
   });
@@ -855,6 +874,7 @@ describe('McpToolsService.createDeck', () => {
         { front: 'Another', back: '   ' },
       ],
       'Deck',
+      undefined,
       'owner-9',
       {}
     );
@@ -864,6 +884,72 @@ describe('McpToolsService.createDeck', () => {
       message:
         'Some cards have an empty back. Every card needs both a front and a back.',
     });
+  });
+
+  it('threads options.noteType through to the pipeline settings and echoes it in applied', async () => {
+    let capturedBody: Record<string, unknown> | undefined;
+    const entry: UploadEntrypoint = (req, res) => {
+      capturedBody = (req as unknown as { body: Record<string, unknown> }).body;
+      res.set('X-Card-Count', '1');
+      res.set('File-Name', 'deck.apkg');
+      res.status(200).send(Buffer.from('APKG-BYTES'));
+    };
+    const { service } = makeService({ uploadEntry: entry });
+    const result = await service.createDeck(
+      [{ front: 'Mitochondrion', back: 'Powerhouse of the cell' }],
+      'Biology',
+      { noteType: 'input', tags: ['bio'] },
+      'owner-9',
+      {}
+    );
+    expect(capturedBody).toEqual({
+      deckName: 'Biology',
+      'enable-input': 'true',
+      cloze: 'false',
+      'global-tags': 'bio',
+    });
+    expect(result).toMatchObject({
+      kind: 'deck',
+      applied: { noteType: 'input', tags: ['bio'] },
+    });
+    expect((result as { ignored?: unknown }).ignored).toBeUndefined();
+  });
+
+  it('downgrades cloze to basic and reports it in ignored when no card has {{c1::}} markup', async () => {
+    const { entry } = captureUpload();
+    const { service } = makeService({ uploadEntry: entry });
+    const result = await service.createDeck(
+      [{ front: 'Mitochondrion', back: 'Powerhouse of the cell' }],
+      'Biology',
+      { noteType: 'cloze' },
+      'owner-9',
+      {}
+    );
+    expect(result).toMatchObject({
+      kind: 'deck',
+      applied: { noteType: 'basic' },
+      ignored: [
+        {
+          option: 'noteType',
+          requested: 'cloze',
+          reason:
+            'No {{c1::}} markup found in the text; built basic cards instead.',
+        },
+      ],
+    });
+  });
+
+  it('omits applied entirely when no options are given, unchanged from before', async () => {
+    const { entry } = captureUpload();
+    const { service } = makeService({ uploadEntry: entry });
+    const result = await service.createDeck(
+      [{ front: 'Q', back: 'A' }],
+      'Deck',
+      undefined,
+      'owner-9',
+      {}
+    );
+    expect((result as { applied?: unknown }).applied).toBeUndefined();
   });
 });
 
@@ -1016,6 +1102,7 @@ describe('McpToolsService.createDeck with subdecks', () => {
     const result = await service.createDeck(
       subdeckCards(),
       'JLPT N5',
+      undefined,
       'owner-9',
       {}
     );
@@ -1045,10 +1132,45 @@ describe('McpToolsService.createDeck with subdecks', () => {
     });
   });
 
+  it('keeps noteType basic and reports it ignored when subdeck cards are involved', async () => {
+    const { service } = makeService({});
+    const result = await service.createDeck(
+      subdeckCards(),
+      'JLPT N5',
+      { noteType: 'input', tags: ['jp'] },
+      'owner-9',
+      {}
+    );
+    expect(result).toMatchObject({
+      kind: 'deck',
+      applied: { noteType: 'basic', tags: [] },
+      ignored: [
+        {
+          option: 'noteType',
+          requested: 'input',
+          reason:
+            'Cards with a deck field always build as Basic; noteType only applies when no card sets deck.',
+        },
+        {
+          option: 'tags',
+          requested: ['jp'],
+          reason:
+            'Cards with a deck field always build with no tags; tags only apply when no card sets deck.',
+        },
+      ],
+    });
+  });
+
   it('increments card usage by the flat total across all subdecks', async () => {
     const incrementCardUsage = jest.fn();
     const { service } = makeService({ incrementCardUsage });
-    await service.createDeck(subdeckCards(), 'JLPT N5', 'owner-9', {});
+    await service.createDeck(
+      subdeckCards(),
+      'JLPT N5',
+      undefined,
+      'owner-9',
+      {}
+    );
     expect(incrementCardUsage).toHaveBeenCalledWith('owner-9', 3);
   });
 
@@ -1064,6 +1186,7 @@ describe('McpToolsService.createDeck with subdecks', () => {
     const result = await service.createDeck(
       subdeckCards(),
       'JLPT N5',
+      undefined,
       'owner-9',
       {}
     );
@@ -1090,6 +1213,7 @@ describe('McpToolsService.createDeck with subdecks', () => {
     const result = await service.createDeck(
       subdeckCards(),
       'JLPT N5',
+      undefined,
       'owner-9',
       { subscriber: true }
     );
@@ -1107,6 +1231,7 @@ describe('McpToolsService.createDeck with subdecks', () => {
         { front: 'ichi', back: '1', deck: 'Vocabulary' },
       ],
       'JLPT N5',
+      undefined,
       'owner-9',
       {}
     );
@@ -1135,6 +1260,7 @@ describe('McpToolsService.createDeck with subdecks', () => {
         { front: 'c', back: 'd' },
       ],
       'JLPT N5',
+      undefined,
       'owner-9',
       {}
     );

--- a/src/services/mcp/McpToolsService.ts
+++ b/src/services/mcp/McpToolsService.ts
@@ -22,6 +22,7 @@ import { groupCardsBySubdeck, hasSubdecks } from './composeSubdecks';
 import { buildSubdeckDecks } from './buildSubdeckDecks';
 import {
   McpConvertOptions,
+  McpCreateDeckOptions,
   mcpOptionsToCardSettings,
 } from './mcpOptionsToCardSettings';
 import {
@@ -454,6 +455,7 @@ export class McpToolsService {
   async createDeck(
     cards: McpCard[],
     deckName: string | undefined,
+    options: McpCreateDeckOptions | undefined,
     owner: string,
     locals: Record<string, unknown>
   ): Promise<ConvertResult> {
@@ -476,7 +478,7 @@ export class McpToolsService {
         : DEFAULT_DECK_NAME;
 
     if (hasSubdecks(cards)) {
-      return this.createSubdeckDeck(cards, title, owner, locals);
+      return this.createSubdeckDeck(cards, title, options, owner, locals);
     }
 
     const markdown = serializeCardsToMarkdown(cards);
@@ -490,20 +492,40 @@ export class McpToolsService {
       size: buffer.byteLength,
       buffer,
     };
-    const res = await this.runUpload(file, locals, { deckName: title });
+    const res = await this.runUpload(file, locals, {
+      deckName: title,
+      ...mcpOptionsToCardSettings(options),
+    });
     const result = await this.mapUploadResult(res, owner, title);
-    if (result.kind === 'deck' && result.cardCount == null) {
-      return { ...result, cardCount: cards.length };
+    if (result.kind === 'error') {
+      return this.everyBackEmpty(cards)
+        ? { ...result, message: EMPTY_BACK_MESSAGE }
+        : result;
     }
-    if (result.kind === 'error' && this.everyBackEmpty(cards)) {
-      return { ...result, message: EMPTY_BACK_MESSAGE };
+    if (result.kind !== 'deck') {
+      return result;
     }
-    return result;
+    const withCount =
+      result.cardCount == null
+        ? { ...result, cardCount: cards.length }
+        : result;
+    if (options == null) {
+      return withCount;
+    }
+    const clozePresent =
+      options.noteType === 'cloze' ? hasClozeMarkup(markdown) : false;
+    const { applied, ignored } = buildAppliedOptions(options, clozePresent);
+    return {
+      ...withCount,
+      applied,
+      ...(ignored ? { ignored } : {}),
+    };
   }
 
   private async createSubdeckDeck(
     cards: McpCard[],
     title: string,
+    options: McpCreateDeckOptions | undefined,
     owner: string,
     locals: Record<string, unknown>
   ): Promise<ConvertResult> {
@@ -552,6 +574,7 @@ export class McpToolsService {
       tts: { enabled: false },
       subdecks,
     };
+    const ignored = this.subdeckIgnoredOptions(options);
     return {
       kind: 'deck',
       jobId: objectId,
@@ -560,8 +583,32 @@ export class McpToolsService {
       downloadUrl: `${this.baseUrl}/api/mcp/decks/${objectId}/download`,
       ...preview,
       applied,
+      ...(ignored ? { ignored } : {}),
       summary: subdeckSummary(title, totalCards, subdecks.length),
     };
+  }
+
+  private subdeckIgnoredOptions(
+    options: McpCreateDeckOptions | undefined
+  ): IgnoredOption[] | undefined {
+    const ignored: IgnoredOption[] = [];
+    if (options?.noteType != null && options.noteType !== 'basic') {
+      ignored.push({
+        option: 'noteType',
+        requested: options.noteType,
+        reason:
+          'Cards with a deck field always build as Basic; noteType only applies when no card sets deck.',
+      });
+    }
+    if (options?.tags != null && options.tags.length > 0) {
+      ignored.push({
+        option: 'tags',
+        requested: options.tags,
+        reason:
+          'Cards with a deck field always build with no tags; tags only apply when no card sets deck.',
+      });
+    }
+    return ignored.length > 0 ? ignored : undefined;
   }
 
   private everyBackEmpty(cards: McpCard[]): boolean {

--- a/src/services/mcp/deckCapabilities.ts
+++ b/src/services/mcp/deckCapabilities.ts
@@ -109,7 +109,7 @@ export const DECK_CAPABILITIES: DeckCapabilities = {
     howItWorks:
       'convert_to_deck scans your text for front and back pairs. Pick one structure below to separate each front from its back — you only need one. The note type (basic, basic-reversed, or input) is set through options.noteType and does not change which structure you use. Cloze is the exception: set options.noteType to cloze and put {{c1::...}} markup inside the front of any structure. Without the markup, cloze falls back to basic.',
     shortcut:
-      'If you already have discrete front and back pairs, skip the text formatting and call create_deck with a { front, back } array instead. It cannot fail on formatting.',
+      'If you already have discrete front and back pairs, skip the text formatting and call create_deck with a { front, back } array instead. It cannot fail on formatting. create_deck also takes options.noteType (basic, basic-reversed, cloze, or input — not mcq), but only for cards with no deck field; subdeck cards always build as Basic.',
     structures: [
       {
         name: 'inline',
@@ -158,7 +158,7 @@ export const DECK_CAPABILITIES: DeckCapabilities = {
         note: 'Cloze needs {{c1::...}} markup in the front of the card. Without the markup, cloze falls back to basic.',
       },
     ],
-    mcq: 'Multiple-choice cards are built from Notion toggle-list exports that mark the correct option, not from free-form text. To make them, convert a Notion export with options.noteType set to mcq. create_deck builds basic front and back cards only.',
+    mcq: 'Multiple-choice cards are built from Notion toggle-list exports that mark the correct option, not from free-form text or structured cards. To make them, convert a Notion export with options.noteType set to mcq. create_deck does not support mcq.',
   },
   conventions: [
     'Cloze cards require {{c1::...}} markup in the text; without it, cloze falls back to basic.',

--- a/src/services/mcp/mcpOptionsToCardSettings.ts
+++ b/src/services/mcp/mcpOptionsToCardSettings.ts
@@ -29,6 +29,13 @@ export interface McpConvertOptions {
   tts?: McpTtsOption;
 }
 
+export type McpCreateDeckNoteType = Exclude<McpNoteType, 'mcq'>;
+
+export interface McpCreateDeckOptions {
+  noteType?: McpCreateDeckNoteType;
+  tags?: string[];
+}
+
 const NOTE_TYPES: readonly McpNoteType[] = [
   'basic',
   'basic-reversed',

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-26-mcp-create-deck-note-types.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-26-mcp-create-deck-note-types.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-26-mcp-create-deck-note-types",
+  "date": "2026-07-26",
+  "type": "feature",
+  "title": "MCP create_deck can build cloze, input, and basic-reversed cards, not just Basic"
+}


### PR DESCRIPTION
## Summary

- `create_deck` had no way to request a note type — always Basic, silently, even when the caller asked for `input`/`cloze`/etc. (only `convert_to_deck` honored `options.noteType`). Wires `options.{noteType, tags}` through `create_deck`'s plain (no-subdeck) path via the same shared upload/parse pipeline `convert_to_deck` already uses, and echoes the applied/ignored options in the response like `convert_to_deck` does.
- `mcq` is excluded from `create_deck`'s `noteType` enum — it needs Notion toggle-list markup a front/back card array structurally can't carry (`convert_to_deck` remains the only path for mcq).
- Cards routed into a subdeck (any card with a `deck` field) bypass the shared parser entirely and still always build Basic — that's a real fork, not a cheap follow-on (traced through `CardOption`/`Note`/`create_deck.py`'s model-selection). Rather than silently dropping a requested `noteType`/`tags` on that path, the response now returns it in `ignored` with a reason, matching the existing cloze-fallback pattern.
- Updated `deckCapabilities.ts`'s `mcq`/`shortcut` copy, which previously stated "create_deck builds basic front and back cards only."
- Changelog entry added.

## Trio synthesis
- **pm**: close the gap on the plain path now (cheap, reuses existing pipeline); ship subdeck limitation honestly rather than doc-only; defer tags/tts/styleTemplate parity as unrequested scope creep.
- **designer**: narrow `options` to `{noteType, tags}` (not deckName/splitByHeadings/styleTemplate/tts — no obvious meaning on a pre-built card list); a documented-but-silent gap is not acceptable — either full parity or a loud echo in the tool result.
- **engineer**: confirmed the subdeck path is a genuine fork (`guessMarkdownCards` bypasses `DeckParser`'s settings→note-flag mapping entirely; `CardOption` flags are inert there) — not cheap to reuse, would mean re-implementing note-transform logic in a second place.
- **Resolution**: plain path gets full `noteType`/`tags` support this PR; subdeck path stays Basic but now returns an `ignored` entry (satisfies designer's "not silent" requirement without the second-parser-core risk engineer flagged). Full subdeck note-type support deferred to a follow-up if usage data shows demand.
- **Expected funnel impact**: none tracked — internal API-contract fix on the MCP beta surface. Recommend watching `create_deck` tool-call `noteType` values (already recorded via `recordToolCall`) at the next MCP adoption review to see if non-Basic requests are common enough to justify subdeck parity.

## Test plan
- [x] `pnpm test -- src/services/mcp/McpToolsService.test.ts src/services/mcp/McpServerFactory.test.ts src/services/mcp/mcpOptionsToCardSettings.test.ts src/services/mcp/buildAppliedOptions.test.ts src/services/mcp/deckCapabilities.test.ts` — 150/150 pass, including 4 new tests (noteType threading, cloze fallback, no-options-unchanged, subdeck ignored echo)
- [x] `npx tsc -p . --noEmit` — clean
- [x] `pnpm format:check` (tree-wide, exact CI command) — clean
- [x] `oxlint` on touched files — no new warnings vs. pre-existing baseline
- Sonar: local `sonar-scanner` refuses to run because Automatic Analysis is enabled for this project ("You are running manual analysis while Automatic Analysis is enabled"); the `sonarqube` MCP plugin isn't connected this session. Automatic Analysis will cover the push.

Browser check: not applicable — MCP server tool surface, no `web/src/` change (changelog JSON only).
