### PR TITLE
fix: expire idle deck shares from the free-tier storage pin

### DIFF
--- a/migrations/20261005000000_add_last_viewed_at_to_deck_shares.js
+++ b/migrations/20261005000000_add_last_viewed_at_to_deck_shares.js
@@ -1,0 +1,18 @@
+exports.up = async (knex) => {
+  await knex.schema.alterTable('deck_shares', (t) => {
+    t.timestamp('last_viewed_at', { useTz: true }).nullable();
+  });
+  // Give the installed base a fresh inactivity window so no share expires on
+  // deploy day; brand-new shares stay null and fall back to created_at.
+  await knex('deck_shares')
+    .whereNull('revoked_at')
+    .update({ last_viewed_at: knex.fn.now() });
+};
+
+// Rolling back after deploy loses view timestamps recorded in the interim;
+// the TTL then falls back to created_at, matching pre-migration behavior.
+exports.down = async (knex) => {
+  await knex.schema.alterTable('deck_shares', (t) => {
+    t.dropColumn('last_viewed_at');
+  });
+};

--- a/src/data_layer/ShareRepository.test.ts
+++ b/src/data_layer/ShareRepository.test.ts
@@ -25,6 +25,20 @@ describe('ShareRepository — generated SQL shape', () => {
     expect(sql).toContain('limit');
   });
 
