### PR TITLE
fix: give each all-in-one conversion its own workspace

### DIFF
--- a/src/usecases/uploads/getPackagesFromZip.test.ts
+++ b/src/usecases/uploads/getPackagesFromZip.test.ts
@@ -190,6 +190,52 @@ describe('getPackagesFromZip — batch concurrency', () => {
     expect(mockPrepareDeckInfoOnly).not.toHaveBeenCalled();
   });
 
+  // Two files take the all-in-one path (cap 2 → one chunk). Sharing one
+  // workspace means the second conversion overwrites the first's deck_info.json
+  // before the Python child reads it, so both build the same deck and one is
+  // lost — while the user is still billed for both.
+  it('gives every all-in-one conversion its own workspace', async () => {
+    const fileNames = ['first.html', 'second.html'];
+    let subdirCount = 0;
+    (Workspace as unknown as Record<string, jest.Mock>).subdir = jest
+      .fn()
+      .mockImplementation(() => ({
+        location: `${FAKE_WORKSPACE_LOCATION}/sub-${subdirCount++}`,
+      }));
+
+    mockZipHandlerClass.mockImplementation(() => ({
+      build: jest.fn().mockResolvedValue(undefined),
+      getFileNames: jest.fn().mockReturnValue(fileNames),
+      files: fileNames.map((name) => ({ name, contents: '<html></html>' })),
+    }));
+
+    mockPrepareDeck.mockImplementation(({ name }: { name: string }) =>
+      Promise.resolve({
+        name,
+        apkg: Buffer.from(''),
+        deck: [],
+        cardCount: 1,
+      })
+    );
+
+    const settings = new CardOption({});
+    const workspace = { location: FAKE_WORKSPACE_LOCATION } as Workspace;
+
+    await getPackagesFromZip(
+      Buffer.from('fake-zip') as unknown as Uint8Array,
+      false,
+      settings,
+      workspace
+    );
+
+    expect(mockPrepareDeck).toHaveBeenCalledTimes(2);
+    const usedLocations = mockPrepareDeck.mock.calls.map(
+      (call) => call[0].workspace.location
+    );
+    expect(new Set(usedLocations).size).toBe(2);
+    expect(usedLocations).not.toContain(FAKE_WORKSPACE_LOCATION);
+  });
+
   it('caps batch chunks at the derived per-worker Python budget (default 2)', async () => {
     const fileCount = 12;
     const fileNames = Array.from(

--- a/src/usecases/uploads/getPackagesFromZip.ts
+++ b/src/usecases/uploads/getPackagesFromZip.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import pLimit from 'p-limit';
 import CardOption from '../../lib/parser/Settings/CardOption';
 import { ZipHandler } from '../../lib/zip/zip';
@@ -248,6 +250,30 @@ async function buildClaudeFlashcardDeck(
   return { packages, warnings };
 }
 
+// The downloader lists decks by reading the top-level workspace, so a deck
+// built in a per-conversion subdirectory has to be lifted back up. A name that
+// is already taken gets a suffix rather than replacing the deck that got there
+// first — silently overwriting is the failure this whole change removes.
+async function liftDecksToParent(from: Workspace, to: Workspace) {
+  if (!fs.existsSync(from.location)) return;
+  const entries = await fs.promises.readdir(from.location);
+  for (const entry of entries) {
+    if (!entry.endsWith('.apkg')) continue;
+    const extension = path.extname(entry);
+    const base = entry.slice(0, -extension.length);
+    let candidate = entry;
+    let suffix = 2;
+    while (fs.existsSync(path.join(to.location, candidate))) {
+      candidate = `${base} (${suffix})${extension}`;
+      suffix += 1;
+    }
+    await fs.promises.rename(
+      path.join(from.location, entry),
+      path.join(to.location, candidate)
+    );
+  }
+}
+
 async function buildAllInOneSlot(
   supportedFileNames: string[],
   zipHandler: ZipHandler,
@@ -261,15 +287,23 @@ async function buildAllInOneSlot(
     supportedFileNames.map((fileName) =>
       limit(() => {
         const relevantFiles = getRelevantFiles(fileName, zipHandler.files);
-        return convertSkippingLockedPdf(fileName, () =>
-          PrepareDeck({
+        // Every conversion needs its own workspace. CustomExporter writes
+        // deck_info.json at a fixed path inside it, and the Python child reads
+        // that file hundreds of milliseconds later — so with a shared workspace
+        // a concurrent conversion overwrites the payload first and both
+        // processes build the same deck.
+        const deckWorkspace = Workspace.subdir(workspace.location);
+        return convertSkippingLockedPdf(fileName, async () => {
+          const result = await PrepareDeck({
             name: fileName,
             files: relevantFiles,
             settings,
             noLimits: paying,
-            workspace,
-          })
-        );
+            workspace: deckWorkspace,
+          });
+          await liftDecksToParent(deckWorkspace, workspace);
+          return result;
+        });
       })
     )
   );


### PR DESCRIPTION
## What

A zip containing exactly two convertible files now produces two decks instead of one.

## Why

`buildAllInOneSlot` ran up to `cap` conversions concurrently and passed every one **the same** `Workspace`. `CustomExporter.deckInfoPath()` is a fixed `path.join(this.workspace, 'deck_info.json')`, written by `configure()` and read by the Python child hundreds of milliseconds later — so the second conversion overwrote the first's payload before it was read, both Python processes built the same deck, both computed the same output filename, and `os.replace` collapsed them into one file.

Two files is the common case, not an edge case. Path selection is `supportedFileNames.length <= 1 || batchSize <= 1`, and prod sets neither `MAX_PYTHON_WORKERS` nor `CONVERSION_WORKERS`, so `cap = floor(8/4) = 2` and a 2-file zip takes this branch as a single chunk. **A Notion export of a page plus one subpage hits it.** 1, 3, and 4 files all work correctly, which is why it never looked like a systemic problem.

**The user was billed for the deck they never got.** `totalCards` is summed from the in-memory `packages` array, so `incrementCardUsage(owner, totalCards)` debits cards from the discarded deck against the monthly quota. `buildBatchResponse` lists decks by reading the directory, so `/downloads` showed one deck with no warning.

`buildDeckBatch` already avoids this with `Workspace.subdir` per deck. The all-in-one path never got that fix.

Fixes https://github.com/2anki/server/issues/3864

## How

Each conversion gets its own `Workspace.subdir(workspace.location)`, matching `buildDeckBatch`. No `n === 2` special case — a larger cap would just widen the broken range.

Because the downloader lists decks by reading the **top-level** workspace, each built deck is lifted back up after its conversion. A name already taken takes a numbered suffix rather than replacing whatever got there first — silently overwriting is the exact failure this removes.

## Testing

**End-to-end through the real pipeline** (this checkout has the Python venv), same two-file zip both times:

| | packages reported | `.apkg` on disk | decks present |
| --- | --- | --- | --- |
| before | 2 | **1** | Beta only |
| after | 2 | 2 | Alpha + Beta |

Unit test added and verified failing first: two files through `getPackagesFromZip` must give `PrepareDeck` two distinct workspaces, neither of them the shared parent. It failed with 1 distinct workspace before the change.

`pnpm test src/usecases/uploads` — 17 suites, 98 tests green. `tsc -p . --noEmit` clean. `pnpm format:check` clean. SonarQube MCP: flagged two `S7772` findings on the import lines I added (`fs`/`path` → `node:fs`/`node:path`), fixed; re-run reports 0 issues.

## Measuring success

A two-file zip yields `deckCount: 2` on `/downloads`. The clearer signal is the absence of the old one: no more reports of a Notion page-plus-subpage export arriving as a single deck.

## Risks

Low. Behaviour for 1 file is untouched (different code path), and 3+ files already used the batch path with per-deck subdirectories. The new work per conversion is one `mkdir` and one `rename`.

The lift step reads the subdirectory and moves only `.apkg` files; media and `deck_info.json` stay behind in the per-deck directory, which is the same disposable workspace they occupied before.

No changelog entry — a user who hit this had no way to know a deck was missing, so an entry would describe a bug most people never observed. Happy to add one if you'd rather announce it.

Browser check: not applicable — no `web/src` files in the diff.

## Goal alignment

Directly on the mission: drop something in, get a clean deck back. Losing half of a two-file upload while charging the user's monthly card quota for it is the sharpest version of failing that, and Notion page-plus-subpage is one of the most common export shapes we handle.
