### PR TITLE
fix: show real copy for a failed AI conversion, not the error code

### DIFF
--- a/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.test.tsx
+++ b/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.test.tsx
@@ -220,6 +220,28 @@ describe('ConversionResult — failed variant', () => {
     ).toBeNull();
   });
 
+  it.each(['claude_parse_failed', 'claude_response_truncated'])(
+    'renders the designer copy for %s instead of the raw identifier',
+    (reason) => {
+      render(
+        <MemoryRouter>
+          <ConversionResult
+            variant="failed"
+            title="Study notes"
+            failureReason={reason}
+            source="upload"
+            onMapColumns={vi.fn()}
+          />
+        </MemoryRouter>
+      );
+
+      expect(screen.queryByText(new RegExp(reason))).toBeNull();
+      expect(
+        screen.getByText(/Something went wrong while making your cards/)
+      ).toBeInTheDocument();
+    }
+  );
+
   it('renders notion token expired reconnect link when source is notion and reason is notion_token_expired', () => {
     render(
       <MemoryRouter>

--- a/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.tsx
+++ b/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.tsx
@@ -14,9 +14,21 @@ import { get2ankiApi } from '../../../../lib/backend/get2ankiApi';
 import { startUnlimitedUpgrade } from '../../../../lib/backend/startUnlimitedUpgrade';
 import { track } from '../../../../lib/analytics/track';
 import { formatResetDate } from './formatResetDate';
-import type { UploadErrorBody } from '../../../../types/UploadErrorBody';
+import type {
+  UploadErrorBody,
+  UploadErrorCode,
+} from '../../../../types/UploadErrorBody';
 import sharedStyles from '../../../../styles/shared.module.css';
 import styles from './ConversionResult.module.css';
+
+// The server stores these identifiers verbatim in job_reason_failure. Without a
+// code to key on, classifyUploadError falls through to its short-message branch
+// and renders the identifier itself as the whole explanation. The designer copy
+// for claude_parse_failed already ships in all 10 locales.
+const CLAUDE_REASON_CODES: Record<string, UploadErrorCode> = {
+  claude_parse_failed: 'claude_parse_failed',
+  claude_response_truncated: 'claude_parse_failed',
+};
 
 const PAYWALL_SURFACE = 'downloads-limit';
 const UNLIMITED_PRICING_HREF = `/pricing?source=${PAYWALL_SURFACE}`;
@@ -207,7 +219,9 @@ function FailedVariant({
     failureReason.includes('MemoryError') ||
     failureReason.includes('Killed');
   const errorBody: UploadErrorBody = {
-    code: isTooLarge ? 'too_large' : 'unknown',
+    code:
+      CLAUDE_REASON_CODES[failureReason.trim()] ??
+      (isTooLarge ? 'too_large' : 'unknown'),
     message: failureReason,
   };
   const friendly = classifyUploadError(errorBody);

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-28-readable-ai-failure-message.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-28-readable-ai-failure-message.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-28-readable-ai-failure-message",
+  "date": "2026-07-28",
+  "type": "fix",
+  "title": "A failed AI conversion explains itself in your language instead of showing an internal error code"
+}


### PR DESCRIPTION
## What

A failed AI conversion shows the designer's sentence instead of the raw internal identifier.

## Why

`ClaudeParseError.message` is the string `claude_parse_failed`; `ClaudeTruncatedError.message` is `claude_response_truncated`. `runChunks` rethrows `new Error(failures[0].reason)`, which flattens the class, so the identifier lands verbatim in `jobs.job_reason_failure`. `ConversionResult` hardcoded `code: 'unknown'`, which has no entry in `UPLOAD_CODE_DEFAULTS`, so `classifyUploadError` fell through to `if (stripped.length < 280) return { title: stripped }` — and rendered the identifier as the entire explanation. Prod jobs carry `claude_parse_failed` today.

Designer copy for `claude_parse_failed` already ships in all 10 locales and was unreachable, because nothing mapped the stored string to a code.

## How

Map the two known identifiers to `claude_parse_failed` in the component, alongside the existing `isTooLarge` string sniff.

Deliberately **not** fixed server-side. Returning a sentence from `jobFailureReasonFromError` would ship English into every locale and bypass the copy that already exists; keeping `job_reason_failure` a machine identifier is also more useful for ops. `claude_response_truncated` maps to the same code because the advice is identical, and it has never been written to a prod row.

## Measuring success

No metric moves. The check is that a job failing with `claude_parse_failed` renders "Something went wrong while making your cards. Try again — if it keeps happening, email support@2anki.net." in the viewer's language.

## Testing

Parameterized test over both identifiers: the raw string must not appear, the designer copy must. Both failed before the change. `ConversionResult`: 28 passed. Web typecheck clean.

Sonar not run locally (no `SONAR_TOKEN` on this box); Automatic Analysis covers the push.

## Risks

Low. A lookup on two exact strings; every other failure reason takes the path it took before.

## Goal alignment

A user who sees `claude_parse_failed` learns nothing and has no next step. The copy that tells them to retry already existed in 10 languages — this connects it.

Browser check: not applicable — no browser run was performed and none is claimed. Alexander waived the browser check for this batch. The rendered output is asserted by the component test at the DOM level, which is what the visual check would confirm.

Fixes #3875
