### PR TITLE
fix: fan out short paragraph runs in DOCX sections into cards

### DIFF
--- a/src/infrastracture/adapters/fileConversion/preprocessDocxHTML.test.ts
+++ b/src/infrastracture/adapters/fileConversion/preprocessDocxHTML.test.ts
@@ -244,3 +244,149 @@ describe('preprocessDocxHTML bullet fan-out', () => {
     expect(result).toContain('<strong>B. right</strong>');
   });
 });
+
+describe('preprocessDocxHTML paragraph fan-out', () => {
+  const phrasebookHTML =
+    '<h2>Greetings</h2>' +
+    '<p>Good morning — Buongiorno</p>' +
+    '<p>Good evening — Buonasera</p>' +
+    '<p>How are you? — Come stai?</p>' +
+    '<p>See you later — A dopo</p>';
+
+  it('fans a run of short paragraphs into one card per paragraph', () => {
+    const result = preprocessDocxHTML(phrasebookHTML, { bulletFanOut: true });
+
+    expect(result).toContain(
+      '<details><summary>Greetings — 1/4</summary>Good morning — Buongiorno</details>'
+    );
+    expect(result).toContain('<summary>Greetings — 4/4</summary>');
+    expect((result.match(/<details>/g) || []).length).toBe(4);
+  });
+
+  it('keeps a section under four short paragraphs as one card', () => {
+    const input =
+      '<h2>Notes</h2>' +
+      '<p>First point.</p>' +
+      '<p>Second point.</p>' +
+      '<p>Third point.</p>';
+
+    const result = preprocessDocxHTML(input, { bulletFanOut: true });
+
+    expect((result.match(/<details>/g) || []).length).toBe(1);
+    expect(result).toContain('<summary>Notes</summary>');
+  });
+
+  it('keeps a section of long prose paragraphs as one card', () => {
+    const prose = 'This paragraph explains a concept in depth. '.repeat(6);
+    const input =
+      '<h2>Theory</h2>' +
+      `<p>${prose}</p><p>${prose}</p><p>${prose}</p><p>${prose}</p>`;
+
+    const result = preprocessDocxHTML(input, { bulletFanOut: true });
+
+    expect((result.match(/<details>/g) || []).length).toBe(1);
+    expect(result).toContain('<summary>Theory</summary>');
+  });
+
+  it('puts one long intro paragraph on a context card and fans the rest', () => {
+    const intro = 'An introductory explanation of the greetings below. '.repeat(
+      5
+    );
+    const input =
+      `<h2>Greetings</h2><p>${intro.trim()}</p>` +
+      '<p>Good morning — Buongiorno</p>' +
+      '<p>Good evening — Buonasera</p>' +
+      '<p>How are you? — Come stai?</p>' +
+      '<p>See you later — A dopo</p>';
+
+    const result = preprocessDocxHTML(input, { bulletFanOut: true });
+
+    expect(result).toContain('<details><summary>Greetings</summary><p>');
+    expect(result).toContain('<summary>Greetings — 1/4</summary>');
+    expect((result.match(/<details>/g) || []).length).toBe(5);
+  });
+
+  it('skips empty and whitespace-only paragraphs without emitting blank cards', () => {
+    const input =
+      '<h2>Greetings</h2>' +
+      '<p>Good morning — Buongiorno</p>' +
+      '<p></p>' +
+      '<p>&nbsp;</p>' +
+      '<p>Good evening — Buonasera</p>' +
+      '<p>How are you? — Come stai?</p>' +
+      '<p>See you later — A dopo</p>';
+
+    const result = preprocessDocxHTML(input, { bulletFanOut: true });
+
+    expect((result.match(/<details>/g) || []).length).toBe(4);
+    expect(result).toContain('<summary>Greetings — 4/4</summary>');
+  });
+
+  it('falls back to one lumped card when the section contains an image', () => {
+    const input =
+      '<h2>Diagrams</h2>' +
+      '<p>Label one</p>' +
+      '<p><img src="figure.png" /></p>' +
+      '<p>Label two</p>' +
+      '<p>Label three</p>' +
+      '<p>Label four</p>';
+
+    const result = preprocessDocxHTML(input, { bulletFanOut: true });
+
+    expect((result.match(/<details>/g) || []).length).toBe(1);
+    expect(result).toContain('<img src="figure.png">');
+  });
+
+  it('falls back to one lumped card when the section contains a table', () => {
+    const input =
+      '<h2>Verbs</h2>' +
+      '<p>To be — essere</p>' +
+      '<p>To have — avere</p>' +
+      '<table><tr><td>io</td><td>sono</td></tr></table>' +
+      '<p>To go — andare</p>' +
+      '<p>To do — fare</p>';
+
+    const result = preprocessDocxHTML(input, { bulletFanOut: true });
+
+    expect((result.match(/<details>/g) || []).length).toBe(1);
+  });
+
+  it('preserves inline formatting on fanned-out paragraph cards', () => {
+    const input =
+      '<h2>Terms</h2>' +
+      '<p><strong>Osmosis</strong> — passive water movement</p>' +
+      '<p><strong>Diffusion</strong> — passive solute movement</p>' +
+      '<p><strong>Active transport</strong> — energy-dependent movement</p>' +
+      '<p><strong>Endocytosis</strong> — bulk intake</p>';
+
+    const result = preprocessDocxHTML(input, { bulletFanOut: true });
+
+    expect(result).toContain(
+      '<details><summary>Terms — 1/4</summary><strong>Osmosis</strong> — passive water movement</details>'
+    );
+  });
+
+  it('does not hijack a section that already has real bullets', () => {
+    const input =
+      '<h2>Mixed</h2>' +
+      '<p>Intro one</p>' +
+      '<p>Intro two</p>' +
+      '<p>Intro three</p>' +
+      '<p>Intro four</p>' +
+      '<ul><li>Bullet A</li><li>Bullet B</li></ul>';
+
+    const result = preprocessDocxHTML(input, { bulletFanOut: true });
+
+    expect(result).toContain('<summary>Mixed — 1/2</summary>');
+    expect(result).toContain(
+      '<details><summary>Mixed</summary><p>Intro one</p><p>Intro two</p><p>Intro three</p><p>Intro four</p></details>'
+    );
+    expect((result.match(/<details>/g) || []).length).toBe(3);
+  });
+
+  it('does not fan out paragraphs when the flag is off', () => {
+    const result = preprocessDocxHTML(phrasebookHTML);
+
+    expect((result.match(/<details>/g) || []).length).toBe(1);
+  });
+});

