### PR TITLE
fix: keep logged-out visitors on the public note type gallery

### DIFF
--- a/web/src/lib/backend/api.test.ts
+++ b/web/src/lib/backend/api.test.ts
@@ -148,6 +148,25 @@ describe('api.get error tagging', () => {
     expect(location.href).toBe('');
   });
 
+  it('a 401 on the public note-type gallery does not bounce to /login', async () => {
+    const location = {
+      origin: 'http://localhost',
+      pathname: '/templates',
+      href: '',
+    };
+    vi.stubGlobal('location', location);
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: 'Authentication required' }), {
+        status: 401,
+      })
+    );
+
+    await expect(
+      get('http://localhost/api/templates/user')
+    ).rejects.toBeInstanceOf(UserNotice);
+    expect(location.href).toBe('');
+  });
+
   it('a 401 on the bare reset path does not bounce to /login', async () => {
     const location = {
       origin: 'http://localhost',

--- a/web/src/lib/backend/api.ts
+++ b/web/src/lib/backend/api.ts
@@ -18,6 +18,7 @@ const NON_AUTH_PATHS = [
   '/auth/magic',
   '/upload',
   '/card-options',
+  '/templates',
   '/pricing',
   '/about',
   '/contact',

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-28-public-note-type-gallery.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-28-public-note-type-gallery.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-28-public-note-type-gallery",
+  "date": "2026-07-28",
+  "type": "fix",
+  "title": "The note type gallery opens without an account instead of sending you to the sign-in page"
+}


### PR DESCRIPTION
## What

`/templates` no longer throws logged-out visitors to `/login` before it can render.

## Why

`/templates` is a public route (`App.tsx:583`, unwrapped — unlike `/templates/new`), but `TemplatesPage` calls `getUserTemplates()` on mount, which hits the `RequireAuthentication`-gated `/api/templates/user` and gets a bare 401. That runs `throwForUnauthorized` → `redirectToLogin()`, and `/templates` was missing from `NON_AUTH_PATHS`, so `location.href = '/login'` fired. The page's own `.catch(() => ({ templates: [], hiddenIds: [] }))` cannot help — the navigation is a side effect performed *before* the throw.

The gallery itself works fine for anons: `/api/templates/defaults` (11 note types) and `/api/templates/official` (13) both return 200 with no cookie. The only thing between an anonymous visitor and the page was the bounce.

It is reachable from the "Note types" card on the landing page — which `HomePage.tsx:162` shows **only** to logged-out visitors — and from the gallery link on `/card-options`.

## How

Add `/templates` to `NON_AUTH_PATHS`. Exact precedent: `ee70c522a37e` fixed the identical bug on password reset by adding `/forgot` and `/users/r`. `/templates/new` and `/templates/edit/:id` remain gated by `requireAuth` in the router, so the prefix match does not open anything.

## Measuring success

Acquisition-facing: `/templates` is a public page linked from the landing page and previously unreachable without an account. The check is that anonymous sessions reaching `/templates` stay there instead of appearing at `/login`.

## Testing

New unit test: a 401 while on `/templates` leaves `location.href` untouched. It failed before the change (`expected '/login' to be ''`). `web/src/lib/backend/`: 106 passed. Web typecheck and lint clean.

Sonar not run locally (no `SONAR_TOKEN` on this box); Automatic Analysis covers the push.

## Risks

Low. The only behavior change is that a background 401 on this path no longer navigates. A genuinely auth-required page under `/templates/` is still protected by the router guard.

## Goal alignment

Acquisition. A public gallery of 24 note types that bounces every logged-out visitor to a sign-in wall is a landing page that cannot convert.

Browser check: not applicable — no browser run was performed and none is claimed. Alexander waived it for this change: the diff is a one-line entry in an allowlist, the behavior it changes is covered by the new unit test, and the page's own rendering is untouched. The unverified part is how `/templates` looks to an anonymous visitor now that the bounce is gone.

Fixes #3870
