### PR TITLE
fix: compute the monthly PDF limit boundary consistently

### DIFF
--- a/src/data_layer/UsersRepository.test.ts
+++ b/src/data_layer/UsersRepository.test.ts
@@ -1,6 +1,8 @@
 import Knex from 'knex';
 import KnexConfig from '../KnexConfig';
 import UsersRepository from './UsersRepository';
+import { isNewMonth } from '../lib/User/isNewMonth';
+import { startOfMonthUtc } from '../lib/User/startOfMonthUtc';
 
 function buildKnexMock() {
   const updateSpy = jest.fn().mockResolvedValue(1);
@@ -368,6 +370,31 @@ describe('UsersRepository.countSignupsSince', () => {
     expect(whereSpy).toHaveBeenCalledWith('created_at', '>=', since);
     expect(countSpy).toHaveBeenCalledWith('* as count');
     expect(count).toBe(42);
+  });
+});
+
+describe('UsersRepository.incrementPrintUsage', () => {
+  const pg = Knex({ client: 'pg' });
+
+  afterAll(() => pg.destroy());
+
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('stamps the month boundary in UTC so getPrintUsage counts the print in the same month', () => {
+    jest.setSystemTime(new Date('2026-07-15T12:00:00.000Z'));
+    const repo = new UsersRepository(pg as any);
+
+    const { bindings } = repo.incrementPrintUsage(1).toSQL();
+    const stampedBoundary = bindings.find(
+      (binding): binding is Date => binding instanceof Date
+    );
+
+    expect(stampedBoundary).toBeInstanceOf(Date);
+    expect((stampedBoundary as Date).toISOString()).toBe(
+      startOfMonthUtc(new Date()).toISOString()
+    );
+    expect(isNewMonth(stampedBoundary as Date, new Date())).toBe(false);
   });
 });
 

--- a/src/data_layer/UsersRepository.ts
+++ b/src/data_layer/UsersRepository.ts
@@ -456,14 +456,17 @@ class UsersRepository {
   }
 
   incrementPrintUsage(id: string | number) {
+    const monthStart = startOfMonthUtc(new Date());
     return this.database(this.table)
       .where({ id })
       .update({
         pdf_prints_this_month: this.database.raw(
-          `CASE WHEN prints_month_started_at < date_trunc('month', NOW()) THEN 1 ELSE pdf_prints_this_month + 1 END`
+          `CASE WHEN prints_month_started_at < ? THEN 1 ELSE pdf_prints_this_month + 1 END`,
+          [monthStart]
         ),
         prints_month_started_at: this.database.raw(
-          `CASE WHEN prints_month_started_at < date_trunc('month', NOW()) THEN date_trunc('month', NOW()) ELSE prints_month_started_at END`
+          `CASE WHEN prints_month_started_at < ? THEN ? ELSE prints_month_started_at END`,
+          [monthStart, monthStart]
         ),
       });
   }


### PR DESCRIPTION
## What
`incrementPrintUsage` stamped `prints_month_started_at` with `date_trunc('month', NOW())`, which Postgres evaluates in the DB session timezone, while the read path (`getPrintUsage` → `isNewMonth`) computes the month boundary in UTC. This binds `startOfMonthUtc(new Date())` as a parameter on the write path so both paths use one timezone, mirroring the already-consistent `incrementCardUsage` twin.

## Why
The monthly PDF print limit's read and write paths computed the month boundary in different timezones. Near a month boundary the value the write path stamped could be read by the gate as belonging to a different month, so the counter did not reliably agree with itself. Aligning both paths on UTC makes the stored stamp and the gate that reads it consistent. No public issue — internal correctness fix filed privately.

## How
`incrementPrintUsage` now computes `monthStart = startOfMonthUtc(new Date())` and binds it into the two `CASE` expressions as a parameter, exactly as `incrementCardUsage` already does. The read path (`getPrintUsage`, `isNewMonth`) was already UTC and is unchanged. Scope was checked against the other counter and flows: the card counter uses separate columns and was already UTC on both sides; `DeletedUserUsageRepository`'s `date_trunc('month', …)` is symmetric on both comparison operands (a separate tombstone-restore flow, not a live gate) and is left untouched. `isNewMonth` and `startOfMonthUtc` are unchanged, so no other caller shifts.

## Measuring success
After deploy, prints stamp `prints_month_started_at` at the UTC start of month (`YYYY-MM-01T00:00:00Z`), not the session-timezone boundary (e.g. the prior day at `22:00Z`). Confirm with a read-only prod query on `users`: for rows touched after the deploy, `prints_month_started_at` sits at `00:00:00+00` on the 1st, and `getPrintUsage` returns the stored `pdf_prints_this_month` for the current UTC month rather than resetting it to 0.

## Testing
- Unit test added: `UsersRepository.incrementPrintUsage › stamps the month boundary in UTC so getPrintUsage counts the print in the same month`. Builds the query with a pg-dialect knex (no connection) under `jest.useFakeTimers()` / `setSystemTime`, asserts the stamped boundary parameter equals `startOfMonthUtc(now)`, and that `isNewMonth` reads that stamp as the current month (not a new one). Verified it fails against the pre-fix code (no Date parameter bound) for the right reason.
- Full `UsersRepository.test.ts` suite green; `CheckMonthlyPrintLimitUseCase`, `CheckMonthlyCardLimitUseCase`, and `src/lib/User/*` date-helper suites green.

## Browser check
Browser check: not applicable — server-only change, no `web/src/` files touched.

Sonar: not run locally (no Docker / no `SONAR_TOKEN` on this box, and the sonarqube MCP is not connected); Automatic Analysis covers the push. The change removes an inline SQL string in favor of parameterized bindings and adds no new complexity.

## Changelog
No entry — internal correctness fix, no user-visible behavior change.

## Risks
Minimal. The write path now binds the same UTC boundary the read path already used and the card counter already uses. Stamps written under the old behavior read correctly again on the next print (which re-stamps in UTC). The card counter and the deleted-user tombstone flow are untouched. Rollback: revert the single-method change.

## Goal alignment
Correctness on the free-tier PDF limit, which underpins the paid-conversion boundary. No funnel metric targeted — internal correctness fix.



no changelog entry — internal correctness fix. The monthly PDF limit value is unchanged; this only makes the read and write paths agree on where the month boundary falls, restoring the limit that was always intended.
