### PR TITLE
fix: replay the PDF-image-fallback flag when restarting a job

### DIFF
--- a/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
+++ b/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
@@ -33,6 +33,7 @@ import CustomExporter from '../../../lib/parser/exporters/CustomExporter';
 import Workspace from '../../../lib/parser/WorkSpace';
 import path from 'path';
 import { writeWorkspaceFile } from './writeWorkspaceFile';
+import { writePdfImageFallbackMarker } from './pdfImageFallbackMarker';
 
 const HTML_GENERATION_CONCURRENCY = 3;
 
@@ -444,6 +445,10 @@ export async function PrepareDeck(
     console.log('[PrepareDeck] Claude branch: files written', {
       durationMs: Date.now() - tWrite,
     });
+
+    writePdfImageFallbackMarker(input.workspace.location, [
+      ...pdfImageFallbackNames,
+    ]);
 
     const userInstructions = input.settings.userInstructions;
     const cardStyle = input.settings.cardStyle || undefined;

--- a/src/infrastracture/adapters/fileConversion/pdfImageFallbackMarker.test.ts
+++ b/src/infrastracture/adapters/fileConversion/pdfImageFallbackMarker.test.ts
@@ -1,0 +1,116 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  CONVERSION_FALLBACK_FILENAME,
+  writePdfImageFallbackMarker,
+  loadPdfImageFallbackNames,
+  matchesPdfImageFallback,
+} from './pdfImageFallbackMarker';
+
+describe('pdfImageFallbackMarker', () => {
+  let workspaceDir: string;
+
+  beforeEach(() => {
+    workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fallback-marker-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  it('writes the fallback names as a JSON array and reads them back', () => {
+    writePdfImageFallbackMarker(workspaceDir, [
+      'scan.pdf.html',
+      'notes/second.pdf.html',
+    ]);
+
+    const written = JSON.parse(
+      fs.readFileSync(
+        path.join(workspaceDir, CONVERSION_FALLBACK_FILENAME),
+        'utf8'
+      )
+    );
+    expect(written).toEqual(['scan.pdf.html', 'notes/second.pdf.html']);
+    expect(loadPdfImageFallbackNames(workspaceDir)).toEqual(
+      new Set(['scan.pdf.html', 'notes/second.pdf.html'])
+    );
+  });
+
+  it('does not write a marker when there are no fallback names', () => {
+    writePdfImageFallbackMarker(workspaceDir, []);
+
+    expect(
+      fs.existsSync(path.join(workspaceDir, CONVERSION_FALLBACK_FILENAME))
+    ).toBe(false);
+  });
+
+  it('returns an empty set when the marker is missing', () => {
+    expect(loadPdfImageFallbackNames(workspaceDir)).toEqual(new Set());
+  });
+
+  it('returns an empty set when the marker is corrupt', () => {
+    fs.writeFileSync(
+      path.join(workspaceDir, CONVERSION_FALLBACK_FILENAME),
+      'not json {'
+    );
+
+    expect(loadPdfImageFallbackNames(workspaceDir)).toEqual(new Set());
+  });
+
+  it('returns an empty set when the marker is not a JSON array', () => {
+    fs.writeFileSync(
+      path.join(workspaceDir, CONVERSION_FALLBACK_FILENAME),
+      JSON.stringify({ scan: true })
+    );
+
+    expect(loadPdfImageFallbackNames(workspaceDir)).toEqual(new Set());
+  });
+
+  it('matches an html file by its basename against the marker set', () => {
+    const names = new Set(['scan.pdf.html']);
+
+    expect(
+      matchesPdfImageFallback(
+        path.join(workspaceDir, 'scan.pdf.html'),
+        workspaceDir,
+        names
+      )
+    ).toBe(true);
+  });
+
+  it('matches an html file by its workspace-relative path', () => {
+    const names = new Set(['notes/second.pdf.html']);
+
+    expect(
+      matchesPdfImageFallback(
+        path.join(workspaceDir, 'notes', 'second.pdf.html'),
+        workspaceDir,
+        names
+      )
+    ).toBe(true);
+  });
+
+  it('does not match an html file that is not in the marker set', () => {
+    const names = new Set(['scan.pdf.html']);
+
+    expect(
+      matchesPdfImageFallback(
+        path.join(workspaceDir, 'page.html'),
+        workspaceDir,
+        names
+      )
+    ).toBe(false);
+  });
+
+  it('never matches when the marker set is empty', () => {
+    expect(
+      matchesPdfImageFallback(
+        path.join(workspaceDir, 'scan.pdf.html'),
+        workspaceDir,
+        new Set()
+      )
+    ).toBe(false);
+  });
+});

--- a/src/infrastracture/adapters/fileConversion/pdfImageFallbackMarker.ts
+++ b/src/infrastracture/adapters/fileConversion/pdfImageFallbackMarker.ts
@@ -1,0 +1,73 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const CONVERSION_FALLBACK_FILENAME = 'conversion-fallback.json';
+
+export function writePdfImageFallbackMarker(
+  workspaceDir: string,
+  fallbackNames: string[]
+): void {
+  if (fallbackNames.length === 0) {
+    return;
+  }
+  try {
+    fs.writeFileSync(
+      path.join(workspaceDir, CONVERSION_FALLBACK_FILENAME),
+      JSON.stringify(fallbackNames)
+    );
+  } catch (error) {
+    console.warn('[pdfImageFallbackMarker] failed to persist fallback marker', {
+      workspaceDir,
+      error,
+    });
+  }
+}
+
+export function loadPdfImageFallbackNames(workspaceDir: string): Set<string> {
+  const markerPath = path.join(workspaceDir, CONVERSION_FALLBACK_FILENAME);
+  try {
+    if (!fs.existsSync(markerPath)) {
+      return new Set();
+    }
+    const parsed: unknown = JSON.parse(fs.readFileSync(markerPath, 'utf8'));
+    if (!Array.isArray(parsed)) {
+      return new Set();
+    }
+    return new Set(
+      parsed.filter((name): name is string => typeof name === 'string')
+    );
+  } catch (error) {
+    console.warn(
+      '[pdfImageFallbackMarker] ignoring unreadable fallback marker',
+      {
+        workspaceDir,
+        error,
+      }
+    );
+    return new Set();
+  }
+}
+
+export function matchesPdfImageFallback(
+  htmlFilePath: string,
+  workspaceDir: string,
+  fallbackNames: Set<string>
+): boolean {
+  if (fallbackNames.size === 0) {
+    return false;
+  }
+  const relative = path
+    .relative(workspaceDir, htmlFilePath)
+    .replaceAll('\\', '/');
+  const base = path.basename(htmlFilePath);
+  for (const marker of fallbackNames) {
+    const normalized = marker.replaceAll('\\', '/');
+    if (normalized === relative || normalized === base) {
+      return true;
+    }
+    if (normalized.split('/').pop() === base) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -1906,6 +1906,150 @@ describe('UploadService.restartClaudeJob — replays original conversion setting
   });
 });
 
+describe('UploadService.restartClaudeJob — replays the PDF-image-fallback flag', () => {
+  const originalWorkspaceBase = process.env.WORKSPACE_BASE;
+  let db: Knex;
+  let workspaceBase: string;
+
+  beforeAll(() => {
+    workspaceBase = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'restart-fallback-base-')
+    );
+    process.env.WORKSPACE_BASE = workspaceBase;
+  });
+
+  afterAll(() => {
+    process.env.WORKSPACE_BASE = originalWorkspaceBase;
+    fs.rmSync(workspaceBase, { recursive: true, force: true });
+  });
+
+  beforeEach(async () => {
+    mockGenerateDeckInfo.mockReset();
+    db = knex({
+      client: 'better-sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    });
+    await db.schema.createTable('jobs', (t) => {
+      t.increments('id');
+      t.string('owner').notNullable();
+      t.string('object_id').notNullable();
+      t.string('title');
+      t.string('type');
+      t.string('status');
+      t.timestamp('created_at').defaultTo(db.fn.now());
+      t.timestamp('last_edited_time');
+      t.string('job_reason_failure');
+      t.integer('card_count');
+    });
+    fs.rmSync(path.join(workspaceBase, 'job-obj-fallback'), {
+      recursive: true,
+      force: true,
+    });
+    const workspaceDir = path.join(workspaceBase, 'job-obj-fallback');
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(workspaceDir, 'scan.pdf.html'),
+      '<html><body><img src="scan.pdf/page-1.png" /></body></html>'
+    );
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  function buildRestartRequest() {
+    return {
+      params: { jobId: 'job-obj-fallback' },
+      body: {},
+    } as unknown as express.Request;
+  }
+
+  async function insertDoneJob() {
+    await db('jobs').insert({
+      owner: '42',
+      object_id: 'job-obj-fallback',
+      title: 'Deck',
+      type: 'claude',
+      status: 'done',
+      last_edited_time: new Date(),
+    });
+  }
+
+  async function restartAndWaitForGenerate(): Promise<unknown[]> {
+    const service = new UploadService(
+      buildRepository(),
+      new JobRepository(db),
+      buildUsersRepo()
+    );
+    const generateCalled = new Promise<unknown[]>((resolve) => {
+      mockGenerateDeckInfo.mockImplementation((...args: unknown[]) => {
+        resolve(args);
+        return new Promise(() => {});
+      });
+    });
+    const { res } = buildResponse();
+    (res.locals as Record<string, unknown>).owner = 42;
+    (res.locals as Record<string, unknown>).subscriber = true;
+    await service.restartClaudeJob(buildRestartRequest(), res);
+    return generateCalled;
+  }
+
+  it('passes pdfImageFallback for a file listed in the fallback marker', async () => {
+    await insertDoneJob();
+    fs.writeFileSync(
+      path.join(workspaceBase, 'job-obj-fallback', 'conversion-fallback.json'),
+      JSON.stringify(['scan.pdf.html'])
+    );
+
+    const args = await restartAndWaitForGenerate();
+
+    expect(args[7]).toMatchObject({
+      isPaying: true,
+      userId: 42,
+      pdfImageFallback: {
+        mediaBaseDir: path.join(workspaceBase, 'job-obj-fallback'),
+      },
+    });
+  });
+
+  it('does not pass pdfImageFallback when no marker was persisted', async () => {
+    await insertDoneJob();
+
+    const args = await restartAndWaitForGenerate();
+
+    expect(
+      (args[7] as { pdfImageFallback?: unknown }).pdfImageFallback
+    ).toBeUndefined();
+  });
+
+  it('does not pass pdfImageFallback when the marker is corrupt', async () => {
+    await insertDoneJob();
+    fs.writeFileSync(
+      path.join(workspaceBase, 'job-obj-fallback', 'conversion-fallback.json'),
+      'not json {'
+    );
+
+    const args = await restartAndWaitForGenerate();
+
+    expect(
+      (args[7] as { pdfImageFallback?: unknown }).pdfImageFallback
+    ).toBeUndefined();
+  });
+
+  it('does not treat the fallback marker file as a media file', async () => {
+    await insertDoneJob();
+    fs.writeFileSync(
+      path.join(workspaceBase, 'job-obj-fallback', 'conversion-fallback.json'),
+      JSON.stringify(['scan.pdf.html'])
+    );
+
+    const args = await restartAndWaitForGenerate();
+
+    expect(args[1]).toEqual([]);
+  });
+});
+
 describe('UploadService.handleUpload — claude flag does not bypass the card limit', () => {
   const originalWorkspaceBase = process.env.WORKSPACE_BASE;
 

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -30,6 +30,11 @@ import {
   CONVERSION_TRUNCATED_MESSAGE,
   FileConversionError,
 } from '../infrastracture/adapters/fileConversion/claudeFileConversion';
+import {
+  CONVERSION_FALLBACK_FILENAME,
+  loadPdfImageFallbackNames,
+  matchesPdfImageFallback,
+} from '../infrastracture/adapters/fileConversion/pdfImageFallbackMarker';
 import type {
   ConversionScoreSource,
   IConversionRuleScoresRepository,
@@ -267,7 +272,8 @@ function walkMediaFiles(dir: string): string[] {
       !isHTMLFile(entry.name) &&
       !isMarkdownFile(entry.name) &&
       !entry.name.endsWith('.apkg') &&
-      entry.name !== CONVERSION_SETTINGS_FILENAME
+      entry.name !== CONVERSION_SETTINGS_FILENAME &&
+      entry.name !== CONVERSION_FALLBACK_FILENAME
     ) {
       results.push(entry.name);
     }
@@ -606,6 +612,7 @@ class UploadService {
     }
 
     const settings = loadPersistedConversionSettings(workspaceDir);
+    const fallbackNames = loadPdfImageFallbackNames(workspaceDir);
     const ownerNumeric = Number(owner);
     const generateOptions = {
       isPaying: paying,
@@ -617,6 +624,16 @@ class UploadService {
     const deckInfoArrays: DeckInfo[][] = [];
     for (const htmlFile of htmlFiles) {
       const content = await fs.promises.readFile(htmlFile, 'utf8');
+      const options = matchesPdfImageFallback(
+        htmlFile,
+        workspaceDir,
+        fallbackNames
+      )
+        ? {
+            ...generateOptions,
+            pdfImageFallback: { mediaBaseDir: workspaceDir },
+          }
+        : generateOptions;
       const deckInfo = await generateDeckInfo(
         content,
         mediaFiles,
@@ -625,7 +642,7 @@ class UploadService {
         settings?.cardStyle || undefined,
         settings?.cardSize,
         settings?.fieldMapping,
-        generateOptions
+        options
       );
       deckInfoArrays.push(deckInfo);
     }

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-29-restart-scanned-pdf.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-29-restart-scanned-pdf.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-29-restart-scanned-pdf",
+  "date": "2026-07-29",
+  "type": "fix",
+  "title": "Restarting a conversion of a scanned PDF works again"
+}


### PR DESCRIPTION
## What
Restarting a Claude conversion of a scanned/unextractable PDF now re-supplies the PDF-image-fallback flag, so the restart routes to the multimodal vision path instead of failing with `ImageOnlyContentError`.

## Why
Closes #3916. A PDF whose text layer is not machine-extractable falls back in `PrepareDeck` to `convertPDFToImages`, producing HTML that is one `<img>` per page with no text. `PrepareDeck` passes `options.pdfImageFallback = { mediaBaseDir }` so `generateDeckInfo` skips `isImageOnlyContent` and uses `generateDeckInfoFromPdfImages`. The restart path (`runClaudeRestart`) never re-supplied that flag, so restarting such a job hit `isImageOnlyContent` and failed with `ImageOnlyContentError` — the user could not recover the job by restarting it. PR #3915 fixed the sibling gap (replaying persisted conversion settings); this closes the fallback-flag gap.

## How
- `PrepareDeck`'s Claude branch persists a `conversion-fallback.json` marker (a JSON array of the fallback HTML file names) whenever `pdfImageFallbackNames` is non-empty.
- `runClaudeRestart` reads the marker (missing/corrupt tolerated → no fallback, current behavior) and passes `options.pdfImageFallback = { mediaBaseDir: workspaceDir }` for each html file whose basename/relative path matches a marker entry.
- `walkMediaFiles` excludes `conversion-fallback.json` (mirrors the existing `conversion-settings.json` exclusion) so the marker never ships as Anki media.
- Marker read/write/match logic lives in one shared helper (`pdfImageFallbackMarker.ts`) used by both sides.

No change to LLM prompts, token budget, or the vision path itself — this only re-selects the already-shipped path on restart. Cost/latency of a restarted scanned-PDF conversion matches the original one-vision-call-per-page path (unchanged); a restart that previously failed instantly now does the same multimodal work it should have.

## Measuring success
Restarted scanned-PDF jobs stop terminating with `ImageOnlyContentError`. In prod logs, `[PrepareDeck] convertFile pdf→images` conversions that are later restarted should show the vision path running on restart rather than the job status flipping to `failed` with an image-only reason.

## Testing
- Unit tests added:
  - `pdfImageFallbackMarker.test.ts` — write/load/match, including missing, corrupt, and non-array markers, basename and relative-path matching (9 tests).
  - `UploadService.test.ts` — restart passes `pdfImageFallback: { mediaBaseDir }` for a marked file; no marker → no fallback; corrupt marker → no throw, no fallback; marker not offered as a media file (4 tests).
- Full server suite: **5950 passed, 73 failed, 26 skipped, 7 todo (6056 total); 646 suites passed, 8 failed.** All 8 failing suites are the documented worktree-environmental failures — `getPageCount` (needs `pdfinfo`) and the `PythonExitError` suites (`DeckParser.*`, `golden/conversionGolden`, `canary/*`) that build real `.apkg` via the genanki venv absent in worktrees. None touch this change.
- `npx tsc -p . --noEmit`: clean.
- `pnpm format:check` (tree-wide CI command): clean.
- Sonar not run locally; Automatic Analysis covers the push.

## Browser check
Browser check: not applicable — web diff is a changelog entry only

## Changelog
`Restarting a conversion of a scanned PDF works again`

## Risks
Low. The marker read is fully tolerant (missing/corrupt → current behavior, no fallback), so a job without a marker restarts exactly as before. The only new file written into the workspace is `conversion-fallback.json`, excluded from media walking. Rollback is a straight revert.

## Goal alignment
Retention/per-user value: paying Claude users hitting an unrecoverable restart on scanned PDFs is a direct frustration on a paid path. This makes the restart button actually recover the job — no funnel metric, internal reliability on the paid conversion path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
