### PR TITLE
fix: replay original conversion settings when restarting a Claude job

### DIFF
--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -1758,6 +1758,154 @@ describe('UploadService.restartClaudeJob — concurrent restart guard', () => {
   });
 });
 
+describe('UploadService.restartClaudeJob — replays original conversion settings', () => {
+  const originalWorkspaceBase = process.env.WORKSPACE_BASE;
+  let db: Knex;
+  let workspaceBase: string;
+
+  beforeAll(() => {
+    workspaceBase = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'restart-settings-base-')
+    );
+    process.env.WORKSPACE_BASE = workspaceBase;
+  });
+
+  afterAll(() => {
+    process.env.WORKSPACE_BASE = originalWorkspaceBase;
+    fs.rmSync(workspaceBase, { recursive: true, force: true });
+  });
+
+  beforeEach(async () => {
+    mockGenerateDeckInfo.mockReset();
+    db = knex({
+      client: 'better-sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    });
+    await db.schema.createTable('jobs', (t) => {
+      t.increments('id');
+      t.string('owner').notNullable();
+      t.string('object_id').notNullable();
+      t.string('title');
+      t.string('type');
+      t.string('status');
+      t.timestamp('created_at').defaultTo(db.fn.now());
+      t.timestamp('last_edited_time');
+      t.string('job_reason_failure');
+      t.integer('card_count');
+    });
+    fs.rmSync(path.join(workspaceBase, 'job-obj-settings'), {
+      recursive: true,
+      force: true,
+    });
+    const workspaceDir = path.join(workspaceBase, 'job-obj-settings');
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(workspaceDir, 'page.html'),
+      '<html><body>Q/A</body></html>'
+    );
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  function buildRestartRequest() {
+    return {
+      params: { jobId: 'job-obj-settings' },
+      body: {},
+    } as unknown as express.Request;
+  }
+
+  async function insertDoneJob() {
+    await db('jobs').insert({
+      owner: '42',
+      object_id: 'job-obj-settings',
+      title: 'Deck',
+      type: 'claude',
+      status: 'done',
+      last_edited_time: new Date(),
+    });
+  }
+
+  async function restartAndWaitForGenerate(): Promise<unknown[]> {
+    const service = new UploadService(
+      buildRepository(),
+      new JobRepository(db),
+      buildUsersRepo()
+    );
+    const generateCalled = new Promise<unknown[]>((resolve) => {
+      mockGenerateDeckInfo.mockImplementation((...args: unknown[]) => {
+        resolve(args);
+        return new Promise(() => {});
+      });
+    });
+    const { res } = buildResponse();
+    (res.locals as Record<string, unknown>).owner = 42;
+    (res.locals as Record<string, unknown>).subscriber = true;
+    await service.restartClaudeJob(buildRestartRequest(), res);
+    return generateCalled;
+  }
+
+  it('replays persisted instructions, card size, and comprehensive option', async () => {
+    await insertDoneJob();
+    fs.writeFileSync(
+      path.join(workspaceBase, 'job-obj-settings', 'conversion-settings.json'),
+      JSON.stringify({
+        'user-instructions': 'Summarize each slide into one dense card',
+        'card-size': 'detailed',
+        'ai-comprehensive': 'true',
+      })
+    );
+
+    const args = await restartAndWaitForGenerate();
+
+    expect(args[0]).toBe('<html><body>Q/A</body></html>');
+    expect(args[2]).toBe('Summarize each slide into one dense card');
+    expect(args[5]).toBe('detailed');
+    expect(args[7]).toMatchObject({
+      isPaying: true,
+      userId: 42,
+      comprehensive: true,
+    });
+  });
+
+  it('does not treat the persisted settings file as a media file', async () => {
+    await insertDoneJob();
+    fs.writeFileSync(
+      path.join(workspaceBase, 'job-obj-settings', 'conversion-settings.json'),
+      JSON.stringify({ 'card-size': 'short' })
+    );
+
+    const args = await restartAndWaitForGenerate();
+
+    expect(args[1]).toEqual([]);
+  });
+
+  it('restarts with defaults when no settings file was persisted', async () => {
+    await insertDoneJob();
+
+    const args = await restartAndWaitForGenerate();
+
+    expect(args[0]).toBe('<html><body>Q/A</body></html>');
+    expect(args[2]).toBeUndefined();
+    expect(args[7]).toMatchObject({ isPaying: true, userId: 42 });
+  });
+
+  it('restarts with defaults when the settings file is corrupt', async () => {
+    await insertDoneJob();
+    fs.writeFileSync(
+      path.join(workspaceBase, 'job-obj-settings', 'conversion-settings.json'),
+      'not json {'
+    );
+
+    const args = await restartAndWaitForGenerate();
+
+    expect(args[0]).toBe('<html><body>Q/A</body></html>');
+    expect(args[2]).toBeUndefined();
+  });
+});
+
 describe('UploadService.handleUpload — claude flag does not bypass the card limit', () => {
   const originalWorkspaceBase = process.env.WORKSPACE_BASE;
 
@@ -1863,6 +2011,48 @@ describe('UploadService.handleUpload — claude flag does not bypass the card li
     expect(create).toHaveBeenCalled();
     expect(capturedStatus()).toBe(202);
     expect(capturedJson()).toEqual({ jobId: 'test-ws-id' });
+  });
+
+  it('persists the conversion settings body into the workspace for restarts', async () => {
+    const previousLocation = mockWorkspaceLocation;
+    mockWorkspaceLocation = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'ws-settings-persist-')
+    );
+    try {
+      const usersRepo = buildUsersRepo();
+      const { repo: jobRepo } = buildJobRepo();
+
+      const service = new UploadService(buildRepository(), jobRepo, usersRepo);
+      const req = buildRequest({
+        body: {
+          'claude-ai-flashcards': 'true',
+          'user-instructions': 'Summarize each slide into one dense card',
+          'card-size': 'detailed',
+          'ai-comprehensive': 'true',
+        },
+      });
+      const { res, capturedStatus } = buildResponse();
+      (res.locals as Record<string, unknown>).owner = 42;
+      (res.locals as Record<string, unknown>).subscriber = true;
+
+      await service.handleUpload(req, res);
+
+      expect(capturedStatus()).toBe(202);
+      const saved = JSON.parse(
+        fs.readFileSync(
+          path.join(mockWorkspaceLocation, 'conversion-settings.json'),
+          'utf8'
+        )
+      );
+      expect(saved).toMatchObject({
+        'user-instructions': 'Summarize each slide into one dense card',
+        'card-size': 'detailed',
+        'ai-comprehensive': 'true',
+      });
+    } finally {
+      fs.rmSync(mockWorkspaceLocation, { recursive: true, force: true });
+      mockWorkspaceLocation = previousLocation;
+    }
   });
 });
 

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -196,6 +196,54 @@ function hasSessionToken(req: express.Request): boolean {
   return typeof token === 'string' && token.length > 0;
 }
 
