### PR TITLE
fix: stop writing undefined onto photo MCQ card backs

### DIFF
--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
@@ -941,6 +941,7 @@ describe('PhotoToFlashcardsUseCase', () => {
       cards: Array<{
         mcq?: boolean;
         cloze?: boolean;
+        back?: string;
         options?: string[];
         correctIndices?: number[];
       }>;
@@ -962,6 +963,7 @@ describe('PhotoToFlashcardsUseCase', () => {
         ...BASE_INPUT,
         isPaying: true,
         mode: 'verbatim',
+        includeSourceImage: false,
       });
 
       const cards = readDeckPayload()[0].cards;
@@ -973,6 +975,7 @@ describe('PhotoToFlashcardsUseCase', () => {
         'Lactase',
       ]);
       expect(cards[0].correctIndices).toEqual([1]);
+      expect(cards[0].back).toBe('');
       expect(cards[1].mcq).toBeFalsy();
       expect(cards[1].cloze).toBe(true);
       expect(cards[2].mcq).toBeFalsy();
@@ -1029,6 +1032,71 @@ describe('PhotoToFlashcardsUseCase', () => {
       expect(card.cloze).toBe(false);
       expect(result.mcqCount).toBe(0);
       expect(result.mcqSkippedCount).toBe(1);
+    });
+
+    it('leaves the back empty when a rejected MCQ carries no answer text', async () => {
+      mockMessageCreate.mockResolvedValueOnce({
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify([
+              {
+                deck: 'Study sheet',
+                cards: [
+                  {
+                    q: 'Pick one',
+                    options: ['A', 'B', 'C'],
+                    correct_index: 1,
+                  },
+                ],
+              },
+            ]),
+          },
+        ],
+        usage: { input_tokens: 100, output_tokens: 50 },
+      });
+      const useCase = new PhotoToFlashcardsUseCase(makeEventsStub());
+      await useCase.execute({
+        ...BASE_INPUT,
+        isPaying: true,
+        mode: 'verbatim',
+        includeSourceImage: false,
+      });
+      expect(readDeckPayload()[0].cards[0].back).toBe('');
+    });
+
+    it('keeps the rationale on the back of a generative MCQ card', async () => {
+      mockMessageCreate.mockResolvedValueOnce({
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify([
+              {
+                deck: 'Study sheet',
+                cards: [
+                  {
+                    q: 'Which enzyme breaks down starch?',
+                    options: ['Lipase', 'Amylase', 'Protease', 'Lactase'],
+                    correct_index: 1,
+                    rationale: 'Amylase hydrolyses starch into maltose.',
+                  },
+                ],
+              },
+            ]),
+          },
+        ],
+        usage: { input_tokens: 100, output_tokens: 50 },
+      });
+      const useCase = new PhotoToFlashcardsUseCase(makeEventsStub());
+      await useCase.execute({
+        ...BASE_INPUT,
+        isPaying: true,
+        mcqEnabled: true,
+        includeSourceImage: false,
+      });
+      expect(readDeckPayload()[0].cards[0].back).toBe(
+        'Amylase hydrolyses starch into maltose.'
+      );
     });
 
     it('leaves the generative path on plain basic cards (no verbatim routing)', async () => {

--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
@@ -290,9 +290,16 @@ interface CompactDeck {
   cards: CompactCard[];
 }
 
+// VerbatimCard types q and a as strings, but the vision response is blind-cast
+// from Claude's JSON and the verbatim MCQ shape carries neither an answer nor a
+// rationale. Interpolating the missing field put the word "undefined" on the
+// back of the card instead of leaving it empty.
+function answerText(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
 function cardBack(card: CompactCard): string {
-  if (typeof card.a === 'string' && card.a.length > 0) return card.a;
-  return typeof card.rationale === 'string' ? card.rationale : '';
+  return answerText(card.a) || answerText(card.rationale);
 }
 
 function flattenDecksToCards(decks: CompactDeck[]): GeneratedFlashcard[] {
@@ -381,7 +388,7 @@ function buildMcqCard(
   const validMcq = asValidMcq(card);
   if (validMcq == null) return null;
   const rationaleBack =
-    validMcq.rationale.length > 0 ? validMcq.rationale : card.a;
+    validMcq.rationale.length > 0 ? validMcq.rationale : answerText(card.a);
   return {
     ...base,
     name: card.q,
@@ -402,7 +409,7 @@ function buildBasicCard(
   return {
     ...base,
     name: card.q,
-    back: `${card.a}${sourceImageTag}`,
+    back: `${answerText(card.a)}${sourceImageTag}`,
     cloze,
   };
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-28-photo-mcq-empty-back.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-28-photo-mcq-empty-back.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-28-photo-mcq-empty-back",
+  "date": "2026-07-28",
+  "type": "fix",
+  "title": "Multiple-choice cards from a photo no longer show the word undefined on the back"
+}


### PR DESCRIPTION
## What

Photo-to-deck no longer writes the literal string `undefined` onto the back of a multiple-choice card.

## Why

`buildVerbatimPrompt` specifies the MCQ shape as `{q, options, correct_index}` — no answer field, no rationale. `buildMcqCard` fell back to `card.a` when the rationale was empty, and `buildBasicCard` interpolated `card.a` directly. `VerbatimCard` types `a` as a string, but `parseClaudeVisionResponse` blind-casts the model's JSON, so at runtime the field is absent and the template literal stringified it.

The result reaches the learner: that value becomes the `Extra` field of the `n2a-mcq` note, and the back template's `{{#Extra}}…{{/Extra}}` section renders because `"undefined"` is non-empty — a highlighted explanation panel reading `undefined` on every review. Verbatim is the most-used photo mode, and the verbatim branch does not require the paid MCQ toggle, so free and paid accounts both hit it.

## How

Both builders read the answer through the same coercion `cardBack` already used, which yields `''` for a missing field. MCQ still prefers the rationale when the generative prompt supplies one — that precedence is unchanged.

## Measuring success

No metric moves; this is card-output correctness on an existing surface. The observable check is that a verbatim MCQ conversion produces a card whose back is empty rather than `undefined`.

## Testing

Three assertions added to the existing verbatim suite — the mixed-shape case, a rejected MCQ carrying no answer text, and a generative MCQ keeping its rationale. All three failed with `"undefined"` before the change. Full file: 72 passed.

The existing test asserted `mcq`, `options`, and `correctIndices` but never `back`, which is why this shipped green.

Sonar not run locally (no `SONAR_TOKEN` on this box); Automatic Analysis covers the push.

## Risks

Low. The change is a type coercion at two call sites; no behavior changes for a card that carries a real answer.

## Goal alignment

Simpler and more beautiful output: a card the learner does not have to mentally discard a broken panel from.

Browser check: not applicable — server-side card construction; the only `web/src/` file is a changelog entry.

Fixes #3869
