### PR TITLE
fix: sweep subscriptions_developer in reconcile

### DIFF
--- a/src/data_layer/DeveloperSubscriptionsRepository.test.ts
+++ b/src/data_layer/DeveloperSubscriptionsRepository.test.ts
@@ -110,4 +110,19 @@ describe('DeveloperSubscriptionsRepository', () => {
     await repo().deactivateBySubscriptionId('sub_1');
     expect(await repo().activeProductIdsForUser(7)).toEqual(['prod_growth']);
   });
+
+  it('lists only active rows with their id and subscription id', async () => {
+    await repo().upsert({ ...base, stripeSubscriptionId: 'sub_1' });
+    await repo().upsert({
+      ...base,
+      stripeSubscriptionId: 'sub_2',
+      active: false,
+    });
+
+    const rows = await repo().listActive();
+
+    expect(rows).toEqual([
+      { id: expect.any(Number), stripe_subscription_id: 'sub_1' },
+    ]);
+  });
 });

--- a/src/data_layer/DeveloperSubscriptionsRepository.ts
+++ b/src/data_layer/DeveloperSubscriptionsRepository.ts
@@ -9,9 +9,15 @@ export interface DeveloperSubscriptionRecord {
   payload: unknown;
 }
 
+export interface ActiveDeveloperSubscriptionRow {
+  id: number;
+  stripe_subscription_id: string;
+}
+
 export interface IDeveloperSubscriptionsRepository {
   upsert(entry: DeveloperSubscriptionRecord): Promise<void>;
   activeProductIdsForUser(userId: number): Promise<string[]>;
+  listActive(): Promise<ActiveDeveloperSubscriptionRow[]>;
   deactivateBySubscriptionId(stripeSubscriptionId: string): Promise<number>;
 }
 
@@ -51,6 +57,15 @@ export class DeveloperSubscriptionsRepository implements IDeveloperSubscriptions
       .where({ user_id: userId, active: true })
       .select('stripe_product_id');
     return toProductIds(rows);
+  }
+
+  // The reconcile sweep re-checks every active row against Stripe. It keys on
+  // the dedicated stripe_subscription_id column, so no payload parsing is
+  // needed — unlike the subscriptions table, which digs the id out of payload.
+  async listActive(): Promise<ActiveDeveloperSubscriptionRow[]> {
+    return this.knex(this.table)
+      .where({ active: true })
+      .select('id', 'stripe_subscription_id');
   }
 
   // The webhook cannot always resolve an account — a developer can pay under a

--- a/src/lib/storage/jobs/helpers/reconcileActiveSubscriptions.test.ts
+++ b/src/lib/storage/jobs/helpers/reconcileActiveSubscriptions.test.ts
@@ -1,4 +1,9 @@
-import { reconcileActiveSubscriptions } from './reconcileActiveSubscriptions';
+import knexLib, { Knex } from 'knex';
+
+import {
+  reconcileActiveSubscriptions,
+  reconcileDeveloperSubscriptions,
+} from './reconcileActiveSubscriptions';
 
 type DbMock = jest.Mock & { updateSpy: jest.Mock };
 