+  it('recordView bumps the view count and stamps the view time in one update', () => {
+    const sql = pgKnex('deck_shares')
+      .where({ id: 7 })
+      .update({
+        view_count: pgKnex.raw('view_count + 1'),
+        last_viewed_at: pgKnex.fn.now(),
+      })
+      .toString();
+
+    expect(sql).toContain('"view_count" = view_count + 1');
+    expect(sql).toContain('"last_viewed_at" = CURRENT_TIMESTAMP');
+    expect(sql).toContain('"id" = 7');
+  });
+
   it('updatePublicListing scopes the update to the token/owner pair and excludes revoked shares', () => {
     const sql = pgKnex('deck_shares')
       .where({ token: 'abc', owner: asOwner(42) })

--- a/src/data_layer/ShareRepository.ts
+++ b/src/data_layer/ShareRepository.ts
@@ -19,7 +19,7 @@ export interface IShareRepository {
   ): Promise<DeckShares | null>;
   findAllByOwner(owner: UsersId): Promise<DeckShares[]>;
   revoke(token: string, owner: UsersId): Promise<boolean>;
-  incrementViewCount(id: DeckSharesId): Promise<void>;
+  recordView(id: DeckSharesId): Promise<void>;
   hasActiveShareForKey(uploadKey: string): Promise<boolean>;
   findByTokenAndOwner(
     token: string,
@@ -83,10 +83,13 @@ class ShareRepository implements IShareRepository {
     return count > 0;
   }
 
-  async incrementViewCount(id: DeckSharesId): Promise<void> {
-    await this.database<DeckShares>(this.table)
+  async recordView(id: DeckSharesId): Promise<void> {
+    await this.database(this.table)
       .where({ id })
-      .increment('view_count', 1);
+      .update({
+        view_count: this.database.raw('view_count + 1'),
+        last_viewed_at: this.database.fn.now(),
+      });
   }
 
   async hasActiveShareForKey(uploadKey: string): Promise<boolean> {

--- a/src/data_layer/public/DeckShares.ts
+++ b/src/data_layer/public/DeckShares.ts
@@ -27,6 +27,8 @@ export default interface DeckShares {
   title: string | null;
 
   card_count: number | null;
+
+  last_viewed_at: Date | null;
 }
 
 /** Represents the initializer for the table public.deck_shares */
@@ -54,6 +56,8 @@ export interface DeckSharesInitializer {
   title?: string | null;
 
   card_count?: number | null;
+
+  last_viewed_at?: Date | null;
 }
 
 /** Represents the mutator for the table public.deck_shares */
@@ -77,4 +81,6 @@ export interface DeckSharesMutator {
   title?: string | null;
 
   card_count?: number | null;
+
+  last_viewed_at?: Date | null;
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -36,6 +36,12 @@ export function resolvePath(dir: string, x: string) {
 
 export const CLEANUP_AGE_SECONDS = 7200;
 
+// How long an unrevoked deck share keeps pinning its upload in storage after
+// the last view (or creation, if never viewed). Uniform across private and
+// public shares — gating only the public path would leave the private-share
+// pin wide open (#3831).
+export const SHARE_INACTIVITY_TTL_DAYS = 90;
+
 export const ONE_HOUR = 60 * 60 * 1000;
 
 export const BUILD_DIR = path.join(__dirname, '../../web/build');

--- a/src/lib/storage/jobs/helpers/deleteNonSubScriberUploadsInDatabase.test.ts
+++ b/src/lib/storage/jobs/helpers/deleteNonSubScriberUploadsInDatabase.test.ts
@@ -9,17 +9,24 @@ function makeDb(uploadsToDelete: { key: string }[] = []) {
   const countMock = jest.fn().mockReturnValue({
     first: jest.fn().mockResolvedValue({ count: uploadsToDelete.length }),
   });
+  const revokeUpdateMock = jest.fn().mockResolvedValue(1);
+  const whereMock = jest.fn().mockReturnValue({
+    whereNull: jest.fn().mockReturnValue({ update: revokeUpdateMock }),
+  });
   const db = {
     raw: jest.fn().mockResolvedValue({ rows: uploadsToDelete }),
     uploads: jest.fn(),
+    fn: { now: jest.fn().mockReturnValue('now()') },
   } as unknown;
 
-  const dbFn = jest
-    .fn()
-    .mockReturnValue({ delete: deleteMock, count: countMock });
+  const dbFn = jest.fn().mockReturnValue({
+    delete: deleteMock,
+    count: countMock,
+    where: whereMock,
+  });
   Object.assign(dbFn, db);
 
-  return { dbFn: dbFn as any, deleteMock };
+  return { dbFn: dbFn as any, deleteMock, revokeUpdateMock };
 }
 
 function makeStorage(deleteResult = true) {
@@ -37,12 +44,15 @@ describe('deleteNonSubScriberUploadsInDatabase', () => {
   });
 
   it('deletes uploads that are not pinned by an active share', async () => {
-    const { dbFn, deleteMock } = makeDb([{ key: 'unpinned.apkg' }]);
+    const { dbFn, revokeUpdateMock } = makeDb([{ key: 'unpinned.apkg' }]);
     const storage = makeStorage();
 
     await deleteNonSubScriberUploadsInDatabase(dbFn, storage as any);
 
     expect(storage.delete).toHaveBeenCalledWith('unpinned.apkg');
+    expect(revokeUpdateMock).toHaveBeenCalledWith({
+      revoked_at: expect.anything(),
+    });
   });
 
   it('passes the NOT EXISTS subquery filtering shared uploads to db.raw', async () => {
@@ -51,9 +61,14 @@ describe('deleteNonSubScriberUploadsInDatabase', () => {
 
     await deleteNonSubScriberUploadsInDatabase(dbFn, storage as any);
 
-    const rawCall = (dbFn.raw as jest.Mock).mock.calls[0][0] as string;
+    const [rawCall, rawBindings] = (dbFn.raw as jest.Mock).mock.calls[0] as [
+      string,
+      unknown,
+    ];
     expect(rawCall).toContain('deck_shares');
     expect(rawCall).toContain('revoked_at IS NULL');
+    expect(rawCall).toContain('COALESCE(ds.last_viewed_at, ds.created_at) > ?');
+    expect(rawBindings).toEqual([expect.any(String)]);
   });
 
   it('exempts holders of an active user pass from upload deletion', async () => {
@@ -172,6 +187,11 @@ describe('deleteNonSubScriberUploadsInDatabase — cleanup-vs-subscriber e2e', (
       t.increments('id').primary();
       t.text('upload_key').notNullable();
       t.text('revoked_at').nullable();
+      // Seeded as explicit 24-char ISO strings in every test. sqlite's
+      // CURRENT_TIMESTAMP emits 'YYYY-MM-DD HH:MM:SS' (space, no Z) which does
+      // NOT compare lexicographically against the ISO cutoff binding.
+      t.text('created_at').nullable();
+      t.text('last_viewed_at').nullable();
     });
   });
 
@@ -203,11 +223,12 @@ describe('deleteNonSubScriberUploadsInDatabase — cleanup-vs-subscriber e2e', (
     // 6: expired pass, no other signal — swept
     await seedUserWithUpload(6, 'exp@example.com', false, 'expired.apkg');
     await db('user_passes').insert({ user_id: 6, expires_at: PAST });
-    // 7: non-subscriber but upload pinned by an unrevoked share — spared
+    // 7: non-subscriber but upload pinned by a fresh unrevoked share — spared
     await seedUserWithUpload(7, 'shared@example.com', false, 'shared.apkg');
     await db('deck_shares').insert({
       upload_key: 'shared.apkg',
       revoked_at: null,
+      created_at: new Date().toISOString(),
     });
     // 8: cancelled subscriber (active = false) — swept
     await seedUserWithUpload(
@@ -267,6 +288,88 @@ describe('deleteNonSubScriberUploadsInDatabase — cleanup-vs-subscriber e2e', (
 
     expect(storage.delete).not.toHaveBeenCalled();
     expect(await remainingUploadKeys()).toEqual(['sub.apkg']);
+  });
+
+  it('sweeps an upload pinned only by a share idle past the TTL and revokes the share', async () => {
+    await seedUserWithUpload(1, 'stale@example.com', false, 'stale.apkg');
+    await db('deck_shares').insert({
+      upload_key: 'stale.apkg',
+      revoked_at: null,
+      created_at: PAST,
+      last_viewed_at: PAST,
+    });
+
+    const storage = { delete: jest.fn() };
+
+    await deleteNonSubScriberUploadsInDatabase(
+      withPgRawShape(db),
+      storage as never
+    );
+
+    expect(storage.delete).toHaveBeenCalledWith('stale.apkg');
+    expect(await remainingUploadKeys()).toEqual([]);
+    const share = await db('deck_shares').first();
+    expect(share.revoked_at).not.toBeNull();
+  });
+
+  it('spares an old share that was viewed within the TTL window', async () => {
+    await seedUserWithUpload(1, 'active@example.com', false, 'active.apkg');
+    await db('deck_shares').insert({
+      upload_key: 'active.apkg',
+      revoked_at: null,
+      created_at: PAST,
+      last_viewed_at: new Date().toISOString(),
+    });
+
+    const storage = { delete: jest.fn() };
+
+    await deleteNonSubScriberUploadsInDatabase(
+      withPgRawShape(db),
+      storage as never
+    );
+
+    expect(storage.delete).not.toHaveBeenCalled();
+    expect(await remainingUploadKeys()).toEqual(['active.apkg']);
+  });
+
+  it('spares a freshly created share that has never been viewed', async () => {
+    await seedUserWithUpload(1, 'fresh@example.com', false, 'fresh.apkg');
+    await db('deck_shares').insert({
+      upload_key: 'fresh.apkg',
+      revoked_at: null,
+      created_at: new Date().toISOString(),
+      last_viewed_at: null,
+    });
+
+    const storage = { delete: jest.fn() };
+
+    await deleteNonSubScriberUploadsInDatabase(
+      withPgRawShape(db),
+      storage as never
+    );
+
+    expect(storage.delete).not.toHaveBeenCalled();
+    expect(await remainingUploadKeys()).toEqual(['fresh.apkg']);
+  });
+
+  it('sweeps a never-viewed share once its creation date passes the TTL', async () => {
+    await seedUserWithUpload(1, 'aged@example.com', false, 'aged.apkg');
+    await db('deck_shares').insert({
+      upload_key: 'aged.apkg',
+      revoked_at: null,
+      created_at: PAST,
+      last_viewed_at: null,
+    });
+
+    const storage = { delete: jest.fn() };
+
+    await deleteNonSubScriberUploadsInDatabase(
+      withPgRawShape(db),
+      storage as never
+    );
+
+    expect(storage.delete).toHaveBeenCalledWith('aged.apkg');
+    expect(await remainingUploadKeys()).toEqual([]);
   });
 
   it('spares a customer whose only paid subscription is a developer tier', async () => {

--- a/src/lib/storage/jobs/helpers/deleteNonSubScriberUploadsInDatabase.ts
+++ b/src/lib/storage/jobs/helpers/deleteNonSubScriberUploadsInDatabase.ts
@@ -1,6 +1,7 @@
 import { Knex } from 'knex';
 import StorageHandler from '../../StorageHandler';
 import Uploads from '../../../../data_layer/public/Uploads';
+import { SHARE_INACTIVITY_TTL_DAYS } from '../../../constants';
 import {
   ErrorEventRepository,
   IErrorEventRepository,
@@ -26,7 +27,18 @@ export const deleteNonSubScriberUploadsInDatabase = async (
   // developer tier reads as a free user here and has their uploads deleted from
   // the bucket irreversibly. Matching on email as well as user_id only ever
   // spares a row, so a loose match is the safe direction.
-  const query = await db.raw(`
+  // A share only pins its upload while it has been viewed (or created, if
+  // never viewed) within the TTL. Without the recency bound any free user
+  // could pin storage forever by creating a share and never revoking it
+  // (#3831). last_viewed_at is null for shares that predate the column's
+  // backfill window, so created_at is the fallback. The cutoff is computed
+  // here and bound as a parameter because sqlite (the e2e test dialect) has
+  // no interval arithmetic.
+  const sharePinCutoff = new Date(
+    Date.now() - SHARE_INACTIVITY_TTL_DAYS * 24 * 60 * 60 * 1000
+  ).toISOString();
+  const query = await db.raw(
+    `
     SELECT up.key
     FROM users u
     JOIN uploads up ON u.id = up.owner
@@ -50,9 +62,13 @@ export const deleteNonSubScriberUploadsInDatabase = async (
       )
       AND NOT EXISTS (
         SELECT 1 FROM deck_shares ds
-        WHERE ds.upload_key = up.key AND ds.revoked_at IS NULL
+        WHERE ds.upload_key = up.key
+          AND ds.revoked_at IS NULL
+          AND COALESCE(ds.last_viewed_at, ds.created_at) > ?
       );
-  `);
+  `,
+    [sharePinCutoff]
+  );
   const nonSubScriberUploads: Uploads[] | undefined = query.rows;
   if (!nonSubScriberUploads) {
     return;
@@ -78,5 +94,13 @@ export const deleteNonSubScriberUploadsInDatabase = async (
     console.info(`Deleting non-subscriber upload ${upload.key}`);
     await storage.delete(upload.key);
     await db('uploads').delete().where('key', upload.key);
+    // deck_shares.upload_key has no FK to uploads, so nothing cascades: revoke
+    // the dead pins here or /shared-decks keeps listing decks that 404.
+    // Per-upload rather than batched after the loop so a mid-loop failure
+    // can't leave already-deleted uploads with live share rows.
+    await db('deck_shares')
+      .where('upload_key', upload.key)
+      .whereNull('revoked_at')
+      .update({ revoked_at: db.fn.now() });
   }
 };

--- a/src/services/ShareService.ts
+++ b/src/services/ShareService.ts
@@ -38,7 +38,7 @@ class ShareService {
   }
 
   async recordView(share: DeckShares): Promise<void> {
-    await this.repository.incrementViewCount(share.id);
+    await this.repository.recordView(share.id);
   }
 
   buildShareUrl(token: string): string {

--- a/web/src/pages/SharedDeckPage/SharedDeckPage.test.tsx
+++ b/web/src/pages/SharedDeckPage/SharedDeckPage.test.tsx
@@ -57,7 +57,7 @@ describe('SharedDeckPage', () => {
 
     renderPage('revoked-token');
 
-    await screen.findByText('This link was turned off by the owner.');
+    await screen.findByText('This link is no longer active.');
     expect(screen.getByText(/Ask them for a new one/i)).toBeInTheDocument();
   });
 

--- a/web/src/pages/SharedDeckPage/SharedDeckPage.tsx
+++ b/web/src/pages/SharedDeckPage/SharedDeckPage.tsx
@@ -15,9 +15,7 @@ function truncateDeckName(name: string): string {
 function RevokedPage() {
   return (
     <div className={styles.errorPage}>
-      <p className={styles.errorTitle}>
-        This link was turned off by the owner.
-      </p>
+      <p className={styles.errorTitle}>This link is no longer active.</p>
       <p className={styles.errorSub}>
         Ask them for a new one, or make your own deck on 2anki.net.
       </p>

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-28-share-inactivity-ttl.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-28-share-inactivity-ttl.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-28-share-inactivity-ttl",
+  "date": "2026-07-28",
+  "type": "fix",
+  "title": "Shared deck links on free accounts expire after 90 days without a view"
+}


### PR DESCRIPTION
Closes #3831

## What

The free-tier storage cleanup (every 2 h, deletes all non-subscriber uploads) exempted any upload with an unrevoked `deck_shares` row, with no age limit — any free user could pin storage forever by creating a share (private or public) and never revoking it.

- A share now pins its upload only while `COALESCE(last_viewed_at, created_at)` is within **90 days** (`SHARE_INACTIVITY_TTL_DAYS`, uniform across private and public shares — gating only the public path would leave the private-share pin open, per the issue).
- New migration adds nullable `last_viewed_at` to `deck_shares` and backfills `now()` for unrevoked rows, so nothing expires on deploy day and the deletion-volume alarm stays quiet on the first post-deploy tick. `pnpm kanel` regenerated `DeckShares.ts` in this PR.
- `ShareRepository.incrementViewCount` → `recordView`: one atomic UPDATE bumps `view_count` and stamps `last_viewed_at` on every share-page view, refreshing the window.
- The cleanup now revokes still-active shares of each upload it deletes (per-upload, inside the loop, so a mid-loop failure can't leave dead pins live) — `/shared-decks` and the owner's shares list stop showing decks that 404. `deck_shares.upload_key` has no FK to `uploads`, so nothing cascaded before.
- Expired shares render the RevokedPage; its title no longer blames the owner for a system action: "This link is no longer active."

## Trio synthesis

- **pm**: 90-day TTL (view-refreshed, so only quarter-dead shares expire); changelog entry ships; not built: tiered TTL (paid users are already fully exempt from this cleanup), UI expiry warnings, warning emails, download-as-view, env flag. Metric: none — storage hygiene; guardrails = deletion-volume alarm quiet at deploy, GSC soft-404s for `/s/*` should fall.
- **designer**: revoked-page copy fix above; TTL surfacing in the share flow cut for this PR (needs a free/paid conditional; fast-follow if support tickets appear).
- **engineer**: ISO-string cutoff binding (sqlite e2e has no interval arithmetic), explicit ISO seeds in the e2e schema, per-upload revoke, transactional migration, no new indexes.
- Conflicts: engineer hesitated on the changelog entry — pm owns the call, entry ships. Download path not stamping views — pm locked "keep the view signal as-is", 90 d absorbs the edge.

## Reviews

- migration-reviewer: ship it — locking (metadata-only ADD COLUMN), backfill, rollback, naming, kanel all pass.
- Adversarial diff review: 0 blockers. Noted (accepted): `uploads.key` lacks a UNIQUE constraint, but `storage.delete(key)` already carried the identical same-key exposure and keys are timestamp+id generated; crash window between upload-delete and revoke is minimized by per-upload ordering.

## Tests

- sqlite e2e (runs the real raw query): idle-past-TTL share swept + revoked; old-but-recently-viewed spared; fresh never-viewed spared; aged never-viewed swept; all pre-existing paid-signal guards still green.
- Full server suite: 5926 passed; only documented environmental failures (`getPageCount` pdfinfo, `PythonExitError` parser/canary suites — no venv in worktrees).
- Full web suite: 353 files / 2766 tests passed; typecheck + lint green. `pnpm format:check` green.
- Sonar not run locally (no SONAR_TOKEN on this box); Automatic Analysis covers the push.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: machine-backed — `pnpm --filter 2anki-web test:golden-path` green (2 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
