### PR TITLE
fix: spare developer-tier customers from the deletion sweeps

### DIFF
--- a/src/data_layer/InactivityEmailRepository.developerTier.sql.test.ts
+++ b/src/data_layer/InactivityEmailRepository.developerTier.sql.test.ts
@@ -1,0 +1,44 @@
+import knexFactory from 'knex';
+
+import { InactivityEmailRepository } from './InactivityEmailRepository';
+
+// Developer tiers live in subscriptions_developer (#3902), not subscriptions,
+// so the subscriber guards on these queries do not see them. Without the
+// exemption a customer whose only paid subscription is a developer tier is
+// treated as a free inactive user: warned, then deleted outright.
+describe('InactivityEmailRepository developer-tier exemption SQL', () => {
+  const pg = knexFactory({ client: 'pg' });
+  const repository = new InactivityEmailRepository(pg);
+
+  afterAll(async () => {
+    await pg.destroy();
+  });
+
+  it('exempts an active developer tier from the warning query', () => {
+    const sql = repository.buildUsersToNotifyQuery(500).toString();
+
+    expect(sql).toContain('"subscriptions_developer"');
+    expect(sql).toContain('subscriptions_developer.user_id = users.id');
+    expect(sql).toContain('subscriptions_developer.email = users.email');
+  });
+
+  it('exempts an active developer tier from the deletion query', () => {
+    const sql = repository.buildUsersToDeleteQuery(100).toString();
+
+    expect(sql).toContain('"subscriptions_developer"');
+    expect(sql).toContain('subscriptions_developer.user_id = u.id');
+  });
+
+  it('exempts an active developer tier from the dead-address candidate query', () => {
+    const sql = repository.buildDeadAddressCandidatesQuery(100).toString();
+
+    expect(sql).toContain('"subscriptions_developer"');
+    expect(sql).toContain('subscriptions_developer.user_id = u.id');
+  });
+
+  it('only exempts while the developer subscription is active', () => {
+    const sql = repository.buildUsersToDeleteQuery(100).toString();
+
+    expect(sql).toContain('"subscriptions_developer"."active" = true');
+  });
+});

