### PR TITLE
fix: run an overdue re-engagement tick at startup

### DIFF
--- a/src/lib/reengagement/jobs/scheduleReEngagementEmails.test.ts
+++ b/src/lib/reengagement/jobs/scheduleReEngagementEmails.test.ts
@@ -28,7 +28,7 @@ describe('scheduleReEngagementEmails', () => {
 
   it('fires sendReEngagementEmails after one interval', async () => {
     const sink = makeSink();
-    const handle = scheduleReEngagementEmails(
+    const handle = await scheduleReEngagementEmails(
       mockRepo,
       mockEmailService,
       sink as unknown as EventsSink,
@@ -42,9 +42,9 @@ describe('scheduleReEngagementEmails', () => {
     clearInterval(handle);
   });
 
-  it('does not fire before the interval elapses', () => {
+  it('does not fire before the interval elapses', async () => {
     const sink = makeSink();
-    const handle = scheduleReEngagementEmails(
+    const handle = await scheduleReEngagementEmails(
       mockRepo,
       mockEmailService,
       sink as unknown as EventsSink,
@@ -60,7 +60,7 @@ describe('scheduleReEngagementEmails', () => {
   it('emits email_batch_sent with campaign=reengagement and the returned count', async () => {
     (sendReEngagementEmails as jest.Mock).mockResolvedValueOnce({ count: 7 });
     const sink = makeSink();
-    const handle = scheduleReEngagementEmails(
+    const handle = await scheduleReEngagementEmails(
       mockRepo,
       mockEmailService,
       sink as unknown as EventsSink,
@@ -82,7 +82,7 @@ describe('scheduleReEngagementEmails', () => {
       new Error('db down')
     );
     const sink = makeSink();
-    const handle = scheduleReEngagementEmails(
+    const handle = await scheduleReEngagementEmails(
       mockRepo,
       mockEmailService,
       sink as unknown as EventsSink,
@@ -98,5 +98,67 @@ describe('scheduleReEngagementEmails', () => {
 
   it('uses RE_ENGAGEMENT_INTERVAL_MS as the default interval', () => {
     expect(RE_ENGAGEMENT_INTERVAL_MS).toBe(24 * 60 * 60 * 1000);
+  });
+
+  // Blue-green redeploys reset the interval before it can elapse, so without a
+  // startup catch-up the tick rarely runs. Eligibility here is a fixed 24-hour
+  // band, so a user missed on their day never becomes eligible again.
+  it('runs an overdue tick at startup when the last run is older than the interval', async () => {
+    const sink = makeSink();
+    const lastRunAt = jest.fn().mockResolvedValue(new Date(Date.now() - 2000));
+
+    const handle = await scheduleReEngagementEmails(
+      mockRepo,
+      mockEmailService,
+      sink as unknown as EventsSink,
+      { intervalMs: 1000, lastRunAt }
+    );
+
+    expect(sendReEngagementEmails).toHaveBeenCalledTimes(1);
+    clearInterval(handle);
+  });
+
+  it('runs an overdue tick at startup when the job has never run', async () => {
+    const sink = makeSink();
+    const lastRunAt = jest.fn().mockResolvedValue(null);
+
+    const handle = await scheduleReEngagementEmails(
+      mockRepo,
+      mockEmailService,
+      sink as unknown as EventsSink,
+      { intervalMs: 1000, lastRunAt }
+    );
+
+    expect(sendReEngagementEmails).toHaveBeenCalledTimes(1);
+    clearInterval(handle);
+  });
+
+  it('does not run a catch-up tick when the last run is recent', async () => {
+    const sink = makeSink();
+    const lastRunAt = jest.fn().mockResolvedValue(new Date(Date.now() - 10));
+
+    const handle = await scheduleReEngagementEmails(
+      mockRepo,
+      mockEmailService,
+      sink as unknown as EventsSink,
+      { intervalMs: 1000, lastRunAt }
+    );
+
+    expect(sendReEngagementEmails).not.toHaveBeenCalled();
+    clearInterval(handle);
+  });
+
+  it('does not run a catch-up tick when no lastRunAt is supplied', async () => {
+    const sink = makeSink();
+
+    const handle = await scheduleReEngagementEmails(
+      mockRepo,
+      mockEmailService,
+      sink as unknown as EventsSink,
+      { intervalMs: 1000 }
+    );
+
+    expect(sendReEngagementEmails).not.toHaveBeenCalled();
+    clearInterval(handle);
   });
 });

--- a/src/lib/reengagement/jobs/scheduleReEngagementEmails.ts
+++ b/src/lib/reengagement/jobs/scheduleReEngagementEmails.ts
@@ -2,15 +2,16 @@ import type { IReEngagementRepository } from '../../../data_layer/ReEngagementRe
 import type { IEmailService } from '../../../services/EmailService/EmailService';
 import type { EventsSink } from '../../../services/events/EventsSink';
 import { sendReEngagementEmails } from '../../storage/jobs/helpers/sendReEngagementEmails';
+import { isOverdue, type LastRunAt } from '../../inactivity/jobs/lastRunAt';
 
 export const RE_ENGAGEMENT_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
-export const scheduleReEngagementEmails = (
+export const scheduleReEngagementEmails = async (
   repo: IReEngagementRepository,
   emailService: IEmailService,
   eventsSink: EventsSink,
-  options: { intervalMs?: number } = {}
-): NodeJS.Timeout => {
+  options: { intervalMs?: number; lastRunAt?: LastRunAt } = {}
+): Promise<NodeJS.Timeout> => {
   const intervalMs = options.intervalMs ?? RE_ENGAGEMENT_INTERVAL_MS;
 
   const tick = async () => {
@@ -25,6 +26,16 @@ export const scheduleReEngagementEmails = (
       console.error('[re-engagement] daily job failed:', error);
     }
   };
+
+  // Blue-green redeploys reset the interval before it can elapse, so without a
+  // catch-up the tick almost never fires. Eligibility is a fixed 24-hour band,
+  // which makes a missed day permanent for everyone in it.
+  if (options.lastRunAt != null) {
+    const lastRun = await options.lastRunAt();
+    if (isOverdue(lastRun, intervalMs, Date.now())) {
+      await tick();
+    }
+  }
 
   const handle = setInterval(tick, intervalMs);
   handle.unref();

--- a/src/server.ts
+++ b/src/server.ts
@@ -293,11 +293,15 @@ const serve = async () => {
   }
 
   const eventsSink = getEventsSink();
+  const eventsRepo = new EventsRepository(database);
   const reEngagementRepo = new ReEngagementRepository(database);
   const emailService = getDefaultEmailService();
-  scheduleReEngagementEmails(reEngagementRepo, emailService, eventsSink);
+  scheduleReEngagementEmails(reEngagementRepo, emailService, eventsSink, {
+    lastRunAt: () => eventsRepo.lastEventAt('email_batch_sent', 'reengagement'),
+  }).catch((error) => {
+    console.error('[re-engagement] failed to schedule:', error);
+  });
 
-  const eventsRepo = new EventsRepository(database);
   const inactivityEmailRepo = new InactivityEmailRepository(database);
   const uploadRepo = new UploadRepository(database);
   const sendInactivityWarningsUseCase = new SendInactivityWarningsUseCase(


### PR DESCRIPTION
## What

The re-engagement email job now runs an overdue tick at startup, like the three sibling schedulers already do.

## Why

`scheduleReEngagementEmails` was a bare `setInterval(tick, 24h)` with no catch-up. Blue-green redeploys (~10/day) reset the timer before 24 hours could elapse, so the tick rarely survived long enough to fire.

Production `email_batch_sent` events by campaign:

| campaign | events | last |
| --- | --- | --- |
| inactivity | 44 | 2026-07-27 |
| pause_resume | 15 | 2026-07-27 |
| reengagement | 12 | **2026-07-16** |

The tick records a batch event **even when it sends zero**, so those 12 events are 12 actual runs across the scheduler's 71-day life — about 17% of days — not a shortage of eligible users.

This hurts more than it would for the siblings because eligibility is a fixed 24-hour band (`created_at >= now() - 4 days AND < now() - 3 days`). A user missed on their day never becomes eligible again. **33 users are in-window with no email right now; 1582 aged out over the last 60 days.** `sendReEngagementEmails` has exactly one call site — no ops command, no cron, nothing to fall back on.

The three siblings at `server.ts:308/320/332` each pass `lastRunAt` and run the overdue tick added in `e50fd8d44462` for precisely this reason. Re-engagement was left out of that change.

Fixes https://github.com/2anki/server/issues/3867

## How

Gave `scheduleReEngagementEmails` the same `lastRunAt` option and startup catch-up as `scheduleInactivityWarnings`, reusing the existing `isOverdue` / `LastRunAt` helper rather than writing a second one. Wired `eventsRepo.lastEventAt('email_batch_sent', 'reengagement')` at the call site, moving `eventsRepo` above the call since it was constructed a few lines below it.

Repeated deploys do not cause repeated sends: the tick records `email_batch_sent` itself, so the next boot sees a recent run and skips the catch-up. That is the same self-limiting behaviour the siblings rely on.

## Testing

Four cases added, the first two verified failing first:

- last run older than the interval → catch-up tick runs (**was: no tick**)
- never run at all → catch-up tick runs (**was: no tick**)
- last run recent → no catch-up
- no `lastRunAt` supplied → no catch-up, unchanged behaviour

The four pre-existing tests held the return value as a timer handle; now that the function is async they `await` it, so `clearInterval` receives a handle instead of a promise (it was silently no-oping otherwise).

`pnpm test src/lib/inactivity src/lib/reengagement` — 4 suites, 25 tests green. `tsc -p . --noEmit` clean. `pnpm format:check` clean. SonarQube MCP on the changed file: 0 issues.

## Measuring success

`email_batch_sent` with `campaign: reengagement` should appear on **most** days rather than ~17% of them, and its event count should track `inactivity` (44 over the same window) instead of trailing it 12-to-44. The first post-deploy tick should also clear the 33 users currently sitting in-window.

## Risks

Low, with one thing worth knowing: the first deploy carrying this will fire a catch-up tick immediately and email the users currently in the eligibility band — up to 33. That is the intended behaviour and the same thing the sibling jobs do on their first boot after `e50fd8d44462`, but it is a real send, not a dry run. `sendReEngagementEmails` already filters `marketing_opt_out` and suppressed recipients.

No changelog entry — this is a background email scheduler. Nothing in the app changes, and "we started sending an email we were supposed to be sending" is not a What's New line.

Browser check: not applicable — no `web/src` files in the diff.

## Goal alignment

Acquisition and retention both. Re-engagement targets users 3–4 days after signup, which is the window where a new account either converts to a habit or goes cold — and 1582 of them were silently skipped in two months.
