### PR TITLE
fix: expire password reset tokens and enforce single use

### DIFF
--- a/migrations/20261001000000_add_reset_token_expiry.js
+++ b/migrations/20261001000000_add_reset_token_expiry.js
@@ -1,0 +1,18 @@
+exports.up = async function (knex) {
+  await knex.schema.alterTable('users', (table) => {
+    table.timestamp('reset_token_expires_at', { useTz: true }).nullable();
+    table.timestamp('reset_token_used_at', { useTz: true }).nullable();
+  });
+
+  // Existing tokens were minted without an expiry and never invalidated on use,
+  // so every one of them is still redeemable. They cannot be given a valid
+  // window retroactively — clear them. Affected users request a new link.
+  await knex('users').whereNotNull('reset_token').update({ reset_token: null });
+};
+
+exports.down = async function (knex) {
+  await knex.schema.alterTable('users', (table) => {
+    table.dropColumn('reset_token_used_at');
+    table.dropColumn('reset_token_expires_at');
+  });
+};

--- a/src/controllers/StripeController/StripeController.test.ts
+++ b/src/controllers/StripeController/StripeController.test.ts
@@ -47,6 +47,8 @@ function buildUser(overrides: Partial<UserWithOwner> = {}): UserWithOwner {
     created_at: null,
     updated_at: null,
     reset_token: null,
+    reset_token_expires_at: null,
+    reset_token_used_at: null,
     patreon: false,
     ankify_access: false,
     developer_access: false,

--- a/src/controllers/UsersControllers.test.ts
+++ b/src/controllers/UsersControllers.test.ts
@@ -3636,3 +3636,85 @@ describe('UsersController.logOutEverywhere', () => {
     expect(logOutEverywhere).not.toHaveBeenCalled();
   });
 });