@@ -7,12 +12,13 @@ function buildDbMock(
 ): DbMock {
   const updateSpy = jest.fn().mockResolvedValue(1);
 
-  const db = jest.fn().mockImplementation(() => {
+  const db = jest.fn().mockImplementation((table: string) => {
+    const rows = table === 'subscriptions_developer' ? [] : activeRows;
     const builder: Record<string, unknown> = {
       select: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
       update: updateSpy,
-      then: (resolve: (value: unknown) => void) => resolve(activeRows),
+      then: (resolve: (value: unknown) => void) => resolve(rows),
     };
     return builder;
   }) as DbMock;
@@ -130,5 +136,125 @@ describe('reconcileActiveSubscriptions', () => {
 
     expect(retrieve).toHaveBeenCalledTimes(2);
     expect(db.updateSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('reconcileDeveloperSubscriptions', () => {
+  let db: Knex;
+
+  beforeEach(async () => {
+    db = knexLib({
+      client: 'better-sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    });
+    await db.schema.createTable('subscriptions_developer', (t) => {
+      t.increments('id');
+      t.string('stripe_subscription_id').unique();
+      t.integer('user_id');
+      t.string('email');
+      t.string('stripe_product_id');
+      t.boolean('active');
+      t.json('payload');
+      t.timestamp('updated_at');
+    });
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  async function insertRow(
+    stripeSubscriptionId: string,
+    active: boolean
+  ): Promise<void> {
+    await db('subscriptions_developer').insert({
+      stripe_subscription_id: stripeSubscriptionId,
+      user_id: 7,
+      email: 'dev@example.com',
+      stripe_product_id: 'prod_starter',
+      active,
+      payload: JSON.stringify({ id: stripeSubscriptionId }),
+    });
+  }
+
+  async function activeFlag(stripeSubscriptionId: string): Promise<boolean> {
+    const row = await db('subscriptions_developer')
+      .where({ stripe_subscription_id: stripeSubscriptionId })
+      .first();
+    return Boolean(row.active);
+  }
+
+  it('flips an active row inactive when Stripe reports the sub as canceled', async () => {
+    await insertRow('sub_dev_1', true);
+    const stripe = buildStripeMock(async () => ({
+      id: 'sub_dev_1',
+      status: 'canceled',
+    }));
+
+    await reconcileDeveloperSubscriptions(db, stripe);
+
+    expect(stripe.subscriptions.retrieve).toHaveBeenCalledWith('sub_dev_1');
+    expect(await activeFlag('sub_dev_1')).toBe(false);
+  });
+
+  it('flips an active row inactive when Stripe returns 404 for the sub', async () => {
+    await insertRow('sub_dev_missing', true);
+    const stripe = {
+      subscriptions: {
+        retrieve: jest.fn().mockRejectedValue({
+          statusCode: 404,
+          message: 'No such subscription',
+        }),
+      },
+    } as any;
+
+    await reconcileDeveloperSubscriptions(db, stripe);
+
+    expect(await activeFlag('sub_dev_missing')).toBe(false);
+  });
+
+  it('flips an active row inactive when Stripe reports the sub as paused', async () => {
+    await insertRow('sub_dev_paused', true);
+    const stripe = buildStripeMock(async () => ({
+      id: 'sub_dev_paused',
+      status: 'active',
+      pause_collection: { behavior: 'void' },
+    }));
+
+    await reconcileDeveloperSubscriptions(db, stripe);
+
+    expect(await activeFlag('sub_dev_paused')).toBe(false);
+  });
+
+  it('leaves an active row alone when Stripe still reports the sub as active', async () => {
+    await insertRow('sub_dev_2', true);
+    const stripe = buildStripeMock(async () => ({
+      id: 'sub_dev_2',
+      status: 'active',
+      cancel_at_period_end: false,
+    }));
+
+    await reconcileDeveloperSubscriptions(db, stripe);
+
+    expect(await activeFlag('sub_dev_2')).toBe(true);
+  });
+
+  it('does not abort the sweep when one Stripe lookup fails; still reconciles the rest', async () => {
+    await insertRow('sub_dev_boom', true);
+    await insertRow('sub_dev_ok', true);
+    const retrieve = jest.fn().mockImplementation(async (id: string) => {
+      if (id === 'sub_dev_boom') {
+        throw new Error('boom');
+      }
+      return { id, status: 'canceled' };
+    });
+    const stripe = { subscriptions: { retrieve } } as any;
+
+    await reconcileDeveloperSubscriptions(db, stripe);
+
+    expect(retrieve).toHaveBeenCalledTimes(2);
+    expect(await activeFlag('sub_dev_boom')).toBe(true);
+    expect(await activeFlag('sub_dev_ok')).toBe(false);
   });
 });

--- a/src/lib/storage/jobs/helpers/reconcileActiveSubscriptions.ts
+++ b/src/lib/storage/jobs/helpers/reconcileActiveSubscriptions.ts
@@ -1,10 +1,21 @@
 import { Knex } from 'knex';
 import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
+import { DeveloperSubscriptionsRepository } from '../../../../data_layer/DeveloperSubscriptionsRepository';
+import { isPaused } from '../../../subscriptions/isPaused';
 
 interface ActiveSubscriptionRow {
   id: number;
   payload: unknown;
 }
+
+// Mirrors ACCESS_GRANTING_STATUSES in src/lib/integrations/stripe.ts, which is
+// module-private there. Keep the two in step: a status outside this set means
+// Stripe has stopped granting access and the local row must follow.
+const ACCESS_GRANTING_STATUSES = new Set<StripeTypes.Subscription['status']>([
+  'active',
+  'past_due',
+  'unpaid',
+]);
 
 function parseSubscriptionId(payload: unknown): string | null {
   if (payload == null) return null;
@@ -48,7 +59,7 @@ async function deactivateRow(
   console.info(`[stripe-sync] Flipped subscription row ${row.id} to inactive`);
 }
 
-export async function reconcileActiveSubscriptions(
+async function reconcileSubscriptionsTable(
   db: Knex,
   stripe: Pick<StripeTypes, 'subscriptions'>
 ): Promise<void> {
@@ -81,4 +92,64 @@ export async function reconcileActiveSubscriptions(
       console.error(`[stripe-sync] Failed to reconcile row ${row.id}:`, error);
     }
   }
+}
+
+function developerSubscriptionRemainsActive(
+  subscription: StripeTypes.Subscription
+): boolean {
+  if (!ACCESS_GRANTING_STATUSES.has(subscription.status)) return false;
+  if (isPaused(subscription)) return false;
+
+  if (subscription.cancel_at_period_end && subscription.cancel_at) {
+    const periodEndMs = subscription.cancel_at * 1000;
+    return Date.now() < periodEndMs;
+  }
+  return true;
+}
+
+export async function reconcileDeveloperSubscriptions(
+  db: Knex,
+  stripe: Pick<StripeTypes, 'subscriptions'>
+): Promise<void> {
+  const repository = new DeveloperSubscriptionsRepository(db);
+  const rows = await repository.listActive();
+
+  console.info(
+    `[stripe-sync] Reconciling ${rows.length} active developer subscription row(s)`
+  );
+
+  for (const row of rows) {
+    try {
+      const subscription = await stripe.subscriptions.retrieve(
+        row.stripe_subscription_id
+      );
+      if (!developerSubscriptionRemainsActive(subscription)) {
+        await repository.deactivateBySubscriptionId(row.stripe_subscription_id);
+        console.info(
+          `[stripe-sync] Flipped developer subscription row ${row.id} to inactive`
+        );
+      }
+    } catch (error) {
+      const statusCode = (error as { statusCode?: number })?.statusCode;
+      if (statusCode === 404) {
+        await repository.deactivateBySubscriptionId(row.stripe_subscription_id);
+        console.info(
+          `[stripe-sync] Flipped developer subscription row ${row.id} to inactive (Stripe 404)`
+        );
+        continue;
+      }
+      console.error(
+        `[stripe-sync] Failed to reconcile developer subscription row ${row.id}:`,
+        error
+      );
+    }
+  }
+}
+
+export async function reconcileActiveSubscriptions(
+  db: Knex,
+  stripe: Pick<StripeTypes, 'subscriptions'>
+): Promise<void> {
+  await reconcileSubscriptionsTable(db, stripe);
+  await reconcileDeveloperSubscriptions(db, stripe);
 }


### PR DESCRIPTION
## What
Extends `reconcileActiveSubscriptions` to also sweep the `subscriptions_developer` table. For each active row it retrieves the subscription from Stripe by the dedicated `stripe_subscription_id` column and flips the row inactive when Stripe returns 404 or reports a status outside the access-granting set (paused and past-period scheduled-cancel included).

## Why
Fixes #3903. `subscriptions_developer` (added in #3902) had no reconcile sweep. The cancellation webhook was the only path that could deactivate a row. An undelivered cancellation (Stripe retry window exhausted, dropped event, refund/dispute) would leave the row `active = true` forever and keep granting a paid API tier that nothing detects. The `subscriptions` table survives this because the reconcile re-checks it against Stripe; the developer table had no equivalent. User-visible outcome: a cancelled developer tier stops granting access even when its cancellation event never reaches us.

## How
- `DeveloperSubscriptionsRepository.listActive()` returns each active row's `id` + `stripe_subscription_id` (repositories are the only layer that touches knex); deactivation reuses the existing `deactivateBySubscriptionId`.
- New exported `reconcileDeveloperSubscriptions(db, stripe)` retrieves each row by its `stripe_subscription_id` (no `payload` parsing needed, unlike the `subscriptions` sweep) and deactivates on 404 or a non-access-granting/paused/expired-scheduled-cancel status. `ACCESS_GRANTING_STATUSES` is mirrored from `src/lib/integrations/stripe.ts` (it is module-private there); the active/paused/`cancel_at_period_end` logic matches `updateStoreSubscription`, the row's write path, so the reconcile agrees with the writer.
- `reconcileActiveSubscriptions` now runs the existing `subscriptions` sweep, then the developer sweep. A per-row `try/catch` means one Stripe error does not abort the rest.
- Untouched: `STRIPE_SYNC_ON_STARTUP` / any env flag — the re-enable decision is split out per the issue.

## Measuring success
Prod log line `[stripe-sync] Flipped developer subscription row <id> to inactive` (and the `(Stripe 404)` variant) confirms the sweep deactivated a drifted developer row. The `[stripe-sync] Reconciling N active developer subscription row(s)` line confirms the sweep ran. Zero developer subscriptions exist in prod today, so no output is expected until the first tier sells.

## Testing
- Unit tests added (`reconcileDeveloperSubscriptions`, real in-memory better-sqlite3, only Stripe mocked at the SDK edge): canceled status -> deactivated; Stripe 404 -> deactivated; paused (`pause_collection`) -> deactivated; still-active -> untouched; one Stripe lookup throwing does not abort the sweep for the rest.
- `DeveloperSubscriptionsRepository.listActive()` unit test: returns only active rows with `id` + `stripe_subscription_id`.
- Existing `reconcileActiveSubscriptions` and `updateStripeSubscriptions` suites still green (34 tests across the affected files).
- `npx tsc -p . --noEmit` clean (deploy build typechecks tests); `pnpm format:check` clean tree-wide; `pnpm arch` 0 errors.
- Sonar not run locally (no `SONAR_TOKEN`, and the SonarQube MCP analyzer was not yet available this session) — Automatic Analysis covers the push.

## Browser check
Browser check: not applicable — server-side sweep, no web/src files.

## Changelog
No changelog entry — the defect is unreachable today (no developer subscriptions exist).

## Risks
Low. The sweep only ever flips a row from active to inactive, and only when Stripe confirms the subscription is gone/non-granting; it never grants access. It runs only inside `updateStripeSubscriptions`, which is manual/`STRIPE_SYNC_ON_STARTUP`-gated (off in prod), so nothing new runs on a normal deploy. Rollback is reverting this PR.

## Goal alignment
Protects revenue integrity on the developer API path: a cancelled tier that keeps its card and rate limits is unpaid usage nothing else detects. No funnel metric to move — internal backstop for a not-yet-live surface.