--- a/src/data_layer/InactivityEmailRepository.ts
+++ b/src/data_layer/InactivityEmailRepository.ts
@@ -57,6 +57,11 @@ export class InactivityEmailRepository implements IInactivityEmailRepository {
         this.buildActivePassExistsQuery('user_passes.user_id = users.id')
       )
       .whereNotExists(
+        this.buildActiveDeveloperSubscriptionQuery(
+          '(subscriptions_developer.user_id = users.id OR subscriptions_developer.email = users.email)'
+        )
+      )
+      .whereNotExists(
         this.database(this.table)
           .whereRaw('inactivity_emails.user_id = users.id')
           .limit(1)
@@ -106,6 +111,11 @@ export class InactivityEmailRepository implements IInactivityEmailRepository {
       .whereNotExists(
         this.buildActivePassExistsQuery('user_passes.user_id = u.id')
       )
+      .whereNotExists(
+        this.buildActiveDeveloperSubscriptionQuery(
+          '(subscriptions_developer.user_id = u.id OR subscriptions_developer.email = u.email)'
+        )
+      )
       .orderBy('ie.sent_at', 'asc')
       .limit(limit);
   }
@@ -140,8 +150,27 @@ export class InactivityEmailRepository implements IInactivityEmailRepository {
       .whereNotExists(
         this.buildActivePassExistsQuery('user_passes.user_id = u.id')
       )
+      .whereNotExists(
+        this.buildActiveDeveloperSubscriptionQuery(
+          '(subscriptions_developer.user_id = u.id OR subscriptions_developer.email = u.email)'
+        )
+      )
       .orderBy('u.id', 'asc')
       .limit(limit);
+  }
+
+  // Developer tiers live in subscriptions_developer (#3902), not subscriptions,
+  // so a customer whose only paid subscription is a developer tier has no row
+  // in the table these guards read. Without this they are treated as a free
+  // inactive user: warned, then deleted. Matching on email as well as user_id
+  // is deliberate and safe here — this predicate only ever SPARES a user, so a
+  // loose match costs nothing, unlike the tier-granting path where an email
+  // match would have been a privilege escalation.
+  private buildActiveDeveloperSubscriptionQuery(userCorrelation: string) {
+    return this.database('subscriptions_developer')
+      .where('subscriptions_developer.active', true)
+      .whereRaw(userCorrelation)
+      .limit(1);
   }
 
   private buildActivePassExistsQuery(userCorrelation: string) {

--- a/src/lib/storage/jobs/helpers/deleteNonSubScriberUploadsInDatabase.test.ts
+++ b/src/lib/storage/jobs/helpers/deleteNonSubScriberUploadsInDatabase.test.ts
@@ -155,6 +155,14 @@ describe('deleteNonSubScriberUploadsInDatabase — cleanup-vs-subscriber e2e', (
       t.text('linked_email').nullable();
       t.boolean('active').nullable();
     });
+    await db.schema.createTable('subscriptions_developer', (t) => {
+      t.increments('id');
+      t.string('stripe_subscription_id');
+      t.integer('user_id');
+      t.string('email');
+      t.string('stripe_product_id');
+      t.boolean('active');
+    });
     await db.schema.createTable('user_passes', (t) => {
       t.increments('id').primary();
       t.integer('user_id').notNullable();
@@ -259,6 +267,51 @@ describe('deleteNonSubScriberUploadsInDatabase — cleanup-vs-subscriber e2e', (
 
     expect(storage.delete).not.toHaveBeenCalled();
     expect(await remainingUploadKeys()).toEqual(['sub.apkg']);
+  });
+
+  it('spares a customer whose only paid subscription is a developer tier', async () => {
+    // Developer tiers live in subscriptions_developer, not subscriptions, so
+    // this customer has no row in the table the subscriber predicate reads.
+    // Without the second clause they read as a free user and their uploads are
+    // deleted from the bucket irreversibly.
+    await seedUserWithUpload(1, 'dev@example.com', false, 'dev.apkg');
+    await db('subscriptions_developer').insert({
+      stripe_subscription_id: 'sub_dev_1',
+      user_id: 1,
+      email: 'dev@example.com',
+      stripe_product_id: 'prod_growth',
+      active: true,
+    });
+
+    const storage = { delete: jest.fn() };
+
+    await deleteNonSubScriberUploadsInDatabase(
+      withPgRawShape(db),
+      storage as never
+    );
+
+    expect(storage.delete).not.toHaveBeenCalled();
+    expect(await remainingUploadKeys()).toEqual(['dev.apkg']);
+  });
+
+  it('still sweeps a user whose developer tier is no longer active', async () => {
+    await seedUserWithUpload(1, 'lapsed@example.com', false, 'lapsed.apkg');
+    await db('subscriptions_developer').insert({
+      stripe_subscription_id: 'sub_dev_2',
+      user_id: 1,
+      email: 'lapsed@example.com',
+      stripe_product_id: 'prod_growth',
+      active: false,
+    });
+
+    const storage = { delete: jest.fn() };
+
+    await deleteNonSubScriberUploadsInDatabase(
+      withPgRawShape(db),
+      storage as never
+    );
+
+    expect(await remainingUploadKeys()).toEqual([]);
   });
 
   it('spares a subscriber who also holds a stale cancelled subscription row', async () => {

--- a/src/lib/storage/jobs/helpers/deleteNonSubScriberUploadsInDatabase.ts
+++ b/src/lib/storage/jobs/helpers/deleteNonSubScriberUploadsInDatabase.ts
@@ -21,6 +21,11 @@ export const deleteNonSubScriberUploadsInDatabase = async (
   // the cancelled row and sweeps a paying subscriber's decks. Lowercasing both
   // sides matches AuthenticationService.getIsSubscriber, which is what the rest
   // of the product uses to decide the same question.
+  // Developer tiers live in subscriptions_developer (#3902), not subscriptions.
+  // Without the second clause a customer whose only paid subscription is a
+  // developer tier reads as a free user here and has their uploads deleted from
+  // the bucket irreversibly. Matching on email as well as user_id only ever
+  // spares a row, so a loose match is the safe direction.
   const query = await db.raw(`
     SELECT up.key
     FROM users u
@@ -33,6 +38,11 @@ export const deleteNonSubScriberUploadsInDatabase = async (
             lower(u.email) = lower(s.email)
             OR lower(u.email) = lower(s.linked_email)
           )
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM subscriptions_developer sd
+        WHERE sd.active = true
+          AND (sd.user_id = u.id OR lower(u.email) = lower(sd.email))
       )
       AND NOT EXISTS (
         SELECT 1 FROM user_passes pass


### PR DESCRIPTION
## What

The three deletion sweeps now recognise a developer-tier customer as paying.

## Why

#3902 routed developer-tier subscriptions to their own `subscriptions_developer` table — but every sweep that decides "is this user paying" still reads only `subscriptions`. A customer whose only paid subscription is a developer tier therefore reads as a free user in three places:

1. **The nightly upload sweep** (`deleteNonSubScriberUploadsInDatabase`) — deletes their decks from the bucket, irreversibly.
2. **The inactivity warning query** — emails them a deletion warning.
3. **The inactive-account deletion query** — deletes the account outright.

Latent today (zero developer subscriptions exist in production), but it becomes live on the first tier purchase, and the failure mode is the worst kind: irreversible deletion of a paying customer's data with no error anywhere.

Found by the fan-out triage: the challenger on #3831 read the sweep query post-#3902 and flagged the new hole.

## How

All three queries gain a `NOT EXISTS` on `subscriptions_developer`, matching on `user_id` **or** `email`. The email match is deliberate and safe *in this direction*: these predicates only ever **spare** a user, so a loose match costs nothing — in contrast to the tier-granting path in `RequireApiKey`, where the identical email match was removed as a privilege escalation in #3902's security review. Direction determines safety.

An inactive developer row spares nothing — covered by tests on both paths.

## Testing

Two e2e cases on the upload sweep (active tier spared; lapsed tier still swept) and four generated-SQL assertions on the inactivity queries, following the existing `activePass.sql.test.ts` pattern — Postgres-dialect knex, no connection, per `.claude/rules/testing.md`. Full suite: 5 925 passing; the one failure is the known `pdfinfo` local issue.

Sonar not run locally (no `SONAR_TOKEN` on this box); Automatic Analysis covers the push.

## Risks

Low. Every clause is a `NOT EXISTS` that can only spare rows, never sweep more. The worst failure of a wrong predicate here is under-deletion — storage cost, not data loss.

## Goal alignment

Revenue protection: the first developer-tier customer must not have their decks or account deleted by a sweep that doesn't know their table exists.

Browser check: not applicable — server-side queries only, no `web/src/` files.

No changelog entry — the defect is unreachable today (no developer subscriptions exist), so no user has experienced it.
