### PR TITLE
fix: match the lifetime allowlist on price or product ID

### DIFF
--- a/src/env.example
+++ b/src/env.example
@@ -48,7 +48,9 @@ PASS_7D_PRICE_ID=''
 # lookup_key (v2_monthly / v2_annual) and already exist in Stripe.
 UNLIMITED_MONTHLY_PRICE_ID=''
 UNLIMITED_YEARLY_PRICE_ID=''
-# Comma-separated Stripe product IDs that qualify for Lifetime access (patreon=true). Amount must also meet the threshold.
+# Comma-separated Stripe price IDs (price_...) or product IDs (prod_...) that qualify for
+# Lifetime access (patreon=true). Either shape matches; a product ID covers every price
+# under it, including retired ones. Amount must also meet the threshold.
 LIFETIME_PRICE_IDS=''
 APPLE_TEAM_ID=''
 APPLE_CLIENT_ID=''

--- a/src/routes/WebhookRouter.test.ts
+++ b/src/routes/WebhookRouter.test.ts
@@ -659,6 +659,85 @@ describe('WebhookRouter — lifetime product-ID allowlist', () => {
     expect(mockUpdatePatreonByEmail).not.toHaveBeenCalled();
   });
 
+  it('grants lifetime access when the allowlist holds the price ID rather than the product ID', async () => {
+    process.env.LIFETIME_PRICE_IDS = 'price_lifetime_abc';
+    mockSessionsRetrieve.mockResolvedValue({
+      id: 'cs_lifetime_test',
+      line_items: {
+        data: [
+          { price: { id: 'price_lifetime_abc', product: LIFETIME_PRODUCT_ID } },
+        ],
+      },
+    });
+    mockWebhookEvent = makeLifetimeEvent(LIFETIME_PRODUCT_ID);
+
+    const res = await postWebhookLifetime();
+    expect(res.status).toBe(200);
+    expect(mockUpdatePatreonByEmail).toHaveBeenCalledWith(
+      'user@example.com',
+      true
+    );
+  });
+
+  it('reports an unmatched high-value checkout instead of skipping it silently', async () => {
+    mockSessionsRetrieve.mockResolvedValue({
+      id: 'cs_lifetime_test',
+      line_items: {
+        data: [{ price: { id: 'price_other', product: 'prod_other' } }],
+      },
+    });
+    mockWebhookEvent = makeLifetimeEvent('prod_other');
+
+    const res = await postWebhookLifetime();
+    expect(res.status).toBe(200);
+    expect(mockUpdatePatreonByEmail).not.toHaveBeenCalled();
+    expect(mockRecordError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        surface: 'stripe_provisioning',
+        code: 'unmatched_high_value_payment',
+      })
+    );
+  });
+
+  it('reports an unmatched high-value checkout even when the allowlist is unset', async () => {
+    delete process.env.LIFETIME_PRICE_IDS;
+    mockSessionsRetrieve.mockResolvedValue({
+      id: 'cs_lifetime_test',
+      line_items: {
+        data: [
+          { price: { id: 'price_lifetime_abc', product: LIFETIME_PRODUCT_ID } },
+        ],
+      },
+    });
+    mockWebhookEvent = makeLifetimeEvent(LIFETIME_PRODUCT_ID);
+
+    const res = await postWebhookLifetime();
+    expect(res.status).toBe(200);
+    expect(mockUpdatePatreonByEmail).not.toHaveBeenCalled();
+    expect(mockRecordError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        surface: 'stripe_provisioning',
+        code: 'unmatched_high_value_payment',
+      })
+    );
+  });
+
+  it('does not report an unmatched payment when the grant succeeds', async () => {
+    mockSessionsRetrieve.mockResolvedValue({
+      id: 'cs_lifetime_test',
+      line_items: {
+        data: [
+          { price: { id: 'price_lifetime_abc', product: LIFETIME_PRODUCT_ID } },
+        ],
+      },
+    });
+    mockWebhookEvent = makeLifetimeEvent(LIFETIME_PRODUCT_ID);
+
+    const res = await postWebhookLifetime();
+    expect(res.status).toBe(200);
+    expect(mockRecordError).not.toHaveBeenCalled();
+  });
+
   it('supports multiple comma-separated product IDs in LIFETIME_PRICE_IDS', async () => {
     process.env.LIFETIME_PRICE_IDS = `prod_other,${LIFETIME_PRODUCT_ID},prod_another`;
     mockSessionsRetrieve.mockResolvedValue({

--- a/src/routes/WebhookRouter.ts
+++ b/src/routes/WebhookRouter.ts
@@ -438,17 +438,26 @@ const WebhooksRouter = () => {
             .map((s) => s.trim())
             .filter((s) => s.length > 0);
 
-          if (amount >= LIFE_TIME_PRICE && lifetimePriceIds.length > 0) {
+          if (amount >= LIFE_TIME_PRICE) {
             try {
               const expandedSession = await stripe.checkout.sessions.retrieve(
                 session.id,
                 { expand: ['line_items'] }
               );
-              const sessionProductId =
-                expandedSession.line_items?.data?.[0]?.price?.product;
-              const isAllowlistedProduct =
-                typeof sessionProductId === 'string' &&
-                lifetimePriceIds.includes(sessionProductId);
+              const sessionPrice =
+                expandedSession.line_items?.data?.[0]?.price ?? null;
+              // price.product is a prod_ string because the price is not
+              // expanded, but the allowlist is configured with the price ID.
+              // Comparing against only one shape means a correct configuration
+              // in the other shape never matches and the buyer stays on a free
+              // account, so match either.
+              const sessionPriceIds = [
+                sessionPrice?.id,
+                sessionPrice?.product,
+              ].filter((value): value is string => typeof value === 'string');
+              const isAllowlistedProduct = sessionPriceIds.some((value) =>
+                lifetimePriceIds.includes(value)
+              );
 
               if (isAllowlistedProduct) {
                 const lifeTimeCustomer = await stripe.customers.retrieve(
@@ -490,8 +499,21 @@ const WebhooksRouter = () => {
                   }
                 }
               } else {
-                console.info(
-                  `[webhook] checkout.session.completed: session ${session.id} amount=${amount} but product=${String(sessionProductId)} not in LIFETIME_PRICE_IDS; skipping lifetime grant`
+                // A payment this large that grants nothing is the failure the
+                // lifetime alarm exists for, so it reports from here rather
+                // than from inside the branch that only runs on a match.
+                await recordErrorUseCase.execute({
+                  userId: null,
+                  surface: 'stripe_provisioning',
+                  code: 'unmatched_high_value_payment',
+                  context: {
+                    amount_total: amount,
+                    session_price_ids: sessionPriceIds,
+                    allowlist_configured: lifetimePriceIds.length > 0,
+                  },
+                });
+                console.error(
+                  `[webhook] checkout.session.completed: session ${session.id} amount=${amount} matched no entry in LIFETIME_PRICE_IDS (candidates=${sessionPriceIds.join('|')}); no lifetime grant`
                 );
               }
             } catch (error) {


### PR DESCRIPTION
## What

The checkout webhook can now actually grant lifetime access. It compares the session's price against `LIFETIME_PRICE_IDS` in either shape — price ID or product ID — and reports any high-value checkout it could not match.

## Why

The handler read `line_items[0].price.product`, which is a `prod_…` string because `price` is not expanded, and tested it against `LIFETIME_PRICE_IDS`. Production configures that variable with a **price** ID. A `price_` string can never equal a `prod_` string, so the branch always logged `skipping lifetime grant` and returned 200.

`users.updatePatreonByEmail` is the only automated lifetime grant in the codebase, and its sole non-test call site sits inside that branch. The next lifetime purchase — $345, sold through the support mailto flow — would have left the buyer on a free account.

Worse, the `unlinked_lifetime_payment` alarm, the one alert built for "money arrived, no upgrade", was nested *inside* the unreachable branch. Nothing anywhere signalled the failure.

The existing unit tests passed because they seed `LIFETIME_PRICE_IDS` with a `prod_` value, so the fixture agreed with the code and disagreed with production.

Fixes https://github.com/2anki/server/issues/3863

## How

- Collect both `price.id` and `price.product` and match either against the allowlist. Production's current value works as configured — **no environment change is required to ship this**. A `prod_` entry still matches every price beneath it, including the retired $105 one, so either configuration style stays valid.
- Hoist the alarm out of the matched branch. An unmatched high-value checkout now records `unmatched_high_value_payment` on the `stripe_provisioning` surface with the amount, the candidate IDs, and whether an allowlist was configured at all.
- Drop `lifetimePriceIds.length > 0` from the amount gate, so a missing configuration reports instead of returning silently. The grant itself stays fail-closed: with no allowlist, nothing matches and no access is granted.
- `src/env.example` said "product IDs"; it now documents both shapes.

## Testing

Four cases added to the existing `WebhookRouter — lifetime product-ID allowlist` block, each verified failing for the right reason first:

- allowlist holds the price ID (production's real shape) → grants (was: silently skipped)
- unmatched high-value checkout → records `unmatched_high_value_payment` (was: `console.info` and nothing else)
- allowlist unset → still reports (was: returned before any check)
- successful grant → records no error

`pnpm test src/routes/WebhookRouter.test.ts` — 36 tests green. `tsc -p . --noEmit` clean. `oxfmt --check src` clean.

SonarQube MCP on `WebhookRouter.ts`: 5 findings, all pre-existing and none on a changed line (S3776 anchors to the handler declaration at :108, four S6836 case-block declarations at :192–:275; the diff starts at :438).

`/security-review` run on the branch — **no HIGH or MEDIUM findings**. It confirmed both candidate IDs originate from the secret-key-authenticated `stripe.checkout.sessions.retrieve` call rather than the signature-verified webhook body, that removing the length guard changes no privilege decision, and that the new error context (`amount_total`, `session_price_ids`, `allowlist_configured`) carries no PII or secrets.

## Measuring success

The next lifetime purchase should log `unlocked lifetime access for email=… (1 row(s) updated)` and set `users.patreon = true`. Any high-value checkout that still grants nothing now shows up as `unmatched_high_value_payment` in `/api/ops/performance/metrics`, which is the signal that was missing entirely.

## Risks

Low. The match widens, so a session that granted before still grants. The only new behaviour on the negative path is one Stripe `sessions.retrieve` call and one error-event row per checkout ≥ $96 that isn't a lifetime purchase. Over-reporting on a "money arrived" path is the right failure direction.

Noted, pre-existing, deliberately untouched: the success path at `WebhookRouter.ts:497` logs a raw customer email, which conflicts with the no-PII-logging rule in `.claude/rules/security.md`. It is three lines from this change but not part of it; the new logging avoids email entirely. Worth a separate `fix:`.

No changelog entry — the defect was latent. No charge above the threshold has existed since the gate shipped on 2026-05-18, so no user ever lost access and there is nothing user-visible to report.

Browser check: not applicable — no `web/src` files in the diff.

## Goal alignment

Straight revenue. This is the highest-value single transaction the product sells, and it was silently failing to deliver. Lifetime buyers reach checkout through a support conversation, so the failure would also have cost a support round-trip and probably a refund.