+
+describe('UsersController.newPassword', () => {
+  const buildNewPasswordController = (
+    overrides: {
+      getUserByLiveResetToken?: jest.Mock;
+      updatePassword?: jest.Mock;
+      logOutEverywhere?: jest.Mock;
+    } = {}
+  ) => {
+    const getUserByLiveResetToken =
+      overrides.getUserByLiveResetToken ??
+      jest.fn().mockResolvedValue({ id: 7 });
+    const updatePassword =
+      overrides.updatePassword ?? jest.fn().mockResolvedValue(1);
+    const logOutEverywhere =
+      overrides.logOutEverywhere ?? jest.fn().mockResolvedValue(1);
+    const userService = {
+      getUserByLiveResetToken,
+      updatePassword,
+    } as unknown as UsersService;
+    const authService = {
+      isNewPasswordValid: jest.fn().mockReturnValue(false),
+      getHashPassword: jest.fn().mockReturnValue('hashed'),
+      logOutEverywhere,
+    } as unknown as AuthenticationService;
+    const controller = new UsersController(
+      userService,
+      authService,
+      {} as ReturnType<typeof import('../data_layer').getDatabase>
+    );
+    return { controller, updatePassword, logOutEverywhere };
+  };
+
+  const buildReq = () =>
+    ({
+      body: { reset_token: 'a-token', password: 'longenoughpw' },
+      headers: {},
+      ip: '203.0.113.9',
+    }) as unknown as express.Request;
+
+  const buildRes = () =>
+    ({
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn().mockReturnThis(),
+    }) as unknown as express.Response;
+
+  it('revokes sessions only after the token is successfully redeemed', async () => {
+    const { controller, logOutEverywhere } = buildNewPasswordController();
+    const res = buildRes();
+
+    await controller.newPassword(buildReq(), res, jest.fn());
+
+    expect(logOutEverywhere).toHaveBeenCalledWith(7);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  // A stale token must not stay usable as a way to force the owner out.
+  it('never revokes sessions when the token no longer redeems', async () => {
+    const { controller, logOutEverywhere } = buildNewPasswordController({
+      getUserByLiveResetToken: jest.fn().mockResolvedValue(null),
+      updatePassword: jest.fn().mockResolvedValue(0),
+    });
+    const res = buildRes();
+
+    await controller.newPassword(buildReq(), res, jest.fn());
+
+    expect(logOutEverywhere).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('does not revoke when the row is gone even if a redeem is reported', async () => {
+    const { controller, logOutEverywhere } = buildNewPasswordController({
+      getUserByLiveResetToken: jest.fn().mockResolvedValue(null),
+    });
+    const res = buildRes();
+
+    await controller.newPassword(buildReq(), res, jest.fn());
+
+    expect(logOutEverywhere).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -97,7 +97,11 @@ class UsersController {
     }
 
     try {
-      await this.authService.revokeSessionsByResetToken(resetToken);
+      // Resolve the owner before redeeming, because redeeming clears the
+      // token. Sessions are revoked only after the redeem succeeds — doing it
+      // first would let a stale token log the owner out on every attempt even
+      // though the password change is refused.
+      const owner = await this.userService.getUserByLiveResetToken(resetToken);
       const updated = await this.userService.updatePassword(
         this.authService.getHashPassword(password),
         resetToken
@@ -105,9 +109,10 @@ class UsersController {
       // No row matched: the token is unknown, already used, or past its
       // window. Same response either way so the endpoint cannot be used to
       // probe which tokens exist.
-      if (updated === 0) {
+      if (updated === 0 || owner?.id == null) {
         return res.status(400).send({ message: 'invalid' });
       }
+      await this.authService.logOutEverywhere(owner.id);
       res.status(200).send({ message: 'ok' });
     } catch (error) {
       console.info('Update password failed');

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -1,5 +1,15 @@
 import crypto from 'node:crypto';
 import express from 'express';
+import { InMemoryRateLimiter } from '../lib/rateLimit/InMemoryRateLimiter';
+import { hashIp, resolveClientIp } from '../lib/rateLimit/ipHelpers';
+
+// The reset-redemption endpoint is unauthenticated by nature, so throttle
+// per-IP attempts to keep it from being usable for token guessing.
+const newPasswordRateLimiter = new InMemoryRateLimiter({
+  windowMs: 15 * 60 * 1000,
+  perKeyMax: 10,
+  globalMax: 500,
+});
 
 import AuthenticationService, {
   UserWithOwner,
@@ -82,12 +92,22 @@ class UsersController {
       return res.status(400).send({ message: 'invalid' });
     }
 
+    if (!newPasswordRateLimiter.check(hashIp(resolveClientIp(req)))) {
+      return res.status(429).send({ message: 'invalid' });
+    }
+
     try {
       await this.authService.revokeSessionsByResetToken(resetToken);
-      await this.userService.updatePassword(
+      const updated = await this.userService.updatePassword(
         this.authService.getHashPassword(password),
         resetToken
       );
+      // No row matched: the token is unknown, already used, or past its
+      // window. Same response either way so the endpoint cannot be used to
+      // probe which tokens exist.
+      if (updated === 0) {
+        return res.status(400).send({ message: 'invalid' });
+      }
       res.status(200).send({ message: 'ok' });
     } catch (error) {
       console.info('Update password failed');

--- a/src/data_layer/UsersRepository.resetToken.sql.test.ts
+++ b/src/data_layer/UsersRepository.resetToken.sql.test.ts
@@ -1,0 +1,42 @@
+import knex from 'knex';
+
+import UsersRepository from './UsersRepository';
+
+describe('UsersRepository reset-token generated SQL', () => {
+  const pg = knex({ client: 'pg' });
+  const repository = new UsersRepository(pg);
+
+  afterAll(async () => {
+    await pg.destroy();
+  });
+
+  it('only redeems a token that is unexpired and unused', () => {
+    const { sql } = repository
+      .buildUpdatePasswordQuery('hashed', 'raw-token')
+      .toSQL();
+
+    expect(sql).toContain('"reset_token" = ?');
+    expect(sql).toContain('"reset_token_expires_at" > ');
+    expect(sql).toContain('"reset_token_used_at" is null');
+  });
+
+  it('marks the token used and clears it when redeemed', () => {
+    const { sql } = repository
+      .buildUpdatePasswordQuery('hashed', 'raw-token')
+      .toSQL();
+
+    expect(sql).toContain('"password" = ?');
+    expect(sql).toContain('"reset_token" = ?');
+    expect(sql).toContain('"reset_token_used_at" =');
+  });
+
+  it('stamps an expiry when a reset token is issued', () => {
+    const expiresAt = new Date('2026-07-27T12:15:00.000Z');
+    const { sql, bindings } = repository
+      .buildUpdateResetTokenQuery('42', 'raw-token', expiresAt)
+      .toSQL();
+
+    expect(sql).toContain('"reset_token_expires_at" = ?');
+    expect(bindings).toContain(expiresAt);
+  });
+});

--- a/src/data_layer/UsersRepository.ts
+++ b/src/data_layer/UsersRepository.ts
@@ -7,6 +7,9 @@ import { startOfMonthUtc } from '../lib/User/startOfMonthUtc';
 import DeletedUserUsageRepository from './DeletedUserUsageRepository';
 import { emailHash } from '../lib/emailHash';
 
+// Matches the magic-link window in MagicTokenRepository.
+export const RESET_TOKEN_TTL_MS = 15 * 60 * 1000;
+
 export interface SignupCountryCount {
   country: string;
   count: number;
@@ -80,10 +83,24 @@ class UsersRepository {
       .increment('ai_template_modify_count', 1);
   }
 
-  updatePassword(hashPassword: string, reset_token: string) {
+  // A reset token is single-use and time-boxed, matching MagicTokenRepository:
+  // the same token must never redeem twice, and an abandoned link must stop
+  // working rather than staying valid indefinitely.
+  buildUpdatePasswordQuery(hashPassword: string, reset_token: string) {
     return this.database(this.table)
       .where({ reset_token })
-      .update({ password: hashPassword, reset_token: null });
+      .whereNotNull('reset_token_expires_at')
+      .where('reset_token_expires_at', '>', this.database.fn.now())
+      .whereNull('reset_token_used_at')
+      .update({
+        password: hashPassword,
+        reset_token: null,
+        reset_token_used_at: this.database.fn.now(),
+      });
+  }
+
+  updatePassword(hashPassword: string, reset_token: string) {
+    return this.buildUpdatePasswordQuery(hashPassword, reset_token);
   }
 
   getByResetToken(token: string) {
@@ -113,10 +130,20 @@ class UsersRepository {
       .update({ developer_access: value });
   }
 
-  updateResetToken(id: string, resetToken: string) {
-    return this.database(this.table)
-      .where({ id })
-      .update({ reset_token: resetToken });
+  buildUpdateResetTokenQuery(id: string, resetToken: string, expiresAt: Date) {
+    return this.database(this.table).where({ id }).update({
+      reset_token: resetToken,
+      reset_token_expires_at: expiresAt,
+      reset_token_used_at: null,
+    });
+  }
+
+  updateResetToken(
+    id: string,
+    resetToken: string,
+    expiresAt: Date = new Date(Date.now() + RESET_TOKEN_TTL_MS)
+  ) {
+    return this.buildUpdateResetTokenQuery(id, resetToken, expiresAt);
   }
 
   createUser(

--- a/src/data_layer/public/Users.ts
+++ b/src/data_layer/public/Users.ts
@@ -63,6 +63,10 @@ export default interface Users {
   language: string | null;
 
   developer_access: boolean;
+
+  reset_token_expires_at: Date | null;
+
+  reset_token_used_at: Date | null;
 }
 
 /** Represents the initializer for the table public.users */
@@ -138,6 +142,10 @@ export interface UsersInitializer {
 
   /** Default value: false */
   developer_access?: boolean;
+
+  reset_token_expires_at?: Date | null;
+
+  reset_token_used_at?: Date | null;
 }
 
 /** Represents the mutator for the table public.users */
@@ -199,4 +207,8 @@ export interface UsersMutator {
   language?: string | null;
 
   developer_access?: boolean;
+
+  reset_token_expires_at?: Date | null;
+
+  reset_token_used_at?: Date | null;
 }

--- a/src/lib/User/isResetTokenLive.test.ts
+++ b/src/lib/User/isResetTokenLive.test.ts
@@ -1,0 +1,63 @@
+import { isResetTokenLive } from './isResetTokenLive';
+
+const now = new Date('2026-07-27T12:00:00.000Z');
+
+describe('isResetTokenLive', () => {
+  it('is live while inside the window and unused', () => {
+    expect(
+      isResetTokenLive(
+        {
+          reset_token_expires_at: new Date('2026-07-27T12:10:00.000Z'),
+          reset_token_used_at: null,
+        },
+        now
+      )
+    ).toBe(true);
+  });
+
+  it('is not live once the window has passed', () => {
+    expect(
+      isResetTokenLive(
+        {
+          reset_token_expires_at: new Date('2026-07-27T11:59:59.000Z'),
+          reset_token_used_at: null,
+        },
+        now
+      )
+    ).toBe(false);
+  });
+
+  it('is not live once redeemed', () => {
+    expect(
+      isResetTokenLive(
+        {
+          reset_token_expires_at: new Date('2026-07-27T12:10:00.000Z'),
+          reset_token_used_at: new Date('2026-07-27T11:55:00.000Z'),
+        },
+        now
+      )
+    ).toBe(false);
+  });
+
+  // Rows written before the expiry column existed: treat as dead so the user
+  // is issued a fresh token instead of being emailed an unusable link.
+  it('is not live when the expiry is missing', () => {
+    expect(isResetTokenLive({ reset_token_expires_at: null }, now)).toBe(false);
+    expect(isResetTokenLive({}, now)).toBe(false);
+  });
+
+  it('accepts a timestamp string from the driver', () => {
+    expect(
+      isResetTokenLive(
+        { reset_token_expires_at: '2026-07-27T12:10:00.000Z' },
+        now
+      )
+    ).toBe(true);
+  });
+
+  it('is not live for an unparseable expiry', () => {
+    expect(isResetTokenLive({ reset_token_expires_at: 'nonsense' }, now)).toBe(
+      false
+    );
+  });
+});

--- a/src/lib/User/isResetTokenLive.ts
+++ b/src/lib/User/isResetTokenLive.ts
@@ -1,0 +1,26 @@
+interface ResetTokenFields {
+  reset_token_expires_at?: Date | string | null;
+  reset_token_used_at?: Date | string | null;
+}
+
+// A stored reset token is only reusable while it is unused and still inside
+// its window. Rows written before the expiry column existed have a null
+// expiry and are never live, so they get replaced rather than re-sent.
+export function isResetTokenLive(
+  user: ResetTokenFields,
+  now: Date = new Date()
+): boolean {
+  if (user.reset_token_used_at != null) {
+    return false;
+  }
+  const expiresAt = user.reset_token_expires_at;
+  if (expiresAt == null) {
+    return false;
+  }
+  const expiry =
+    expiresAt instanceof Date ? expiresAt : new Date(String(expiresAt));
+  if (Number.isNaN(expiry.getTime())) {
+    return false;
+  }
+  return expiry.getTime() > now.getTime();
+}

--- a/src/services/UsersService.test.ts
+++ b/src/services/UsersService.test.ts
@@ -122,6 +122,10 @@ describe('UsersService.sendResetEmail', () => {
       id: 1,
       email: 'al@example.com',
       reset_token: 'existing-token',
+      // Still inside its window, so it is reused rather than reminted and
+      // this test stays focused on the email send.
+      reset_token_expires_at: new Date(Date.now() + 10 * 60 * 1000),
+      reset_token_used_at: null,
     });
     const repository = { getByEmail } as unknown as UsersRepository;
     const service = new UsersService(repository, emailService);

--- a/src/services/UsersService.ts
+++ b/src/services/UsersService.ts
@@ -6,6 +6,7 @@ import AuthenticationService from './AuthenticationService';
 import { IEmailService } from './EmailService/EmailService';
 import type { IMagicTokenRepository } from '../data_layer/MagicTokenRepository';
 import hashToken from '../lib/misc/hashToken';
+import { isResetTokenLive } from '../lib/User/isResetTokenLive';
 
 const MAGIC_LINK_RATE_LIMIT = 5;
 const MAGIC_LINK_RATE_WINDOW_MS = 60 * 60 * 1000;
@@ -56,7 +57,11 @@ class UsersService {
     user: Users,
     authService: AuthenticationService
   ) {
-    if (user.reset_token) {
+    // Reuse the outstanding token only while it is still inside its window.
+    // A token that has expired (or predates the expiry column) must be
+    // replaced, otherwise the user would be emailed a link the redeeming
+    // query rejects and could never complete a reset.
+    if (user.reset_token && isResetTokenLive(user)) {
       return user.reset_token;
     }
     const resetToken = authService.newResetToken();

--- a/src/services/UsersService.ts
+++ b/src/services/UsersService.ts
@@ -69,6 +69,20 @@ class UsersService {
     return resetToken;
   }
 
+  // Resolves a reset token to its owner only while the token is still
+  // redeemable. getByResetToken alone ignores the window, so callers that use
+  // it for a privileged action would act on a token the redeem step refuses.
+  async getUserByLiveResetToken(token: string): Promise<Users | null> {
+    if (typeof token !== 'string' || token.length === 0) {
+      return null;
+    }
+    const user = await this.repository.getByResetToken(token);
+    if (!user || !isResetTokenLive(user)) {
+      return null;
+    }
+    return user;
+  }
+
   getUserFrom(email: string) {
     return this.repository.getByEmail(email);
   }

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-27-reset-link-expiry.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-27-reset-link-expiry.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-27-reset-link-expiry",
+  "date": "2026-07-27",
+  "type": "fix",
+  "title": "Password reset links expire after 15 minutes and can only be used once"
+}


### PR DESCRIPTION
Brings password reset tokens in line with magic links, which already handle this correctly.

## What changed

`users.reset_token` had no expiry, and the only thing that ever invalidated it was a successful password change. A reset link that was requested and never used stayed redeemable indefinitely.

`MagicTokenRepository` already solves this — `expires_at` plus `used_at`, both enforced in `findValidToken`. Reset tokens now follow the same shape:

- New `reset_token_expires_at` and `reset_token_used_at` columns; `pnpm kanel` regenerated in this PR.
- Tokens are minted with a 15 minute window, matching the magic-link TTL.
- The redeeming query filters on both the window and `used_at`, rather than trusting the token alone.
- Redemption stamps `used_at`, so the same token cannot redeem twice.
- No row matched now returns a failure instead of a silent success, and unknown, spent and expired tokens all return the same response so the endpoint cannot be used to distinguish them.
- The endpoint is unauthenticated by nature, so it is throttled per IP via the existing `InMemoryRateLimiter`.

## Migration note

The migration clears existing `reset_token` values. They were issued without a window and cannot be given one retroactively. **Any outstanding reset link stops working on deploy** and those users request a new one — the forgot-password flow is unchanged and works immediately.

## Verification

- 3 new SQL-shape tests in `UsersRepository.resetToken.sql.test.ts`, written first and confirmed failing for the right reason, asserting the redeeming query filters on window and `used_at`, stamps `used_at`, and that minting sets the expiry.
- Migration applied to a local Postgres; kanel regenerated against the live schema.
- Server `tsc --noEmit` green — includes fixing a `UserWithOwner` mock literal in `StripeController.test.ts` that the new columns would otherwise have broken at deploy build time.
- `pnpm format:check` green. Full server suite: 5,764 passed; the 8 failing suites are the documented worktree-environment failures (no Python venv → `PythonExitError` in parser/canary, no `pdfinfo` for `getPageCount`) and none touch this diff.
- Sonar not run locally (no SONAR_TOKEN on this box); Automatic Analysis covers the push.

Browser check: not applicable — server-side auth change, no web files touched.
