### PR TITLE
fix: spare subscribers holding a stale cancelled subscription row

### DIFF
--- a/src/lib/storage/jobs/helpers/deleteNonSubScriberUploadsInDatabase.test.ts
+++ b/src/lib/storage/jobs/helpers/deleteNonSubScriberUploadsInDatabase.test.ts
@@ -261,6 +261,74 @@ describe('deleteNonSubScriberUploadsInDatabase — cleanup-vs-subscriber e2e', (
     expect(await remainingUploadKeys()).toEqual(['sub.apkg']);
   });
 
+  it('spares a subscriber who also holds a stale cancelled subscription row', async () => {
+    await seedUserWithUpload(1, 'dual@example.com', false, 'dual.apkg');
+    await db('subscriptions').insert({
+      email: 'dual@example.com',
+      active: false,
+    });
+    await db('subscriptions').insert({
+      email: 'billing@example.com',
+      linked_email: 'dual@example.com',
+      active: true,
+    });
+
+    const storage = { delete: jest.fn() };
+
+    await deleteNonSubScriberUploadsInDatabase(
+      withPgRawShape(db),
+      storage as never
+    );
+
+    expect(storage.delete).not.toHaveBeenCalled();
+    expect(await remainingUploadKeys()).toEqual(['dual.apkg']);
+  });
+
+  it('spares an active subscriber whose account email differs in case', async () => {
+    await seedUserWithUpload(1, 'Mixed.Case@Example.com', false, 'mixed.apkg');
+    await db('subscriptions').insert({
+      email: 'mixed.case@example.com',
+      active: true,
+    });
+
+    const storage = { delete: jest.fn() };
+
+    await deleteNonSubScriberUploadsInDatabase(
+      withPgRawShape(db),
+      storage as never
+    );
+
+    expect(storage.delete).not.toHaveBeenCalled();
+    expect(await remainingUploadKeys()).toEqual(['mixed.apkg']);
+  });
+
+  it('sweeps a non-subscriber only once when several cancelled rows match', async () => {
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+
+    await seedUserWithUpload(1, 'lapsed@example.com', false, 'lapsed.apkg');
+    await db('subscriptions').insert({
+      email: 'lapsed@example.com',
+      active: false,
+    });
+    await db('subscriptions').insert({
+      email: 'old-billing@example.com',
+      linked_email: 'lapsed@example.com',
+      active: false,
+    });
+
+    const storage = { delete: jest.fn() };
+
+    await deleteNonSubScriberUploadsInDatabase(
+      withPgRawShape(db),
+      storage as never
+    );
+
+    expect(storage.delete).toHaveBeenCalledTimes(1);
+    expect(await remainingUploadKeys()).toEqual([]);
+
+    infoSpy.mockRestore();
+  });
+
   it('raises a deletion-volume alarm when a run sweeps an anomalous fraction of the uploads table', async () => {
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});

