### PR TITLE
fix: let a user who claimed a pass be deleted

### DIFF
--- a/migrations/20261002000000_pass_claim_user_delete_fk.js
+++ b/migrations/20261002000000_pass_claim_user_delete_fk.js
@@ -1,0 +1,59 @@
+// The pass-claim columns shipped with the default NO ACTION delete rule while
+// every other FK into users is CASCADE or SET NULL, so deleting a user who had
+// merely been issued a claim link raised 23503 and rolled the whole transaction
+// back. Both constraints have to change: dropping only one still fails on the
+// other.
+exports.up = async (knex) => {
+  await knex.schema.table('pass_claim_tokens', (table) => {
+    table.dropForeign(['user_id']);
+    table
+      .foreign('user_id')
+      .references('id')
+      .inTable('users')
+      .onDelete('CASCADE');
+  });
+
+  // The pass was paid for and outlives the account. Nulling the column is what
+  // AnonymousPassRepository.unclaim already does to return a pass to the pool.
+  await knex.schema.table('anonymous_passes', (table) => {
+    table.dropForeign(['claimed_by_user_id']);
+    table
+      .foreign('claimed_by_user_id')
+      .references('id')
+      .inTable('users')
+      .onDelete('SET NULL');
+  });
+
+  // Without an index on the referencing column Postgres seq-scans the child
+  // table for every row removed from users, which the bulk inactive-user sweep
+  // pays repeatedly.
+  await knex.raw(
+    'CREATE INDEX IF NOT EXISTS pass_claim_tokens_user_id_index ON pass_claim_tokens (user_id)'
+  );
+  await knex.raw(
+    'CREATE INDEX IF NOT EXISTS anonymous_passes_claimed_by_user_id_index ON anonymous_passes (claimed_by_user_id)'
+  );
+};
+
+exports.down = async (knex) => {
+  await knex.raw('DROP INDEX IF EXISTS anonymous_passes_claimed_by_user_id_index');
+  await knex.raw('DROP INDEX IF EXISTS pass_claim_tokens_user_id_index');
+
+  await knex.schema.table('anonymous_passes', (table) => {
+    table.dropForeign(['claimed_by_user_id']);
+    table
+      .foreign('claimed_by_user_id')
+      .references('id')
+      .inTable('users')
+      .onDelete('NO ACTION');
+  });
+
+  await knex.schema.table('pass_claim_tokens', (table) => {
+    table.dropForeign(['user_id']);
+    table
+      .foreign('user_id')
+      .references('id')
+      .inTable('users')
+      .onDelete('NO ACTION');
+  });
+};

--- a/src/data_layer/UsersRepository.test.ts
+++ b/src/data_layer/UsersRepository.test.ts
@@ -489,5 +489,44 @@ const RUN_INTEGRATION = process.env.DATABASE_URL != null;
 
       expect(favorite).toBeUndefined();
     });
+
+    // A claim token is written before the claim is confirmed, so merely being
+    // issued a claim link made the account permanently undeletable.
+    it('deletes a user who has claimed an anonymous pass, releasing the pass', async () => {
+      const repo = new UsersRepository(db);
+      const passRows = await db('anonymous_passes')
+        .insert({
+          stripe_session_id: `cs_claim_${userId}`,
+          kind: '7d',
+          expires_at: new Date(Date.now() + 86_400_000),
+          payment_intent_id: `pi_claim_${userId}`,
+          claimed_by_user_id: userId,
+        })
+        .returning('id');
+      const passId = passRows[0].id;
+      await db('pass_claim_tokens').insert({
+        user_id: userId,
+        anonymous_pass_id: passId,
+        token_hash: `claim-tok-${userId}`,
+        expires_at: new Date(Date.now() + 3_600_000),
+      });
+
+      try {
+        await repo.deleteUser(String(userId));
+
+        expect(await db('users').where({ id: userId }).first()).toBeUndefined();
+        expect(
+          await db('pass_claim_tokens').where({ user_id: userId }).first()
+        ).toBeUndefined();
+
+        // The pass outlives the user — it was paid for and may be re-claimed.
+        const pass = await db('anonymous_passes').where({ id: passId }).first();
+        expect(pass).toBeDefined();
+        expect(pass.claimed_by_user_id).toBeNull();
+      } finally {
+        await db('pass_claim_tokens').where({ user_id: userId }).del();
+        await db('anonymous_passes').where({ id: passId }).del();
+      }
+    });
   }
 );


### PR DESCRIPTION
## What

Deleting an account no longer fails for a user who has claimed — or merely been issued a claim link for — an anonymous pass.

## Why