+const CONVERSION_SETTINGS_FILENAME = 'conversion-settings.json';
+
+function persistConversionSettings(workspaceDir: string, body: unknown): void {
+  try {
+    const entries = Object.entries(
+      (body ?? {}) as Record<string, unknown>
+    ).filter(
+      (entry): entry is [string, string] => typeof entry[1] === 'string'
+    );
+    fs.writeFileSync(
+      path.join(workspaceDir, CONVERSION_SETTINGS_FILENAME),
+      JSON.stringify(Object.fromEntries(entries))
+    );
+  } catch (error) {
+    console.warn('[UploadService] failed to persist conversion settings', {
+      workspaceDir,
+      error,
+    });
+  }
+}
+
+function loadPersistedConversionSettings(
+  workspaceDir: string
+): CardOption | null {
+  const settingsPath = path.join(workspaceDir, CONVERSION_SETTINGS_FILENAME);
+  try {
+    if (!fs.existsSync(settingsPath)) {
+      return null;
+    }
+    const parsed: unknown = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null;
+    }
+    const input = Object.fromEntries(
+      Object.entries(parsed).filter(
+        (entry): entry is [string, string] => typeof entry[1] === 'string'
+      )
+    );
+    return new CardOption(input);
+  } catch (error) {
+    console.warn('[UploadService] ignoring unreadable conversion settings', {
+      workspaceDir,
+      error,
+    });
+    return null;
+  }
+}
+
 function walkHtmlFiles(dir: string): string[] {
   const results: string[] = [];
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -218,7 +266,8 @@ function walkMediaFiles(dir: string): string[] {
     } else if (
       !isHTMLFile(entry.name) &&
       !isMarkdownFile(entry.name) &&
-      !entry.name.endsWith('.apkg')
+      !entry.name.endsWith('.apkg') &&
+      entry.name !== CONVERSION_SETTINGS_FILENAME
     ) {
       results.push(entry.name);
     }
@@ -556,14 +605,27 @@ class UploadService {
       throw new Error('No HTML files found in workspace');
     }
 
+    const settings = loadPersistedConversionSettings(workspaceDir);
+    const ownerNumeric = Number(owner);
+    const generateOptions = {
+      isPaying: paying,
+      userId:
+        Number.isFinite(ownerNumeric) && ownerNumeric > 0 ? ownerNumeric : null,
+      comprehensive: settings?.aiComprehensive,
+    };
+
     const deckInfoArrays: DeckInfo[][] = [];
     for (const htmlFile of htmlFiles) {
       const content = await fs.promises.readFile(htmlFile, 'utf8');
       const deckInfo = await generateDeckInfo(
         content,
         mediaFiles,
-        undefined,
-        onProgress
+        settings?.userInstructions,
+        onProgress,
+        settings?.cardStyle || undefined,
+        settings?.cardSize,
+        settings?.fieldMapping,
+        generateOptions
       );
       deckInfoArrays.push(deckInfo);
     }
@@ -817,6 +879,7 @@ class UploadService {
     const title =
       files.length === 1 ? files[0].originalname : `${files.length} files`;
     await this.jobRepository.create(ws.id, owner, title, 'claude');
+    persistConversionSettings(ws.location, req.body);
 
     const ownerForEvent = Number(owner);
     track('conversion_started', {

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-28-restart-keeps-settings.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-28-restart-keeps-settings.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-28-restart-keeps-settings",
+  "date": "2026-07-28",
+  "type": "fix",
+  "title": "Restarting a conversion keeps your AI instructions, card size, and comprehensive mode"
+}


### PR DESCRIPTION
Closes #3914

## Problem

Investigating the two angry `downloads/deck_done` emoji feedbacks (26–27 Jul) showed the German one followed this chain: first Claude conversion attempt failed to parse → user clicked **Restart** on the Downloads page → the restarted conversion ran `generateDeckInfo(content, mediaFiles, undefined, onProgress)`, dropping the user's instructions, card size, card style, field mapping, and the comprehensive option. Prod logs show the original call with `hasUserInstructions: true` and the post-restart call with `hasUserInstructions: false`, two minutes before the negative feedback landed.

## Fix

- `handleAsyncUpload` persists the upload's settings body (string values only) as `conversion-settings.json` in the job workspace — the same directory the restart flow already requires to exist.
- `runClaudeRestart` rebuilds `CardOption` from that file and passes the full argument list to `generateDeckInfo`, including `{ isPaying, userId, comprehensive }`.
- `walkMediaFiles` excludes the settings file so it is not offered to Claude as a media asset.
- A missing or corrupt settings file degrades to the previous behavior (defaults), never fails the restart.

## Tests

- New: replays persisted instructions/card size/comprehensive on restart; settings file not treated as media; defaults when file missing; defaults when file corrupt; async upload writes the settings file.
- Full server suite: 6008 passed, only the documented environmental `getPageCount` (pdfinfo) failures.
- Full web suite: 2766 passed.
- `pnpm format:check` clean tree-wide.

Sonar not run locally (no SONAR_TOKEN on this box); Automatic Analysis covers the push.

Browser check: not applicable — web diff is a changelog entry only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
