### PR TITLE
docs: add AI usage and cost concentration to the weekly retro

### DIFF
--- a/.claude/commands/weekly-retro.md
+++ b/.claude/commands/weekly-retro.md
@@ -51,6 +51,45 @@ GROUP BY 1, 2 ORDER BY 1, 2;
 
 Report one table: per origin, `upload_started → deck_downloaded → account_created → checkout_completed` plus upload→download and download→paid rates. Name the single biggest leak stage and the origin it hits hardest. Known gap (as of 2026-07-19): `signup_origin` is missing on `upload_started`/`checkout_completed` events, so the per-origin read is mostly `(none)` until that instrumentation fix lands — keep flagging it in the gaps section while true. If the read fails, record it under "Gaps to close before next retro" — do not skip silently.
 
+### 1b. Pull AI usage and cost concentration
+
+AI is the only per-use variable cost in the product — every other cost is flat. This read answers "how many people are actually using it, and how concentrated is the spend," so a rising Anthropic bill can be read as growth or as one heavy user before it becomes a decision. Same SSH+psql channel as section 1.
+
+```sql
+-- distinct users per AI surface, last 7 days
+SELECT 'ai_conversions' surface, count(*) uses, count(DISTINCT user_id) users
+  FROM events WHERE name='ai_conversion_completed' AND created_at >= now() - interval '7 days'
+UNION ALL SELECT 'photo_to_deck', count(*), count(DISTINCT user_id)
+  FROM events WHERE name='vision_photo_converted' AND created_at >= now() - interval '7 days'
+UNION ALL SELECT 'chat', count(*), count(DISTINCT c.user_id)
+  FROM chat_messages m JOIN conversations c ON c.id=m.conversation_id
+  WHERE m.created_at >= now() - interval '7 days'
+UNION ALL SELECT 'mindmaps', count(*), count(DISTINCT user_id)
+  FROM mindmaps WHERE created_at >= now() - interval '7 days'
+UNION ALL SELECT 'mcp_active_tokens', count(*), count(DISTINCT user_id)
+  FROM mcp_access_tokens WHERE expires_at > now();
+
+-- concentration: top AI users and their share
+SELECT user_id, count(*) conversions
+  FROM events WHERE name='ai_conversion_completed' AND created_at >= now() - interval '7 days'
+  GROUP BY 1 ORDER BY 2 DESC LIMIT 5;
+
+-- funnel above AI: badge seen → toggled on → converted
+SELECT name, count(DISTINCT user_id) users FROM events
+  WHERE name IN ('upload_ai_badge_viewed','upload_ai_turned_on','ai_conversion_completed')
+  AND created_at >= now() - interval '7 days' GROUP BY 1;
+```
+
+Report one table (surface / uses / distinct users) plus three derived numbers:
+
+- **Distinct AI users this week** as a share of active paying subs — the adoption read.
+- **Top-user share**: what fraction of AI conversions came from the single heaviest user. **Flag when one user exceeds 40%** — the bill is then one person's habits, not product growth, and a usage change by that one account will look like a trend.
+- **Cost per AI conversion** = Anthropic month-to-date cost ÷ month-to-date `ai_conversion_completed` count. Compare against the $7.99 monthly price to name the break-even conversions/month; flag any top user above it.
+
+The dollar figure is **not** in the DB — Alexander reads month-to-date total from the Anthropic console (Cost view, API key `2anki.net`). Ask for it once per retro; if it isn't supplied, report the usage table and concentration anyway and note the missing cost under "Gaps to close before next retro". Never guess or carry forward a stale dollar amount.
+
+Baseline (2026-07-27, 27-day window): $77.52 MTD · 126 AI conversions by 10 users · 37 distinct users across all AI surfaces (~5% of paying subs) · top user 49% of conversions · ~$0.60/conversion · MCP 0 active tokens.
+
 ## 2. Pull GA4 traffic + engagement (last 7 days vs prior 7 days)
 
 Use the `analytics-mcp` tools against GA4 property `properties/286902985`. Run these reports:
@@ -109,7 +148,7 @@ Any DB field, support theme, or GA4 check that was skipped this run goes here so
 - **Do not write retro output into the repo.** `Documentation/retros/` is retired (deleted 2026-07-19) — committed retro files published business metrics in a public repo. The retro's artifacts are the chat output and the CLAUDE.md baseline block; historical numbers are re-queried from prod DB when needed.
 - Two screens max.
 - Numbers in tables.
-- "Numbers" section (DB), "Funnel by origin" table (section 1a), and "Traffic Sources" section (GA4) all required.
+- "Numbers" section (DB), "Funnel by origin" table (section 1a), "AI usage" table (section 1b), and "Traffic Sources" section (GA4) all required.
 - Work-mix bucket shares and the treadmill flag are required output, even when nothing is flagged ("acquisition 40% — no flag").
 - Recommendation in one paragraph.
 - Do not list five things. The point of the retro is to force a single decision.


### PR DESCRIPTION
## Summary

The weekly retro reads users, funnel, traffic, and work-mix — but nothing about AI usage, which is the only per-use variable cost in the product. Today a rising Anthropic bill can't be distinguished from growth without a manual dig.

New section 1b pulls, on the same read-only SSH+psql channel as the rest of the retro:

- **Per-surface usage table** — AI conversions, photo-to-deck, chat, mindmaps, MCP active tokens: uses and distinct users.
- **Concentration flag** — top-user share of AI conversions, flagged above 40%, because at that point the bill tracks one person's habits rather than product growth.
- **Cost per conversion** vs the $7.99 price, so the break-even conversions/month is explicit and heavy users above it are named.
- **Funnel above AI** — badge viewed → toggled on → converted, which is where the adoption story lives.

The dollar figure stays a manual read from the Anthropic console (it isn't in the DB). The retro asks for it once and records a gap if it isn't supplied — explicitly never guessing or carrying a stale amount forward.

## Why now

Today's pull, prompted by the token-usage spike in the dashboard: **$77.52 month-to-date, 126 AI conversions by 10 users, 37 distinct users across all AI surfaces (~5% of 723 paying subs), one user at 49% of all AI conversions, ~$0.60/conversion, MCP 0 active tokens.** Spend is healthy in absolute terms (~1.3% of subscription revenue) but concentrated enough that one account moves the whole line — exactly the shape that should be visible weekly rather than rediscovered.

That snapshot is recorded in the section as a baseline so the next retro has something to compare against.

## Verification

`pnpm format:check` green. Docs-only change to `.claude/commands/weekly-retro.md`; every query in it was run against prod read-only today and returns the shapes described.

Browser check: not applicable — no source or web change, agent command documentation only.
