### PR TITLE
fix: offer every chat attachment type the server accepts

### DIFF
--- a/web/src/components/ChatPanel/ChatPanel.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.tsx
@@ -13,6 +13,7 @@ import { compressImageForUpload } from '../../lib/image/compressImageForUpload';
 import AssistantMarkdown from '../../pages/Chat/AssistantMarkdown';
 import CardPreview from '../../pages/Chat/CardPreview';
 import ConsentModal from '../ConsentModal/ConsentModal';
+import { ALLOWED_ATTACHMENT_TYPES, ATTACHMENT_ACCEPT } from './attachmentTypes';
 import styles from './ChatPanel.module.css';
 
 export interface ChatCard {
@@ -77,14 +78,6 @@ interface AttachmentChip {
   state: ChipState;
   retryCount: number;
 }
-
-const ALLOWED_TYPES = new Set([
-  'application/pdf',
-  'image/png',
-  'image/jpeg',
-  'image/gif',
-  'image/webp',
-]);
 
 const MAX_FILE_BYTES = 10 * 1024 * 1024;
 const MAX_TOTAL_BYTES = 25 * 1024 * 1024;
@@ -555,7 +548,7 @@ function ComposerPill({
           ref={fileInputRef}
           type="file"
           multiple
-          accept="application/pdf,image/png,image/jpeg,image/gif,image/webp"
+          accept={ATTACHMENT_ACCEPT}
           style={{ display: 'none' }}
           onChange={(e) => {
             if (e.target.files != null && e.target.files.length > 0) {
@@ -721,7 +714,9 @@ export default function ChatPanel({
   async function addFiles(incoming: File[]) {
     setNetworkError(null);
 
-    const disallowed = incoming.filter((f) => !ALLOWED_TYPES.has(f.type));
+    const disallowed = incoming.filter(
+      (f) => !ALLOWED_ATTACHMENT_TYPES.has(f.type)
+    );
     if (disallowed.length > 0) {
       if (disallowed.length === 1) {
         setNetworkError(

--- a/web/src/components/ChatPanel/attachmentTypes.parity.test.ts
+++ b/web/src/components/ChatPanel/attachmentTypes.parity.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { ALLOWED_ATTACHMENT_TYPES } from './attachmentTypes';
+
+const MIME_LITERAL = /'([a-z]+\/[a-zA-Z0-9.+-]+)'/g;
+
+function readServerSource(relativePath: string): string {
+  return readFileSync(join(__dirname, '../../../../', relativePath), 'utf8');
+}
+
+// ALLOWED_MIMES in ChatController is BINARY_VERIFIED_MIMES plus ZIP_BASED_MIMES
+// plus TEXT_MIMES, and the last two are built from constants that live in
+// extractAttachmentText. Reading the whole controller instead would also pick up
+// unrelated content types such as text/event-stream.
+function readServerAllowedMimes(): Set<string> {
+  const controller = readServerSource('src/controllers/ChatController.ts');
+  const binaryBlock =
+    /const BINARY_VERIFIED_MIMES = new Set\(\[([^\]]*)\]/.exec(controller);
+  if (binaryBlock == null) {
+    throw new Error('BINARY_VERIFIED_MIMES not found in ChatController');
+  }
+
+  const extract = readServerSource(
+    'src/usecases/chat/extractAttachmentText.ts'
+  );
+  const textExtractableBlock =
+    /export const TEXT_EXTRACTABLE_MIMES = new Set<string>\(\[([^\]]*)\]/.exec(
+      extract
+    );
+  if (textExtractableBlock == null) {
+    throw new Error(
+      'TEXT_EXTRACTABLE_MIMES not found in extractAttachmentText'
+    );
+  }
+  const namedConstants = Array.from(
+    textExtractableBlock[1].matchAll(/([A-Z_]+),/g),
+    (m) => m[1]
+  );
+
+  const mimes = new Set(
+    Array.from(binaryBlock[1].matchAll(MIME_LITERAL), (m) => m[1])
+  );
+  for (const name of namedConstants) {
+    const declaration = new RegExp(
+      `export const ${name} =\\s*'([a-z]+\\/[a-zA-Z0-9.+-]+)'`
+    ).exec(extract);
+    if (declaration == null) {
+      throw new Error(`${name} has no literal in extractAttachmentText`);
+    }
+    mimes.add(declaration[1]);
+  }
+  return mimes;
+}
+
+describe('chat attachment type parity', () => {
+  it('every type the picker offers is one the server accepts', () => {
+    const serverMimes = readServerAllowedMimes();
+    const missing = Array.from(ALLOWED_ATTACHMENT_TYPES).filter(
+      (type) => !serverMimes.has(type)
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it('offers every type the server accepts', () => {
+    const serverMimes = readServerAllowedMimes();
+    const unofferable = Array.from(serverMimes).filter(
+      (type) => !ALLOWED_ATTACHMENT_TYPES.has(type)
+    );
+    expect(unofferable).toEqual([]);
+  });
+});

--- a/web/src/components/ChatPanel/attachmentTypes.ts
+++ b/web/src/components/ChatPanel/attachmentTypes.ts
@@ -1,0 +1,29 @@
+// Must stay in step with ALLOWED_MIMES in src/controllers/ChatController.ts.
+// The server has accepted zip, docx, md, and txt since chat attachments
+// shipped — its rejection message names them — but the picker only offered PDF
+// and images, so the four types whose text the server persists for follow-up
+// turns could never be attached from any client 2anki ships.
+// attachmentTypes.parity.test.ts fails when the two lists drift.
+const ATTACHMENT_MIME_TYPES = [
+  'application/pdf',
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+  'application/zip',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'text/markdown',
+  'text/plain',
+];
+
+export const ALLOWED_ATTACHMENT_TYPES = new Set(ATTACHMENT_MIME_TYPES);
+
+// Extensions ride along because a browser reports an empty type for .md and
+// .txt often enough that a MIME-only accept list hides them in the file picker.
+export const ATTACHMENT_ACCEPT = [
+  ...ATTACHMENT_MIME_TYPES,
+  '.zip',
+  '.docx',
+  '.md',
+  '.txt',
+].join(',');

--- a/web/src/pages/Chat/ChatPage.test.tsx
+++ b/web/src/pages/Chat/ChatPage.test.tsx
@@ -261,12 +261,12 @@ describe('ChatPage', () => {
     });
   });
 
-  it('shows error when file type is not allowed', async () => {
+  it('shows a chip for a .docx, which the server has always accepted', async () => {
     renderChatPage();
     const input = document.querySelector(
       'input[type="file"]'
     ) as HTMLInputElement;
-    const file = new File(['data'], 'document.docx', {
+    const file = new File(['data'], 'lecture.docx', {
       type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
     });
     Object.defineProperty(input, 'files', {
@@ -276,9 +276,24 @@ describe('ChatPage', () => {
     fireEvent.change(input);
 
     await waitFor(() => {
-      expect(
-        screen.getByText(/Can't attach document.docx/)
-      ).toBeInTheDocument();
+      expect(screen.getByTitle('lecture.docx')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error when file type is not allowed', async () => {
+    renderChatPage();
+    const input = document.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement;
+    const file = new File(['data'], 'clip.mp4', { type: 'video/mp4' });
+    Object.defineProperty(input, 'files', {
+      value: [file],
+      configurable: true,
+    });
+    fireEvent.change(input);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Can't attach clip.mp4/)).toBeInTheDocument();
     });
   });
 

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-28-chat-attach-more-file-types.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-28-chat-attach-more-file-types.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-28-chat-attach-more-file-types",
+  "date": "2026-07-28",
+  "type": "feature",
+  "title": "Chat accepts .zip, .docx, .md, and .txt attachments, and remembers them across follow-up messages"
+}


### PR DESCRIPTION
## What

The chat file picker now offers every type the server accepts, which makes the attachment-memory feature reachable for the first time.

## Why

`TEXT_EXTRACTABLE_MIMES` is zip / docx / md / txt — those are the types whose text gets persisted to `chat_messages.attachment_text` and replayed into model history on follow-up turns. The picker accepted **only** PDF and images. The intersection is empty, so #3678's fix could never fire from any client 2anki ships, and its changelog entry ("Chat now remembers an uploaded file across follow-up messages") was false for every type a user could attach.

Prod: `SELECT count(*), count(attachment_text) FROM chat_messages WHERE created_at > '2026-07-17'` → `54 | 0`.

The server was never the constraint — `ALLOWED_MIMES` has accepted all six since attachments shipped, and its rejection message literally reads "Files work here as PDF, image, .zip, .docx, .md, or .txt." Only the picker disagreed.

## How

One client constant for the allowed types and the `accept` string, plus a parity test that reads the server source (same shape as `events.parity.test.ts`) and fails in both directions. The drift that caused this can't ship silently again.

Extensions ride along in `accept` because browsers report an empty type for `.md` and `.txt` often enough to hide them in the picker.

## Not in scope

Part (b) of the issue — extracting PDF text into `attachment_text` — is not here. A PDF still reaches the model as a native `document` block on the turn it's attached and is still absent from later turns. That needs server-side PDF text extraction and is a separate change; `application/pdf` must **not** be added to `TEXT_EXTRACTABLE_MIMES`, which would run binary bytes through the text path.

## Measuring success

`count(attachment_text)` on `chat_messages` should stop being zero. That query is the whole test of whether the memory feature is alive.

## Testing

New parity test, both directions. `src/components/ChatPanel/`: 54 passed. Web typecheck and lint clean.

Sonar not run locally (no `SONAR_TOKEN` on this box); Automatic Analysis covers the push.

## Risks

Low. Widening the picker to types the server already validates — every upload still passes the server's magic-byte / zip-signature / UTF-8 checks. Placeholder copy still says "attach a PDF"; changing it means a string in 10 locales and is left for a copy pass.

## Goal alignment

A shipped feature that nobody could use is worse than an unshipped one — it consumed review, a changelog entry, and a claim to users, and returned nothing.

Browser check: not applicable — no browser run was performed and none is claimed. Alexander waived the browser check for this batch. The change is the value of an `accept` attribute and a Set membership test, both asserted in unit tests.

Fixes #3873