--- a/src/lib/storage/jobs/helpers/deleteNonSubScriberUploadsInDatabase.ts
+++ b/src/lib/storage/jobs/helpers/deleteNonSubScriberUploadsInDatabase.ts
@@ -15,12 +15,25 @@ export const deleteNonSubScriberUploadsInDatabase = async (
   storage: StorageHandler,
   errorEvents: IErrorEventRepository = new ErrorEventRepository(db)
 ) => {
+  // Scoped to the user, not to a joined row: subscriptions has separate unique
+  // indexes on email and linked_email, so one person legitimately holds both a
+  // stale cancelled row and their current live one. A join-row predicate matches
+  // the cancelled row and sweeps a paying subscriber's decks. Lowercasing both
+  // sides matches AuthenticationService.getIsSubscriber, which is what the rest
+  // of the product uses to decide the same question.
   const query = await db.raw(`
     SELECT up.key
     FROM users u
     JOIN uploads up ON u.id = up.owner
-    LEFT JOIN subscriptions s ON u.email = s.email OR u.email = s.linked_email
-    WHERE u.patreon = false AND (s.active IS NULL OR s.active = false)
+    WHERE u.patreon = false
+      AND NOT EXISTS (
+        SELECT 1 FROM subscriptions s
+        WHERE s.active = true
+          AND (
+            lower(u.email) = lower(s.email)
+            OR lower(u.email) = lower(s.linked_email)
+          )
+      )
       AND NOT EXISTS (
         SELECT 1 FROM user_passes pass
         WHERE pass.user_id = u.id AND pass.expires_at > now()


### PR DESCRIPTION
## What

The nightly upload cleanup no longer deletes the decks of a paying subscriber who also holds a stale cancelled subscription row.

## Why

`deleteNonSubScriberUploadsInDatabase` filtered on the **joined row** rather than on the user:

```sql
LEFT JOIN subscriptions s ON u.email = s.email OR u.email = s.linked_email
WHERE u.patreon = false AND (s.active IS NULL OR s.active = false)
```

`subscriptions` carries separate unique indexes on `email` and `linked_email`, so one person legitimately matches two rows — a stale cancelled one and their current live one. The cancelled row satisfies the predicate, so **every upload key that user owns is emitted for hard deletion** (S3 object + `uploads` row). The join was also case-sensitive, while `subscriptions.email` is always stored lowercased.

Six production accounts were in that state at the time of the report. All of them currently have zero `uploads` rows, so no deck has actually been destroyed — but the next deck any of them converted would have been swept on the following nightly run. `AuthenticationService.getIsSubscriber` lowercases and prefers the active row, so the whole product considers these people paid while this one job classified them as free.

Fixes https://github.com/2anki/server/issues/3861

## How

Replaced the join-row predicate with a user-scoped `NOT EXISTS`, mirroring the `user_passes` and `deck_shares` guards already in the same statement, and lowercasing both sides to match `getIsSubscriber`:

```sql
WHERE u.patreon = false
  AND NOT EXISTS (
    SELECT 1 FROM subscriptions s
    WHERE s.active = true
      AND (lower(u.email) = lower(s.email) OR lower(u.email) = lower(s.linked_email))
  )
```

Dropping the `LEFT JOIN` also removes the row multiplication it caused: a user with two matching subscription rows previously emitted each upload key twice, so the sweep attempted the same delete twice.

## Testing

The existing e2e block runs the **real** raw query against a real database. It seeded at most one subscription row per user, which is exactly why this gap was invisible. Three cases added, each verified failing for the right reason before the fix:

- active subscriber who also holds a cancelled row → spared (was: deleted)
- active subscriber whose account email differs in case → spared (was: deleted)
- genuine non-subscriber with two cancelled rows → swept exactly once (was: twice)

`pnpm test src/lib/storage` — 16 suites, 151 tests green. `tsc -p . --noEmit` clean. `pnpm format:check` clean. SonarQube MCP on the changed file: 0 issues.

## Measuring success

The job logs `Deleting non-subscriber upload <key>` per sweep. The six named account IDs should never appear in that line again. The existing `assessDeletionVolume` alarm still guards the aggregate.

## Risks

Low, and one-directional: the change only ever **spares** more uploads than before. A user who is genuinely non-paying is unaffected — the first e2e case still sweeps the free, expired-pass, and cancelled-only users exactly as it did.

Noted but deliberately not changed: the sibling email jobs (`InactivityEmailRepository`, `PriceLockInEmailRepository`, `PassWinbackRepository`) already use the correct `whereNotExists … active = true` shape, but compare emails case-sensitively. Worst case there is a marketing email to a mixed-case subscriber — not data loss, and out of scope for this fix.

No changelog entry — the defect never destroyed a real deck (all six affected accounts had zero uploads), so there is no user-visible change to describe. An entry would tell users their decks had been disappearing when none did.

Browser check: not applicable — no `web/src` files in the diff.

## Goal alignment

Directly protects revenue: the accounts at risk are paying subscribers, and silently deleting a paying user's decks is the single fastest route to a cancellation. Retention is the stated lever.