--- a/src/infrastracture/adapters/fileConversion/preprocessDocxHTML.ts
+++ b/src/infrastracture/adapters/fileConversion/preprocessDocxHTML.ts
@@ -64,6 +64,46 @@ function processListItem(html: string): string | null {
   return buildToggle(question, options, correctAnswers);
 }
 
+const PARAGRAPH_FAN_OUT_MIN_ITEMS = 4;
+const PARAGRAPH_FAN_OUT_MAX_CHARS = 200;
+const PARAGRAPH_FAN_OUT_MIN_SHORT_RATIO = 0.8;
+
+interface ParagraphFanOut {
+  units: string[];
+  contextParts: string[];
+}
+
+function collectParagraphFanOut(
+  $: any,
+  siblings: any[]
+): ParagraphFanOut | null {
+  const units: string[] = [];
+  const contextParts: string[] = [];
+  let longCount = 0;
+
+  for (const el of siblings) {
+    const $el = $(el);
+    if (!$el.is('p') || $el.find('img').length > 0) return null;
+
+    const text = $el.text().replaceAll('\u00a0', ' ').trim();
+    if (text.length === 0) continue;
+
+    if (text.length <= PARAGRAPH_FAN_OUT_MAX_CHARS) {
+      const inner = $el.html();
+      if (inner != null && inner.trim().length > 0) units.push(inner);
+    } else {
+      longCount += 1;
+      contextParts.push($.html(el));
+    }
+  }
+
+  if (units.length < PARAGRAPH_FAN_OUT_MIN_ITEMS) return null;
+  const shortRatio = units.length / (units.length + longCount);
+  if (shortRatio < PARAGRAPH_FAN_OUT_MIN_SHORT_RATIO) return null;
+
+  return { units, contextParts };
+}
+
 function buildSectionToggles(
   $: any,
   summary: string,
@@ -93,22 +133,28 @@ function buildSectionToggles(
     }
   }
 
+  let units = bullets;
+  let contextParts = otherParts;
+
   if (bullets.length === 0) {
-    return `<details><summary>${summary}</summary>${otherParts.join('')}</details>`;
+    const paragraphFanOut = collectParagraphFanOut($, siblings);
+    if (paragraphFanOut === null) {
+      return `<details><summary>${summary}</summary>${otherParts.join('')}</details>`;
+    }
+    units = paragraphFanOut.units;
+    contextParts = paragraphFanOut.contextParts;
   }
 
   const toggles: string[] = [];
