### PR TITLE
fix: verify checkout session ownership before linking a subscription

### DIFF
--- a/src/controllers/StripeController/StripeController.test.ts
+++ b/src/controllers/StripeController/StripeController.test.ts
@@ -97,13 +97,15 @@ type SessionCustomerDetails = NonNullable<
 >;
 
 function buildSession(
-  customerEmail: string | null
-): Pick<StripeTypes.Checkout.Session, 'customer_details'> {
+  customerEmail: string | null,
+  metadataUserId?: string
+): Pick<StripeTypes.Checkout.Session, 'customer_details' | 'metadata'> {
   return {
     customer_details:
       customerEmail == null
         ? null
         : ({ email: customerEmail } as SessionCustomerDetails),
+    metadata: metadataUserId == null ? null : { user_id: metadataUserId },
   };
 }
 
@@ -279,7 +281,7 @@ describe('StripeController', () => {
       authedUser(h, 'user@2anki.com');
       h.persistStripeSessionUseCase.execute.mockResolvedValue(true);
       h.stripe.checkout.sessions.retrieve.mockResolvedValue(
-        buildSession('paypal@email.com')
+        buildSession('paypal@email.com', '1')
       );
       h.usersService.updateSubScriptionEmailUsingPrimaryEmail.mockResolvedValue(
         1
@@ -303,7 +305,7 @@ describe('StripeController', () => {
       authedUser(h, 'user@2anki.com');
       h.persistStripeSessionUseCase.execute.mockResolvedValue(true);
       h.stripe.checkout.sessions.retrieve.mockResolvedValue(
-        buildSession('user@2anki.com')
+        buildSession('user@2anki.com', '1')
       );
 
       const req = mockRequest({ session_id: 'cs_test_123' });
@@ -314,6 +316,25 @@ describe('StripeController', () => {
       expect(
         h.usersService.updateSubScriptionEmailUsingPrimaryEmail
       ).not.toHaveBeenCalled();
+    });
+
+    it('does not link when the session does not belong to the logged-in user', async () => {
+      const h = buildController();
+      authedUser(h, 'attacker@2anki.com');
+      h.persistStripeSessionUseCase.execute.mockResolvedValue(true);
+      h.stripe.checkout.sessions.retrieve.mockResolvedValue(
+        buildSession('victim@email.com', '999')
+      );
+
+      const req = mockRequest({ session_id: 'cs_test_leaked' });
+      const res = mockResponse();
+
+      await h.controller.getSuccessfulCheckout(req, res);
+
+      expect(
+        h.usersService.updateSubScriptionEmailUsingPrimaryEmail
+      ).not.toHaveBeenCalled();
+      expect(h.persistStripeSessionUseCase.execute).not.toHaveBeenCalled();
     });
 
     it('serves the page without error when no token present', async () => {

--- a/src/controllers/StripeController/StripeController.test.ts
+++ b/src/controllers/StripeController/StripeController.test.ts
@@ -337,6 +337,24 @@ describe('StripeController', () => {
       expect(h.persistStripeSessionUseCase.execute).not.toHaveBeenCalled();
     });
 
+    it('does not link when the session was never paid for', async () => {
+      const h = buildController();
+      authedUser(h, 'user@2anki.com');
+      h.persistStripeSessionUseCase.execute.mockResolvedValue(false);
+      h.stripe.checkout.sessions.retrieve.mockResolvedValue(
+        buildSession('paypal@email.com', '1')
+      );
+
+      const req = mockRequest({ session_id: 'cs_test_unpaid' });
+      const res = mockResponse();
+
+      await h.controller.getSuccessfulCheckout(req, res);
+
+      expect(
+        h.usersService.updateSubScriptionEmailUsingPrimaryEmail
+      ).not.toHaveBeenCalled();
+    });
+
     it('serves the page without error when no token present', async () => {
       const h = buildController();
       mockedExtractToken.mockReturnValue(null);

--- a/src/controllers/StripeController/StripeController.ts
+++ b/src/controllers/StripeController/StripeController.ts
@@ -37,11 +37,13 @@ export class StripeController {
       if (this.sessionBelongsToUser(session, loggedInUser)) {
         // Persist subscription before linking — without this, the link write is a
         // no-op when the webhook hasn't fired yet and the subscriptions row doesn't exist.
-        await this.persistStripeSessionUseCase.execute(sessionId);
+        // A false result means the session was never paid for, so there is nothing
+        // to link and the email on it should not be attached to this account.
+        const paid = await this.persistStripeSessionUseCase.execute(sessionId);
 
         const email = session.customer_details?.email;
 
-        if (loggedInUser.email !== email && email) {
+        if (paid && email && loggedInUser.email !== email) {
           await this.usersService.updateSubScriptionEmailUsingPrimaryEmail(
             email.toLowerCase(),
             loggedInUser.email.toLowerCase()

--- a/src/controllers/StripeController/StripeController.ts
+++ b/src/controllers/StripeController/StripeController.ts
@@ -32,22 +32,32 @@ export class StripeController {
     const sessionId = req.query.session_id as string;
 
     if (loggedInUser && sessionId) {
-      // Persist subscription before linking — without this, the link write is a
-      // no-op when the webhook hasn't fired yet and the subscriptions row doesn't exist.
-      await this.persistStripeSessionUseCase.execute(sessionId);
-
       const session = await this.stripe.checkout.sessions.retrieve(sessionId);
-      const email = session.customer_details?.email;
 
-      if (loggedInUser.email !== email && email) {
-        await this.usersService.updateSubScriptionEmailUsingPrimaryEmail(
-          email.toLowerCase(),
-          loggedInUser.email.toLowerCase()
-        );
+      if (this.sessionBelongsToUser(session, loggedInUser)) {
+        // Persist subscription before linking — without this, the link write is a
+        // no-op when the webhook hasn't fired yet and the subscriptions row doesn't exist.
+        await this.persistStripeSessionUseCase.execute(sessionId);
+
+        const email = session.customer_details?.email;
+
+        if (loggedInUser.email !== email && email) {
+          await this.usersService.updateSubScriptionEmailUsingPrimaryEmail(
+            email.toLowerCase(),
+            loggedInUser.email.toLowerCase()
+          );
+        }
       }
     }
 
     sendIndex(res);
+  }
+
+  private sessionBelongsToUser(
+    session: Pick<StripeTypes.Checkout.Session, 'metadata'>,
+    loggedInUser: { id: number }
+  ): boolean {
+    return session.metadata?.user_id === String(loggedInUser.id);
   }
 
   async checkSubscriptionStatus(req: express.Request, res: express.Response) {

--- a/web/src/components/PassLadderCard/PassLadderCard.i18n.test.tsx
+++ b/web/src/components/PassLadderCard/PassLadderCard.i18n.test.tsx
@@ -21,12 +21,7 @@ describe('PassLadderCard in German', () => {
   });
 
   it('translates the headline and keeps the Unlimited price in the CTA', () => {
-    render(
-      <PassLadderCard
-        offerOverride={{ passCount: 3, spentUsd: 12 }}
-        emailOverride="learner@example.com"
-      />
-    );
+    render(<PassLadderCard offerOverride={{ passCount: 3, spentUsd: 12 }} />);
     expect(
       screen.getByText('Gibst du mehr für Pässe aus, als Unlimited kostet?')
     ).toBeInTheDocument();
@@ -36,12 +31,7 @@ describe('PassLadderCard in German', () => {
   });
 
   it('pluralises the pass count body', () => {
-    render(
-      <PassLadderCard
-        offerOverride={{ passCount: 1, spentUsd: 4 }}
-        emailOverride="learner@example.com"
-      />
-    );
+    render(<PassLadderCard offerOverride={{ passCount: 1, spentUsd: 4 }} />);
     expect(screen.getByText(/Du hast 1 Pass gekauft/i)).toBeInTheDocument();
   });
 });

--- a/web/src/components/PassLadderCard/PassLadderCard.test.tsx
+++ b/web/src/components/PassLadderCard/PassLadderCard.test.tsx
@@ -15,6 +15,13 @@ vi.mock('../../lib/analytics/track', () => ({
   track: (...args: unknown[]) => mockTrack(...args),
 }));
 
+const mockStartUnlimitedUpgrade = vi.fn();
+
+vi.mock('../../lib/backend/startUnlimitedUpgrade', () => ({
+  startUnlimitedUpgrade: (...args: unknown[]) =>
+    mockStartUnlimitedUpgrade(...args),
+}));
+
 const repeatBuyer = {
   data: {
     locals: { patreon: false, subscriber: true },
@@ -54,21 +61,21 @@ describe('PassLadderCard', () => {
     });
   });
 
-  it('links to the subscribe flow and tracks the upgrade click', () => {
+  it('starts the checkout through the API and tracks the upgrade click', () => {
     mockUseUserLocals.mockReturnValue(repeatBuyer);
     render(<PassLadderCard />);
 
     const cta = screen.getByRole('link', { name: 'Get Unlimited — $7.99/mo' });
-    expect(cta).toHaveAttribute(
-      'href',
-      expect.stringContaining('prefilled_email=buyer%40example.com')
-    );
+    expect(cta).toHaveAttribute('href', '/pricing?source=pass_ladder_success');
 
     fireEvent.click(cta);
     expect(mockTrack).toHaveBeenCalledWith('paywall_upgrade_clicked', {
       surface: 'pass_ladder_success',
       plan: 'unlimited',
     });
+    expect(mockStartUnlimitedUpgrade).toHaveBeenCalledWith(
+      'pass_ladder_success'
+    );
   });
 
   it('renders nothing when the server sends no offer', () => {

--- a/web/src/components/PassLadderCard/PassLadderCard.tsx
+++ b/web/src/components/PassLadderCard/PassLadderCard.tsx
@@ -1,22 +1,19 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, type MouseEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { track } from '../../lib/analytics/track';
 import { useUserLocals } from '../../lib/hooks/useUserLocals';
-import { getSubscribeLink } from '../../pages/PricingPage/payment.links';
+import { startUnlimitedUpgrade } from '../../lib/backend/startUnlimitedUpgrade';
 import styles from './PassLadderCard.module.css';
 
 const SURFACE = 'pass_ladder_success';
+const PRICING_HREF = `/pricing?source=${SURFACE}`;
 
 interface PassLadderCardProps {
   readonly offerOverride?: { passCount: number; spentUsd: number };
-  readonly emailOverride?: string;
 }
 
-export function PassLadderCard({
-  offerOverride,
-  emailOverride,
-}: PassLadderCardProps = {}) {
+export function PassLadderCard({ offerOverride }: PassLadderCardProps = {}) {
   const { t } = useTranslation('marketing');
   const { data } = useUserLocals();
   const shownFiredRef = useRef(false);
@@ -35,8 +32,10 @@ export function PassLadderCard({
 
   if (offer == null) return null;
 
-  const handleUnlimitedClick = () => {
+  const handleUnlimitedClick = async (event: MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
     track('paywall_upgrade_clicked', { surface: SURFACE, plan: 'unlimited' });
+    await startUnlimitedUpgrade(SURFACE);
   };
 
   return (
@@ -50,7 +49,7 @@ export function PassLadderCard({
       </p>
       <a
         className={styles.cta}
-        href={getSubscribeLink(emailOverride ?? data?.user?.email)}
+        href={PRICING_HREF}
         onClick={handleUnlimitedClick}
       >
         {t('passLadder.cta')}

--- a/web/src/lib/backend/startUnlimitedUpgrade.test.ts
+++ b/web/src/lib/backend/startUnlimitedUpgrade.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const startUnlimitedCheckout = vi.fn();
+
+vi.mock('./get2ankiApi', () => ({
+  get2ankiApi: () => ({ startUnlimitedCheckout }),
+}));
+
+import { startUnlimitedUpgrade } from './startUnlimitedUpgrade';
+
+function stubLocation() {
+  const location = { href: '' };
+  vi.stubGlobal('location', location);
+  return location;
+}
+
+describe('startUnlimitedUpgrade', () => {
+  beforeEach(() => {
+    startUnlimitedCheckout.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it('creates the session through the API so it carries the buyer identity', async () => {
+    startUnlimitedCheckout.mockResolvedValue({ url: 'https://stripe/session' });
+    const location = stubLocation();
+
+    await startUnlimitedUpgrade('limit-wall');
+
+    expect(startUnlimitedCheckout).toHaveBeenCalledWith(
+      'month',
+      undefined,
+      'limit-wall'
+    );
+    expect(location.href).toBe('https://stripe/session');
+  });
+
+  it('falls back to the pricing page when the session cannot be created', async () => {
+    startUnlimitedCheckout.mockResolvedValue({ status: 'error' });
+    const location = stubLocation();
+
+    await startUnlimitedUpgrade('limit-wall');
+
+    expect(location.href).toBe('/pricing?source=limit-wall');
+  });
+
+  it('encodes the surface it was given', async () => {
+    startUnlimitedCheckout.mockResolvedValue({ status: 'unavailable' });
+    const location = stubLocation();
+
+    await startUnlimitedUpgrade('downloads limit');
+
+    expect(location.href).toBe('/pricing?source=downloads%20limit');
+  });
+});
+
+function collectSourceFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(full));
+      continue;
+    }
+    if (/\.(ts|tsx)$/.test(entry.name)) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+describe('static Stripe payment links', () => {
+  it('are not referenced anywhere in the web app', () => {
+    const offenders = collectSourceFiles(join(process.cwd(), 'src')).filter(
+      (file) =>
+        readFileSync(file, 'utf8').includes('buy.stripe.com') &&
+        !file.endsWith('startUnlimitedUpgrade.test.ts')
+    );
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/web/src/lib/backend/startUnlimitedUpgrade.ts
+++ b/web/src/lib/backend/startUnlimitedUpgrade.ts
@@ -1,0 +1,13 @@
+import { get2ankiApi } from './get2ankiApi';
+
+export async function startUnlimitedUpgrade(surface: string): Promise<void> {
+  const result = await get2ankiApi().startUnlimitedCheckout(
+    'month',
+    undefined,
+    surface
+  );
+  globalThis.location.href =
+    'url' in result
+      ? result.url
+      : `/pricing?source=${encodeURIComponent(surface)}`;
+}

--- a/web/src/pages/DownloadsPage/DownloadsPage.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.tsx
@@ -271,8 +271,7 @@ function isNotionTokenExpired(
 function renderFailurePanelContent(
   source: DeckRow['source'],
   reason: string,
-  onMapColumns: () => void,
-  email?: string
+  onMapColumns: () => void
 ): ReactNode {
   const monthlyLimit = parseMonthlyLimitPayload(reason);
   if (monthlyLimit != null) {
@@ -283,7 +282,6 @@ function renderFailurePanelContent(
         limit={monthlyLimit.limit}
         cardsUsed={monthlyLimit.cards_used}
         resetOn={monthlyLimit.reset_on}
-        email={email}
       />
     );
   }
@@ -841,8 +839,7 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                       {renderFailurePanelContent(
                                         row.source,
                                         row.job.job_reason_failure,
-                                        () => setMappingModalJob(row.job),
-                                        data?.user?.email ?? undefined
+                                        () => setMappingModalJob(row.job)
                                       )}
                                     </td>
                                   </tr>

--- a/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.test.tsx
+++ b/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.test.tsx
@@ -18,6 +18,12 @@ vi.mock('../../../../lib/backend/get2ankiApi', () => ({
   get2ankiApi: () => ({ startPassCheckout: mockStartPassCheckout }),
 }));
 
+const mockStartUnlimitedUpgrade = vi.fn();
+vi.mock('../../../../lib/backend/startUnlimitedUpgrade', () => ({
+  startUnlimitedUpgrade: (...args: unknown[]) =>
+    mockStartUnlimitedUpgrade(...args),
+}));
+
 vi.mock('../../hooks/useJobs', () => ({ default: vi.fn() }));
 
 describe('parseMonthlyLimitPayload', () => {
@@ -69,7 +75,6 @@ describe('ConversionResult — paywalled variant', () => {
           resetOn={
             'resetOn' in props ? props.resetOn : '2026-07-01T00:00:00.000Z'
           }
-          email="user@example.com"
         />
       </MemoryRouter>
     );

--- a/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.tsx
+++ b/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.tsx
@@ -9,11 +9,9 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { classifyUploadError } from '../../../../components/errors/helpers/getErrorMessage';
 import { parseAmbiguousColumnsPayload } from '../../../../lib/fieldMapping/types';
-import {
-  getSubscribeLink,
-  PASS_PRICES,
-} from '../../../PricingPage/payment.links';
+import { PASS_PRICES } from '../../../PricingPage/payment.links';
 import { get2ankiApi } from '../../../../lib/backend/get2ankiApi';
+import { startUnlimitedUpgrade } from '../../../../lib/backend/startUnlimitedUpgrade';
 import { track } from '../../../../lib/analytics/track';
 import { formatResetDate } from './formatResetDate';
 import type { UploadErrorBody } from '../../../../types/UploadErrorBody';
@@ -21,6 +19,7 @@ import sharedStyles from '../../../../styles/shared.module.css';
 import styles from './ConversionResult.module.css';
 
 const PAYWALL_SURFACE = 'downloads-limit';
+const UNLIMITED_PRICING_HREF = `/pricing?source=${PAYWALL_SURFACE}`;
 
 type Source = 'notion' | 'upload' | 'dropbox' | 'drive';
 
@@ -39,7 +38,6 @@ interface PaywalledProps {
   limit: number;
   cardsUsed: number;
   resetOn?: string;
-  email?: string;
 }
 
 interface FailedProps {
@@ -65,12 +63,10 @@ function PaywalledVariant({
   limit,
   cardsUsed,
   resetOn,
-  email,
 }: Omit<PaywalledProps, 'variant' | 'title'>) {
   const { t } = useTranslation();
   const shownFiredRef = useRef(false);
   const [pendingKind, setPendingKind] = useState<'24h' | '7d' | null>(null);
-  const upgradeHref = getSubscribeLink(email);
   const resetDate = formatResetDate(resetOn);
 
   useEffect(() => {
@@ -97,15 +93,16 @@ function PaywalledVariant({
     setPendingKind(null);
   };
 
-  const handleUnlimitedClick = (event: MouseEvent<HTMLAnchorElement>) => {
+  const handleUnlimitedClick = async (event: MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
     if (pendingKind != null) {
-      event.preventDefault();
       return;
     }
     track('paywall_upgrade_clicked', {
       surface: PAYWALL_SURFACE,
       plan: 'unlimited',
     });
+    await startUnlimitedUpgrade(PAYWALL_SURFACE);
   };
 
   return (
@@ -146,7 +143,7 @@ function PaywalledVariant({
               })}
         </button>
         <a
-          href={upgradeHref}
+          href={UNLIMITED_PRICING_HREF}
           className={styles.seeAllPlans}
           onClick={handleUnlimitedClick}
           aria-disabled={pendingKind != null}
@@ -261,7 +258,6 @@ export function ConversionResult(props: Readonly<ConversionResultProps>) {
         limit={props.limit}
         cardsUsed={props.cardsUsed}
         resetOn={props.resetOn}
-        email={props.email}
       />
     );
   }

--- a/web/src/pages/LimitPage/LimitPage.test.tsx
+++ b/web/src/pages/LimitPage/LimitPage.test.tsx
@@ -22,6 +22,13 @@ vi.mock('../../lib/hooks/useUserLocals', () => ({
   useUserLocals: vi.fn(),
 }));
 
+const mockStartUnlimitedUpgrade = vi.fn();
+
+vi.mock('../../lib/backend/startUnlimitedUpgrade', () => ({
+  startUnlimitedUpgrade: (...args: unknown[]) =>
+    mockStartUnlimitedUpgrade(...args),
+}));
+
 const mockedUseUserLocals = vi.mocked(useUserLocals);
 
 function asLoggedIn() {
@@ -96,11 +103,13 @@ describe('LimitPage', () => {
     expect(backLink.closest('a')?.getAttribute('href')).toBe('/upload');
   });
 
-  it('Unlimited plan link carries ref=limit-wall parameter', () => {
+  it('starts the Unlimited checkout through the API, not a static link', () => {
     renderPage();
     const upgradeLink = screen.getByText('Upgrade to Unlimited');
-    const href = upgradeLink.getAttribute('href') ?? '';
-    expect(href).toContain('ref=limit-wall');
+    expect(upgradeLink.getAttribute('href')).toBe('/pricing?source=limit-wall');
+
+    fireEvent.click(upgradeLink);
+    expect(mockStartUnlimitedUpgrade).toHaveBeenCalledWith('limit-wall');
   });
 
   it('features the Day Pass as the primary unblock', () => {

--- a/web/src/pages/LimitPage/LimitPage.tsx
+++ b/web/src/pages/LimitPage/LimitPage.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type MouseEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
 import { track } from '../../lib/analytics/track';
 import { get2ankiApi } from '../../lib/backend/get2ankiApi';
-import { getSubscribeLink } from '../PricingPage/payment.links';
+import { startUnlimitedUpgrade } from '../../lib/backend/startUnlimitedUpgrade';
 import { PassCards } from '../PricingPage/components/PassCards';
 import { useUserLocals } from '../../lib/hooks/useUserLocals';
 import styles from './LimitPage.module.css';
@@ -75,7 +75,6 @@ function AnonymousLimit() {
 export function LimitPage() {
   const { t } = useTranslation('accountx');
   const { data: userLocals, isLoading } = useUserLocals();
-  const email = userLocals?.user?.email;
   const isLoggedIn = userLocals?.user?.id != null;
   const [dayPassPending, setDayPassPending] = useState(false);
   const [weekPassPending, setWeekPassPending] = useState(false);
@@ -129,8 +128,17 @@ export function LimitPage() {
   };
 
   const unlimitedLink = isLoggedIn
-    ? `${getSubscribeLink(email)}&ref=${REF}`
+    ? `/pricing?source=${REF}`
     : `/login?redirect=/pricing&ref=${REF}`;
+
+  const handleUnlimitedClick = async (event: MouseEvent<HTMLAnchorElement>) => {
+    track('paywall_upgrade_clicked', { surface: REF, plan: 'unlimited' });
+    if (!isLoggedIn) {
+      return;
+    }
+    event.preventDefault();
+    await startUnlimitedUpgrade(REF);
+  };
 
   return (
     <div className={styles.page}>
@@ -176,12 +184,7 @@ export function LimitPage() {
           <a
             href={unlimitedLink}
             className={styles.planCtaSecondary}
-            onClick={() =>
-              track('paywall_upgrade_clicked', {
-                surface: REF,
-                plan: 'unlimited',
-              })
-            }
+            onClick={handleUnlimitedClick}
           >
             {t('limit.upgradeToUnlimited')}
           </a>

--- a/web/src/pages/PricingPage/payment.links.ts
+++ b/web/src/pages/PricingPage/payment.links.ts
@@ -3,13 +3,5 @@ export const PASS_PRICES = {
   '7d': '$9',
 } as const;
 
-export const getSubscribeLink = (email?: string) => {
-  const base =
-    process.env.NODE_ENV === 'development'
-      ? 'https://buy.stripe.com/test_fZebM83k00Rj6PeeUU'
-      : 'https://buy.stripe.com/8x27sK9aV44W4rG3ek3Je08';
-  return email ? `${base}?prefilled_email=${encodeURIComponent(email)}` : base;
-};
-
 export const getLifetimeLink = () =>
   'mailto:support@2anki.net?subject=Lifetime%20Access%20for%202anki.net&body=Hello,%20I%20would%20like%20to%20purchase%20a%20lifetime%20access%20for%202anki.net.';

--- a/web/src/pages/UploadSuccessPreviewPage/UploadSuccessPreviewPage.tsx
+++ b/web/src/pages/UploadSuccessPreviewPage/UploadSuccessPreviewPage.tsx
@@ -40,10 +40,7 @@ export default function UploadSuccessPreviewPage() {
           <CreateAccountNotice />
         </Variant>
         <Variant title="Repeat pass buyer — pass ladder">
-          <PassLadderCard
-            offerOverride={{ passCount: 3, spentUsd: 13 }}
-            emailOverride="preview@example.com"
-          />
+          <PassLadderCard offerOverride={{ passCount: 3, spentUsd: 13 }} />
         </Variant>
         <Variant title="Logged-in free — pass upsell">
           <UpsellCard surface="upload_success_upsell" />

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-27-upgrade-checkout-linking.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-27-upgrade-checkout-linking.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-27-upgrade-checkout-linking",
+  "date": "2026-07-27",
+  "type": "fix",
+  "title": "Upgrading to Unlimited from the limit wall or downloads page links the subscription to your account"
+}


### PR DESCRIPTION
## What

Closes `GHSA-rg93-7f5r-364f`. `/successful-checkout` linked whatever email was on the Stripe session named by `?session_id=` to whoever was logged in, with no check that the two were the same person. Anyone holding another user's session id could attach that user's subscription email to their own account.

The gate is now `session.metadata.user_id === String(loggedInUser.id)`, and nothing is persisted or linked before it passes.

Making that gate safe required a second change. Three upgrade CTAs pointed at a static Stripe payment link whose sessions carry no metadata at all, so the gate alone would have turned those purchases from working into silently unlinked. They now create sessions through the API instead.

## Why the second half was necessary

I read the payment link's own completed sessions off Stripe rather than guessing at its configuration:

- It redirects to `https://2anki.net/successful-checkout?session_id={CHECKOUT_SESSION_ID}` — the exact route this gate guards.
- Its sessions carry `metadata: {}`. The gate rejects every one of them.
- It sells `price_1TTTHLB4lekI0uHmwmUo3LeA` at **$6.00/month** — the pre-v2 price — while the button next to it advertises $7.99/mo. It bypassed the cohort resolution in `UnlimitedCheckoutUseCase` entirely, so anyone clicking it locked in the legacy rate permanently.
- Across 600 sessions (8 Jun – 27 Jul) it produced 108, the last on **22 June**. Nothing since. But it stayed wired into `LimitPage`, `ConversionResult`, and `PassLadderCard`, so it was one click from being used again.

Merging the gate without this would have been a regression, not an incomplete fix.

## How

- `sessionBelongsToUser()` compares the session's `metadata.user_id` against the authenticated user's id. `persistStripeSessionUseCase` and the email link both moved inside it.
- The link is additionally gated on the persist result, which is already `false` for an unpaid session. Not exploitable today — every session the app creates forces `customer_email` to the caller's own address — but that safety was incidental, and a future flow stamping `user_id` while leaving the email to Stripe Checkout would reopen it.
- `startUnlimitedUpgrade(surface)` calls the existing `POST /api/checkout/unlimited`, which stamps the buyer id into session metadata server-side and resolves the price through the v2 cohort logic. Interval stays monthly, matching what the link charged.
- Each anchor keeps a real `href` to `/pricing`, so the error fallback, middle-click, and open-in-new-tab still land somewhere useful; the click handler takes over when it can.
- `getSubscribeLink` is deleted, along with the `email` / `emailOverride` props that existed only to prefill it.

## Measuring success

No new checkout session can reach `/successful-checkout` without an identifying `user_id`. The `checkout/unlimited` sessions already carry `surface`, so upgrade conversions from these three surfaces become attributable for the first time — previously they were invisible, indistinguishable from direct pricing-page traffic.

## Testing

- Server: a session belonging to another user is refused, and an unpaid session is refused. Both written failing first. `StripeController` suite 10/10; `tsc -p . --noEmit` clean.
- Web: `startUnlimitedUpgrade` unit tests cover the API call, the pricing-page fallback, and surface encoding. The three CTA tests now assert the API call rather than a static href. Full web suite 350 files / 2747 tests green; `typecheck` and tree-wide `format:check` clean.
- A guard test asserts `buy.stripe.com` appears nowhere under `web/src`, so the link cannot be reintroduced.
- Security review run against the full diff: no bypass of the gate, `user_id` confirmed server-controlled at all four session-creation sites, no open redirect through `surface`. The unpaid-session hardening above came out of that review.

## Risks

**A payment link removed from the UI is not a deactivated payment link.** `plink_1TTTI0B4lekI0uHmQXCGmFy7` still resolves for anyone holding the URL from a bookmark, a shared message, or an old email — and a purchase through it still charges $6/mo and still produces a session this gate refuses to link. **It needs to be archived in the Stripe dashboard.** The guard test only covers this repo, so a reference living in the iOS repo or in marketing email would have the same problem.

A legacy payment-link checkout still in flight across the deploy will not auto-link. Zero such sessions in five weeks, so this is close to theoretical, but it is a real window.

`checkSubscriptionStatus` still passes an unvalidated `session_id` to the persist use case. The review traced it and found no privilege gain — the write is keyed by the Stripe customer's own email and entitlement is read from the session user — so it is out of scope here rather than overlooked.

## Goal alignment

Revenue correctness, on two counts: subscriptions can no longer be claimed by the wrong account, and the upgrade path stops selling a price we retired in June.

## Browser check

Browser check: not applicable — no browser pass was run, and merging on test evidence is a deliberate call by the maintainer rather than an unnoticed gap.

What stands in for it: the three CTA tests assert the click calls the API session helper instead of a static href, a guard test proves `buy.stripe.com` survives nowhere under `web/src`, and the click path is an exact mirror of the already-shipped `PaywallBanner` upgrade flow. Full web suite green (350 files / 2747 tests).

Worth a manual pass on the three CTAs (limit wall, downloads paywall, pass-ladder card) after deploy — each should open a Stripe checkout rather than navigate to buy.stripe.com.

