### PR TITLE
fix: harden the photo vision response parser

### DIFF
--- a/src/lib/claude/ClaudeService.ts
+++ b/src/lib/claude/ClaudeService.ts
@@ -463,7 +463,7 @@ export function buildUserMessage(
   return `Convert this HTML content into the compact deck JSON:\n\n${strippedContent}${mediaFilesList}${instructionsSection}${fieldMappingSection}${styleSection}${sizeSection}`;
 }
 
-function extractJsonArray(text: string): string | null {
+export function extractJsonArray(text: string): string | null {
   const start = text.indexOf('[');
   if (start === -1) return null;
   const end = text.lastIndexOf(']');

--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
@@ -1149,6 +1149,69 @@ describe('PhotoToFlashcardsUseCase', () => {
       ).rejects.toMatchObject({ status: 422 });
     });
 
+    it('converts a response that opens with a sentence of prose', async () => {
+      mockMessageCreate.mockResolvedValueOnce({
+        content: [
+          {
+            type: 'text',
+            text:
+              'Here are the flashcards from your photo:\n\n' +
+              JSON.stringify([
+                { deck: 'Study', cards: [{ q: 'Q1', a: 'A1' }] },
+              ]),
+          },
+        ],
+        usage: { input_tokens: 100, output_tokens: 50 },
+      });
+      const useCase = new PhotoToFlashcardsUseCase(makeEventsStub());
+      const result = await useCase.execute({ ...BASE_INPUT, isPaying: true });
+      expect(result.cardCount).toBe(1);
+    });
+
+    it('fails as a 422, not a TypeError, when the array holds bare cards', async () => {
+      mockMessageCreate.mockResolvedValueOnce({
+        content: [
+          { type: 'text', text: JSON.stringify([{ q: 'Q1', a: 'A1' }]) },
+        ],
+        usage: { input_tokens: 100, output_tokens: 50 },
+      });
+      const useCase = new PhotoToFlashcardsUseCase(makeEventsStub());
+      await expect(
+        useCase.execute({ ...BASE_INPUT, isPaying: true })
+      ).rejects.toMatchObject({ status: 422 });
+    });
+
+    it('keeps the MCQ fields through parsing', async () => {
+      mockMessageCreate.mockResolvedValueOnce({
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify([
+              {
+                deck: 'Study',
+                cards: [
+                  {
+                    q: 'Which enzyme breaks down starch?',
+                    options: ['Lipase', 'Amylase', 'Protease', 'Lactase'],
+                    correct_index: 1,
+                    rationale: 'Amylase hydrolyses starch.',
+                  },
+                ],
+              },
+            ]),
+          },
+        ],
+        usage: { input_tokens: 100, output_tokens: 50 },
+      });
+      const useCase = new PhotoToFlashcardsUseCase(makeEventsStub());
+      const result = await useCase.execute({
+        ...BASE_INPUT,
+        isPaying: true,
+        mode: 'verbatim',
+      });
+      expect(result.mcqCount).toBe(1);
+    });
+
     it('does not leak the raw model text in the thrown error message', async () => {
       mockMessageCreate.mockResolvedValueOnce({
         content: [

--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
@@ -5,6 +5,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import { spawn, execFileSync } from 'node:child_process';
 
 import {
+  extractJsonArray,
   getAnthropicClient,
   normalizeTag,
 } from '../../lib/claude/ClaudeService';
@@ -318,14 +319,46 @@ function logUnreadableVisionResponse(raw: string): void {
         .update(raw)
         .digest('hex')
         .slice(0, 12),
+      response_prefix: raw.slice(0, 200),
+      response_tail: raw.slice(-200),
     })
   );
 }
 
+// The model's own field set is wider than the shared parser's: an MCQ card
+// carries options, correct_index, and rationale, which sanitizeCompactDecks
+// drops. Cards keep their shape here; only entries that would crash the caller
+// are removed — a deck with no cards array, or a card with no usable front.
+function sanitizeVisionDecks(parsed: unknown[]): CompactDeck[] {
+  const decks: CompactDeck[] = [];
+  for (const entry of parsed) {
+    if (typeof entry !== 'object' || entry === null) continue;
+    const raw = entry as { deck?: unknown; cards?: unknown };
+    if (!Array.isArray(raw.cards)) continue;
+    const cards = raw.cards.filter((card) => {
+      if (typeof card !== 'object' || card === null) return false;
+      const q = (card as { q?: unknown }).q;
+      return typeof q === 'string' && q.trim().length > 0;
+    });
+    decks.push({
+      deck:
+        typeof raw.deck === 'string' && raw.deck.trim().length > 0
+          ? raw.deck
+          : 'Photo deck',
+      // The card shape is whatever the model emitted; buildDeckCards reads every
+      // field defensively, which is why a cast is enough here.
+      cards: cards as CompactCard[],
+    });
+  }
+  return decks;
+}
+
 function parseClaudeVisionResponse(raw: string): CompactDeck[] {
   const cleaned = raw.replace(/```json|```/g, '').trim();
-  const jsonEnd = cleaned.lastIndexOf(']');
-  const toParse = jsonEnd >= 0 ? cleaned.slice(0, jsonEnd + 1) : cleaned;
+  // Slicing from index 0 made a single sentence of preamble fatal on this path
+  // while the shared parser shrugs it off. Prod carries vision_parse_failed on
+  // complete responses for exactly that reason.
+  const toParse = extractJsonArray(cleaned) ?? cleaned;
 
   let parsed: unknown;
   try {
@@ -339,7 +372,15 @@ function parseClaudeVisionResponse(raw: string): CompactDeck[] {
     logUnreadableVisionResponse(raw);
     throw makeUnreadableVisionResponseError();
   }
-  return parsed as CompactDeck[];
+
+  // An array of bare cards parses fine and then crashes the caller on
+  // d.cards.length, which surfaces as a 400 carrying the internal message.
+  const decks = sanitizeVisionDecks(parsed);
+  if (decks.length === 0) {
+    logUnreadableVisionResponse(raw);
+    throw makeUnreadableVisionResponseError();
+  }
+  return decks;
 }
 
 function mediaTypeToExt(mediaType: VisionMediaType): string {

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-28-photo-conversion-robust-parse.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-28-photo-conversion-robust-parse.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-28-photo-conversion-robust-parse",
+  "date": "2026-07-28",
+  "type": "fix",
+  "title": "Photo conversions that used to fail with a blame-the-photo message now produce their cards"
+}


### PR DESCRIPTION
## What

The photo vision parser no longer fails on a complete, readable response, and no longer crashes on an unexpected array shape.

## Why

`parseClaudeVisionResponse` sliced from index 0 to the last `]` and called `JSON.parse` once. It had none of the shared parser's hardening, so:

- **A sentence of preamble was fatal.** The same response converts fine on the PDF-vision path, which reuses `parseDeckResponse`. Prod carries 3 `vision_parse_failed` against 135 `vision_call_success`, on complete ~3.9 KB responses with zero truncation log lines — and at least one user retried twice, minutes apart, being told to take a clearer or less dense photo.
- **A flat `[{q, a}]` array crashed the caller.** The function ended in `return parsed as CompactDeck[]`, and the next line reads `d.cards.length` unguarded. `ErrorHandler` returned **400 with the raw internal message** and emailed the maintainer.

## How

Share the extraction step (`extractJsonArray`, now exported) and add a local shape check.

**Not** a delegation to `parseDeckResponse`, despite the sibling path doing exactly that — that would have been a silent regression. `sanitizeCompactDecks` whitelists `q/a/tags/cloze/media` and drops `options`, `correct_index`, and `rationale`, so every MCQ card on this path would vanish. The local sanitizer removes only what would crash the caller — a deck with no `cards` array, a card with no usable front — and leaves the card shape alone. A test asserts the MCQ fields survive.

The failure log recorded only a length and a SHA prefix, which is why the three prod failures are undiagnosable; it now carries a bounded 200-character window from each end.

## Measuring success

`vision_parse_failed` should approach zero. When one does occur, the log window makes it diagnosable instead of a dead end.

## Testing

Three tests added: a response opening with prose converts (failed before with a 422); a flat array of bare cards fails as a 422 rather than a TypeError (failed before); the MCQ fields survive parsing (passes before and after — it guards the regression the obvious fix would have caused). `src/usecases/imageOcclusion/` + `src/lib/claude/`: 268 passed.

Sonar not run locally (no `SONAR_TOKEN` on this box); Automatic Analysis covers the push.

## Risks

Low. Every response that parsed before still parses; the new paths are ones that previously threw or crashed. The one new export is a pure string function.

## Goal alignment

Photo-to-deck is a paid surface. Telling a user their photo is too dense when the model returned a perfectly good deck is the worst version of a conversion failure — it sends them to fix something that was never wrong.

Browser check: not applicable — server-side parser; the only `web/src/` file is a changelog entry.

Fixes #3874
