### PR TITLE
fix: stop silently truncating long PDF conversions

### DIFF
--- a/src/infrastracture/adapters/fileConversion/claudeFileConversion.test.ts
+++ b/src/infrastracture/adapters/fileConversion/claudeFileConversion.test.ts
@@ -1,16 +1,18 @@
 import type Anthropic from '@anthropic-ai/sdk';
 import { convertWithClaude, FileConversionError } from './claudeFileConversion';
 
-const makeAnthropicMock = (responseText: string) => ({
+const makeAnthropicMock = (responseText: string, stopReason = 'end_turn') => ({
   messages: {
     create: jest.fn().mockResolvedValue({
       content: [{ type: 'text', text: responseText }],
+      stop_reason: stopReason,
     }),
   },
   beta: {
     messages: {
       create: jest.fn().mockResolvedValue({
         content: [{ type: 'text', text: responseText }],
+        stop_reason: stopReason,
       }),
     },
   },
@@ -103,14 +105,55 @@ describe('convertWithClaude', () => {
     expect(mock.beta.messages.create).not.toHaveBeenCalled();
   });
 
-  it('uses 8192 max_tokens', async () => {
+  it('uses 32768 max_tokens', async () => {
     const mock = makeAnthropicMock('<p>result</p>');
     await convertWithClaude(mock as unknown as Anthropic, 'system prompt', [
       { type: 'text', text: 'user text' },
     ]);
 
     const callArg = (mock.messages.create as jest.Mock).mock.calls[0][0];
-    expect(callArg.max_tokens).toBe(8192);
+    expect(callArg.max_tokens).toBe(32768);
+  });
+
+  it('throws instead of returning a silently truncated document', async () => {
+    const mock = makeAnthropicMock('<p>first half of the docu', 'max_tokens');
+
+    await expect(
+      convertWithClaude(mock as unknown as Anthropic, 'system prompt', [
+        { type: 'text', text: 'user text' },
+      ])
+    ).rejects.toThrow(/too large to convert in one pass/);
+  });
+
+  it('throws on truncation on the PDF path too', async () => {
+    const mock = makeAnthropicMock('<p>first half', 'max_tokens');
+
+    await expect(
+      convertWithClaude(
+        mock as unknown as Anthropic,
+        'system prompt',
+        [{ type: 'text', text: 'user text' }],
+        { pdf: true }
+      )
+    ).rejects.toThrow(/too large to convert in one pass/);
+  });
+
+  it('joins every text block instead of reading only the first', async () => {
+    const mock = makeAnthropicMock('');
+    (mock.messages.create as jest.Mock).mockResolvedValue({
+      content: [
+        { type: 'text', text: '<p>part one</p>' },
+        { type: 'text', text: '<p>part two</p>' },
+      ],
+      stop_reason: 'end_turn',
+    });
+
+    const result = await convertWithClaude(
+      mock as unknown as Anthropic,
+      'system prompt',
+      [{ type: 'text', text: 'user text' }]
+    );
+    expect(result).toBe('<p>part one</p><p>part two</p>');
   });
 
   it('uses the default model when CLAUDE_FILE_CONVERSION_MODEL is unset', async () => {

--- a/src/infrastracture/adapters/fileConversion/claudeFileConversion.ts
+++ b/src/infrastracture/adapters/fileConversion/claudeFileConversion.ts
@@ -4,7 +4,33 @@ import type { BetaContentBlockParam } from '@anthropic-ai/sdk/resources/beta/mes
 import { logClaudeUsage } from '../../../lib/claude/logClaudeUsage';
 
 const DEFAULT_MODEL = 'claude-sonnet-4-6';
-const MAX_TOKENS = 8192;
+// A cap, not a charge — output is billed on tokens actually generated, so a
+// generous ceiling costs nothing on documents that were never near it. At the
+// old 8192 a dense multi-page PDF hit the cap routinely, and the truncation
+// went unchecked, so the user received the front of their document as if it
+// were the whole thing.
+const MAX_TOKENS = 32768;
+
+export const CONVERSION_TRUNCATED_MESSAGE =
+  'This document is too large to convert in one pass. Split it into smaller parts and convert each one.';
+
+// Silent truncation is the worst outcome: the output parses, the deck builds,
+// and the user has no signal that the tail of their document is missing. An
+// error they can act on beats half a deck they cannot detect.
+function assertNotTruncated(stopReason: string | null | undefined): void {
+  if (stopReason === 'max_tokens') {
+    throw new FileConversionError(CONVERSION_TRUNCATED_MESSAGE);
+  }
+}
+
+function joinTextBlocks(content: { type: string; text?: string }[]): string {
+  return content
+    .filter(
+      (block): block is { type: 'text'; text: string } => block.type === 'text'
+    )
+    .map((block) => block.text)
+    .join('');
+}
 
 export class FileConversionError extends Error {
   constructor(message: string) {
@@ -47,8 +73,8 @@ export async function convertWithClaude(
         betas: ['pdfs-2024-09-25'],
       });
       logClaudeUsage('claudeFileConversion', response.usage);
-      const block = response.content[0];
-      return block.type === 'text' ? block.text : '';
+      assertNotTruncated(response.stop_reason);
+      return joinTextBlocks(response.content);
     }
 
     const response = await client.messages.create({
@@ -58,9 +84,10 @@ export async function convertWithClaude(
       messages: [{ role: 'user', content: userContent }],
     });
     logClaudeUsage('claudeFileConversion', response.usage);
-    const block = response.content[0];
-    return block.type === 'text' ? block.text : '';
+    assertNotTruncated(response.stop_reason);
+    return joinTextBlocks(response.content);
   } catch (error) {
+    if (error instanceof FileConversionError) throw error;
     const message = error instanceof Error ? error.message : String(error);
     throw new FileConversionError(message);
   }

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -25,6 +25,10 @@ import { EmptyDeckError } from '../usecases/jobs/EmptyDeckError';
 import { UploadFileUnavailableError } from '../usecases/uploads/UploadFileUnavailableError';
 import { isExpectedClientFault } from '../lib/misc/isExpectedClientFault';
 import type { DeckScore } from '../lib/parser/scoreCandidateDeck';
+import {
+  CONVERSION_TRUNCATED_MESSAGE,
+  FileConversionError,
+} from '../infrastracture/adapters/fileConversion/claudeFileConversion';
 import type {
   ConversionScoreSource,
   IConversionRuleScoresRepository,
@@ -880,6 +884,8 @@ class UploadService {
           err instanceof EmptyDeckError ||
           err instanceof ClaudeParseError ||
           err instanceof ClaudeLargeSectionError ||
+          (err instanceof FileConversionError &&
+            err.message === CONVERSION_TRUNCATED_MESSAGE) ||
           err instanceof ImageOnlyContentError ||
           (err instanceof Error && isExpectedClientFault(err)) ||
           (err instanceof Error && isPdfPasswordSentinel(err.message)) ||

--- a/src/usecases/jobs/jobFailureReason.ts
+++ b/src/usecases/jobs/jobFailureReason.ts
@@ -1,6 +1,10 @@
 import { APIResponseError, APIErrorCode } from '@notionhq/client';
 import { PythonExitError } from '../../lib/anki/buildPythonExitError';
 import { ClaudeLargeSectionError } from '../../lib/claude/ClaudeService';
+import {
+  CONVERSION_TRUNCATED_MESSAGE,
+  FileConversionError,
+} from '../../infrastracture/adapters/fileConversion/claudeFileConversion';
 import { EmptyDeckError } from './EmptyDeckError';
 import { inferColumnMapping } from '../../lib/notionDatabase/inferColumnMapping';
 import { isNotionDatabaseNotPageError } from '../../services/NotionService/helpers/isNotionDatabaseNotPageError';
@@ -144,6 +148,12 @@ export function jobFailureReasonFromError(
     return EMPTY_DECK_FAILURE_REASON;
   }
   if (error instanceof ClaudeLargeSectionError) {
+    return error.message;
+  }
+  if (
+    error instanceof FileConversionError &&
+    error.message === CONVERSION_TRUNCATED_MESSAGE
+  ) {
     return error.message;
   }
   if (error instanceof PythonExitError) {

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-28-pdf-conversion-no-silent-cutoff.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-28-pdf-conversion-no-silent-cutoff.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-28-pdf-conversion-no-silent-cutoff",
+  "date": "2026-07-28",
+  "type": "fix",
+  "title": "Long PDFs convert much further, and one too large to finish says so instead of quietly dropping its last pages"
+}


### PR DESCRIPTION
## What

A long PDF conversion that hits the output ceiling now says so instead of silently shipping the front of the document. The ceiling also quadruples, so far fewer conversions hit it at all.

## Why

`convertWithClaude` sent a whole PDF in one call capped at 8 192 output tokens with **no `stop_reason` check**. A dense document past ~15 pages came back cut mid-stream and the pipeline carried on as if the output were complete: the deck built, no error fired, and the user's last pages were absent. That is the reported *"questions from the last pages get no cards"* — and after this week's chunk-retry fixes, this was the only remaining unguarded truncation on the upload path.

## How

- **Cap 8 192 → 32 768.** A cap is not a charge — output is billed on tokens actually generated — so the ceiling costs nothing on documents that were never near it and simply lets longer documents finish.
- **`stop_reason === 'max_tokens'` throws** with "This document is too large to convert in one pass. Split it into smaller parts and convert each one." An error the user can act on beats half a deck they cannot detect.
- The message is classified as an expected user-input state on the async path and passed through `jobFailureReasonFromError`, so it reaches the downloads page verbatim instead of collapsing to generic failure text.
- `content[0]` → join of every text block, which previously dropped everything after the first block.

## Scope

Part **(a)** of #3849 — the long-document half. The wide-table half is a different cause (`dedupeCardsByFront` discarding per-column cards that share a front) and stays open; it needs its prod log signal read before any prompt change. The issue stays open for that half.

## Measuring success

`[Claude] claudeFileConversion` usage logs: output-token counts above 8 192 appearing at all proves the raise is doing work; the truncation message appearing in `jobs.job_reason_failure` instead of silent half-decks is the guard doing its job.

## Testing

Five new tests: truncation throws on both the PDF and plain paths (failed before — the mock returned truncated text as a success), the raised cap, multi-block joining, and the failure-reason mapping including the negative case (other conversion failures stay generic). Full suite: 5 928 passing; the one failure is the known `pdfinfo` local issue.

Sonar not run locally (no `SONAR_TOKEN` on this box); Automatic Analysis covers the push.

## Risks

Low. Conversions that previously succeeded honestly are unchanged. The behaviour change is confined to conversions that were already broken: they now fail loudly instead of succeeding falsely. Latency rises only on documents whose tail was previously being cut, which is the point.

## Goal alignment

Paid-path trust: this fires only for paying users ("Generate questions from PDF uploads" is behind `noLimits`), and a silently incomplete deck is the kind of failure that reads as "the product is unreliable" without ever showing an error.

Browser check: not applicable — server-side conversion path; the only `web/src/` file is a changelog entry.

Part of #3849 (the long-document half; the wide-table half remains open).