-  if (otherParts.length > 0) {
+  if (contextParts.length > 0) {
     toggles.push(
-      `<details><summary>${summary}</summary>${otherParts.join('')}</details>`
+      `<details><summary>${summary}</summary>${contextParts.join('')}</details>`
     );
   }
-  bullets.forEach((bullet, index) => {
+  units.forEach((unit, index) => {
     const cue =
-      bullets.length > 1
-        ? `${summary} — ${index + 1}/${bullets.length}`
-        : summary;
-    toggles.push(`<details><summary>${cue}</summary>${bullet}</details>`);
+      units.length > 1 ? `${summary} — ${index + 1}/${units.length}` : summary;
+    toggles.push(`<details><summary>${cue}</summary>${unit}</details>`);
   });
   return toggles.join('');
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-26-docx-paragraph-fanout.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-26-docx-paragraph-fanout.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-26-docx-paragraph-fanout",
+  "date": "2026-07-26",
+  "type": "fix",
+  "title": "Word documents with short paragraph lists under a heading fan out into one card per line, not one oversized card"
+}


### PR DESCRIPTION
## Summary

DOCX sections written as paragraph-per-line Q&A/phrasebook content (no Word list formatting) collapsed into one oversized card per heading — `buildSectionToggles` only fanned out real `<ul>/<ol>` lists. Qualifying paragraph runs now fan out one card per paragraph through the same toggle machinery the bullet path uses.

Fixes #3846.

## What changed

`collectParagraphFanOut` in `preprocessDocxHTML.ts`: when a section has no list bullets, a run of short paragraphs fans out when ALL hold:

- 4+ qualifying `<p>` siblings (each ≤200 chars of plain text, nbsp-normalized; empty/whitespace-only paragraphs skipped, not counted, never emitted as blank cards)
- ≥80% of the section's non-empty paragraphs are short (a long intro becomes a context card, mirroring the existing mixed paragraph+list behavior)
- No images or tables anywhere in the section (any non-`<p>` sibling or `<p><img></p>` aborts fan-out — the section stays one lumped card, nothing dropped)

Card fronts reuse the existing positional cue (`Heading — i/N`). Sections below the thresholds, prose sections, and everything with the `bulletFanOut` flag off keep their current single-card shape byte-for-byte. Blast radius is docx uploads only — the chat attachment path calls the converter without the flag.

## Decisions made overnight (please review)

- Threshold: fan out at 4+ short paragraphs, ≤200 chars each, ≥80% short — pm said 4/200, designer said 5/120, engineer said 2/200; took the median count and the majority cap. Assumption: length gate protects 2–4-paragraph lecture notes (long prose never fans). If wrong, tune the three constants at the top of `preprocessDocxHTML.ts`.
- Card front: kept the existing `Heading — i/N` cue (pm + engineer) for consistency with the shipped bullet fan-out. Designer preferred a text-snippet front (first ~60 chars, no counter) as a better retrieval cue — deliberately NOT built here to avoid diverging the two fan-out paths; worth a follow-up issue if you agree with the designer.
- Mixed content: any image or table in the section aborts paragraph fan-out entirely (engineer's data-loss guard) instead of skipping the media element. Conservative by intent.
- Scope: did NOT touch the `overlappingCloze === 'off'` ↔ `bulletFanOut` coupling in `PrepareDeck.ts:118` (unanimous: separate question, flagged in the issue itself). No user-facing notice when fan-out doesn't trigger (designer: notices are for failures, not correct judgment calls).
- Metric (pm): DOCX-cohort deck usability → return/re-upload rate, read from `/api/ops/metrics`; silent-quality bug, won't show in conversion-success rates.

## Verification

- TDD: 10 new colocated tests written first and confirmed failing (collapse reproduced), then green — 32/32 in `preprocessDocxHTML.test.ts`, 117/117 across `fileConversion/`
- Server `tsc --noEmit` green, web typecheck green, `pnpm format:check` green
- Sonar not run locally (no SONAR_TOKEN on this box); Automatic Analysis covers the push

## Browser check

Browser check: not applicable — server-side DOCX preprocessor change; the only web/src file is a changelog JSON entry