`migrations/20260930000000_add_pass_claim_columns.js` (#3855) added `anonymous_passes.claimed_by_user_id` and `pass_claim_tokens.user_id` without a delete action, so both default to `NO ACTION`. Every other live foreign key into `users` is `CASCADE` or `SET NULL`.

`UsersRepository.deleteUser` clears ten owner-scoped tables explicitly and relies on the delete action for everything else, so `DELETE FROM users` raised `23503`, the transaction rolled back, and `UsersControllers.deleteAccount` returned `500 {"message":"Failed to delete account"}` — **after** it had already run `cancelUserSubscriptions(…, 'immediate', true)` and revoked the Apple token. No retry could ever succeed. `DeleteInactiveUsersUseCase` swallowed the error and skipped those accounts silently, forever.

`ClaimPassUseCase` inserts the token row *before* the claim is confirmed, so being issued a claim link was enough to make an account permanently undeletable. One production user is in that state today.

This is the third migration of its class — `20260612000000` and `20260911000000` exist solely to backfill missing delete actions.

Fixes https://github.com/2anki/server/issues/3866

## How

One migration, both constraints (changing one still fails on the other):

- `pass_claim_tokens.user_id` → `ON DELETE CASCADE`. A token whose user is gone is unclaimable; `ConfirmPassClaimUseCase` checks `tokenRow.user_id === userId`.
- `anonymous_passes.claimed_by_user_id` → `ON DELETE SET NULL`. The pass was paid for and outlives the account. Nulling that column is exactly what `AnonymousPassRepository.unclaim` already does, and `findUnclaimedByBuyerEmailHash` / `findActive` both filter on it being null — so the pass correctly returns to the pool for the same buyer to re-claim.
- An index on each referencing column. Without one Postgres seq-scans the child table for every row removed from `users`, which the bulk inactive-user sweep pays repeatedly. Plain (non-`CONCURRENTLY`) is correct here: both tables are new and small, and `CONCURRENTLY` cannot run inside knex's transaction.

`down` restores `NO ACTION` on both and drops both indexes, reproducing the exact pre-migration schema.

## Testing

Extended the existing `DATABASE_URL`-gated integration block in `UsersRepository.test.ts`, which runs against real Postgres rather than a mock. The new case seeds a claimed `anonymous_passes` row plus a `pass_claim_tokens` row, deletes the user, and asserts the token is gone, the pass row survives, and `claimed_by_user_id` is null.

Verified failing first with the exact production error:

```
error: delete from "users" where "id" = $1 - update or delete on table "users"
violates foreign key constraint "anonymous_passes_claimed_by_user_id_foreign"
on table "anonymous_passes"
```

Migration applied to a local Postgres, then `pnpm test src/data_layer/UsersRepository.test.ts` — 21 passed. `tsc -p . --noEmit` and `oxfmt --check src` clean.

**kanel:** run against the migrated local schema. A delete-action change plus two indexes is not represented in Kanel's output, so the diff correctly carries zero `src/data_layer/public/` changes. The only regenerated file that differed was an unrelated formatter line-wrap in `SubscriptionRecoveryNotifications.ts`, reverted per the repo rule on unrelated regeneration noise.

**`migration-reviewer` verdict: ship it.** Its findings, in brief:

- `DROP CONSTRAINT` takes `ACCESS EXCLUSIVE` on the child table only, metadata-only. `ADD CONSTRAINT … FOREIGN KEY` takes `SHARE ROW EXCLUSIVE` on both the child table **and** `users` — it blocks writes to `users`, not reads — and knex has no `NOT VALID` option, so the validation scan runs under that lock. The scan is over `pass_claim_tokens` (days old, rate-limited to 12/user/hr) and `anonymous_passes` (low hundreds of rows), so it is single-digit milliseconds. Same pattern as the two shipped precedents.
- It independently confirmed the "last live gap" claim by grepping every `.inTable('users')` in `migrations/`: the only other bare FKs belong to `favorites` (already recreated as CASCADE by `20260911000000`) and `trial_ended_emails` (table dropped entirely).
- It corrected a naming error in my first draft — the compensating method is `unclaim`, not `releaseClaim`. Fixed in the migration comment and commit body.

## Measuring success

The affected production user can delete their account and receive a 200. `DeleteInactiveUsersUseCase` stops silently skipping them, so the inactive sweep's deletion count should tick up by the small number of accounts currently wedged.

## Risks

Low. Pure DDL, no data written in either direction. The brief write-lock on `users` is the only production-visible effect and is milliseconds at these table sizes. The one inherent caveat of any FK bug-fix migration: running `down` in production after further pass-claim activity would reopen the original `23503`.

Out of scope, noted by the reviewer for a follow-up: `pass_claim_tokens.anonymous_pass_id` still has no index — the same seq-scan concern on the other FK of the same table. It shipped in #3855 and is not part of this diff.

No changelog entry — an account-deletion 500 that one user could hit. The fix is invisible to everyone else, and an entry would tell the whole user base that account deletion had been broken.

Browser check: not applicable — no `web/src` files in the diff.

## Goal alignment

Deleting your account has to work; a 500 that no retry can clear is the worst version of that failure, and it fires after the subscription has already been cancelled. Internal-facing, but it also unblocks the inactive-user sweep that keeps the registered-user count honest.
