### PR TITLE
fix: stamp updated_at on every subscriptions write

### DIFF
--- a/src/lib/integrations/stripe.test.ts
+++ b/src/lib/integrations/stripe.test.ts
@@ -52,6 +52,8 @@ describe('updateStoreSubscription', () => {
       t.json('payload');
       t.string('stripe_product_id');
       t.string('linked_email');
+      t.timestamp('created_at');
+      t.timestamp('updated_at');
     });
     await db.schema.createTable('developer_tiers', (t) => {
       t.increments('id');
@@ -305,6 +307,8 @@ describe('updateStoreSubscription linked_email resolution', () => {
       t.json('payload');
       t.string('stripe_product_id');
       t.string('linked_email');
+      t.timestamp('created_at');
+      t.timestamp('updated_at');
     });
     await db.schema.createTable('developer_tiers', (t) => {
       t.increments('id');
@@ -405,6 +409,8 @@ describe('updateStoreSubscription developer tiers', () => {
       t.json('payload');
       t.string('stripe_product_id');
       t.string('linked_email');
+      t.timestamp('created_at');
+      t.timestamp('updated_at');
     });
     await db.schema.createTable('developer_tiers', (t) => {
       t.increments('id');

--- a/src/lib/integrations/stripe.ts
+++ b/src/lib/integrations/stripe.ts
@@ -215,6 +215,7 @@ export const updateStoreSubscription = async (
     active: shouldRemainActive,
     payload: JSON.stringify(subscription),
     stripe_product_id: stripeProductId,
+    updated_at: new Date(),
   };
   if (linkedEmail != null) {
     mergeColumns.linked_email = linkedEmail;

--- a/src/lib/storage/jobs/helpers/reconcileActiveSubscriptions.test.ts
+++ b/src/lib/storage/jobs/helpers/reconcileActiveSubscriptions.test.ts
@@ -48,7 +48,7 @@ describe('reconcileActiveSubscriptions', () => {
 
     expect(stripe.subscriptions.retrieve).toHaveBeenCalledWith('sub_1');
     expect(db.updateSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ active: false })
+      expect.objectContaining({ active: false, updated_at: expect.any(Date) })
     );
   });
 
@@ -82,7 +82,7 @@ describe('reconcileActiveSubscriptions', () => {
     await reconcileActiveSubscriptions(db as any, stripe);
 
     expect(db.updateSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ active: false })
+      expect.objectContaining({ active: false, updated_at: expect.any(Date) })
     );
   });
 
@@ -102,7 +102,7 @@ describe('reconcileActiveSubscriptions', () => {
     await reconcileActiveSubscriptions(db as any, stripe);
 
     expect(db.updateSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ active: false })
+      expect.objectContaining({ active: false, updated_at: expect.any(Date) })
     );
   });
 

--- a/src/lib/storage/jobs/helpers/reconcileActiveSubscriptions.ts
+++ b/src/lib/storage/jobs/helpers/reconcileActiveSubscriptions.ts
@@ -51,7 +51,10 @@ async function deactivateRow(
   row: ActiveSubscriptionRow,
   subscription?: StripeTypes.Subscription
 ): Promise<void> {
-  const update: { active: boolean; payload?: string } = { active: false };
+  const update: { active: boolean; payload?: string; updated_at: Date } = {
+    active: false,
+    updated_at: new Date(),
+  };
   if (subscription) {
     update.payload = JSON.stringify(subscription);
   }

--- a/src/lib/storage/jobs/helpers/updateStripeSubscriptions.test.ts
+++ b/src/lib/storage/jobs/helpers/updateStripeSubscriptions.test.ts
@@ -161,6 +161,32 @@ describe('updateStripeSubscriptions — batch provisioning fields', () => {
     );
   });
 
+  it('stamps updated_at when a subscription changes active status', async () => {
+    const { updateSubscriptionSpy } = setupDbMock({
+      email: 'user@example.com',
+      active: false,
+      payload: '{}',
+    });
+    setupStripeMock([buildSubscription('prod_autoSync789')]);
+    await updateStripeSubscriptions();
+    expect(updateSubscriptionSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ active: true, updated_at: expect.any(Date) })
+    );
+  });
+
+  it('stamps updated_at when a subscription is refreshed without a status change', async () => {
+    const { updateSubscriptionSpy } = setupDbMock({
+      email: 'user@example.com',
+      active: true,
+      payload: '{}',
+    });
+    setupStripeMock([buildSubscription('prod_autoSync789')]);
+    await updateStripeSubscriptions();
+    expect(updateSubscriptionSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ updated_at: expect.any(Date) })
+    );
+  });
+
   it('backfills users.stripe_customer_id for a new subscription', async () => {
     const { updateUsersSpy } = setupDbMock(null);
     setupStripeMock([buildSubscription()]);

--- a/src/lib/storage/jobs/helpers/updateStripeSubscriptions.ts
+++ b/src/lib/storage/jobs/helpers/updateStripeSubscriptions.ts
@@ -139,15 +139,17 @@ async function updateExistingSubscription(
       active: shouldRemainActive,
       payload,
       stripe_product_id: stripeProductId,
+      updated_at: new Date(),
     });
   } else {
     console.info(
       `Subscription status for email=${shortHash(email)} remains ${shouldRemainActive ? 'active' : 'inactive'}`
     );
-    await db
-      .table('subscriptions')
-      .where({ email })
-      .update({ payload, stripe_product_id: stripeProductId });
+    await db.table('subscriptions').where({ email }).update({
+      payload,
+      stripe_product_id: stripeProductId,
+      updated_at: new Date(),
+    });
   }
 }
 

--- a/src/services/SubscriptionService.test.ts
+++ b/src/services/SubscriptionService.test.ts
@@ -274,12 +274,25 @@ describe('SubscriptionService.cancelUserSubscriptions', () => {
     const updatePayload = db.updateSpy.mock.calls[0][0] as {
       active: boolean;
       payload: string;
+      updated_at: Date;
     };
     expect(updatePayload.active).toBe(false);
     expect(JSON.parse(updatePayload.payload).status).toBe('canceled');
+    expect(updatePayload.updated_at).toBeInstanceOf(Date);
     expect(db.whereRawSpy).toHaveBeenCalledWith("payload->>'id' = ?", [
       'sub_123',
     ]);
+  });
+
+  it('stamps updated_at when deactivating a row by id', async () => {
+    const db = buildDbMock();
+    (getDatabase as jest.Mock).mockReturnValue(db);
+
+    await new SubscriptionService().deactivateSubscription(4374);
+
+    expect(db.updateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ active: false, updated_at: expect.any(Date) })
+    );
   });
 
   it('does not touch the DB for period_end cancel', async () => {
@@ -451,9 +464,11 @@ describe('SubscriptionService.cancelSubscriptionById', () => {
     const updatePayload = db.updateSpy.mock.calls[0][0] as {
       active: boolean;
       payload: string;
+      updated_at: Date;
     };
     expect(updatePayload.active).toBe(false);
     expect(JSON.parse(updatePayload.payload).status).toBe('canceled');
+    expect(updatePayload.updated_at).toBeInstanceOf(Date);
   });
 
   it('does not touch the DB for period_end cancel', async () => {

--- a/src/services/SubscriptionService.ts
+++ b/src/services/SubscriptionService.ts
@@ -17,6 +17,7 @@ async function softDeleteLocalSubscription(
     .update({
       active: false,
       payload: JSON.stringify(canceledPayload),
+      updated_at: new Date(),
     });
 }
 
@@ -287,7 +288,7 @@ export class SubscriptionService {
 
     await database('subscriptions')
       .where({ id: subscriptionId })
-      .update({ active: false });
+      .update({ active: false, updated_at: new Date() });
   }
 }
 


### PR DESCRIPTION
## The bug

Every write path that updates the `subscriptions` table omitted `updated_at`, so the column has never moved off its insert default. On prod:

- **852** inactive rows, **all** with `updated_at = created_at`
- **0** rows with `updated_at > created_at`

Against 727 active rows and a documented ~73 cancellations per 30 days, zero updated timestamps is not a coincidence — the column is simply never maintained. There's no history table either, so the moment any subscription flipped active or inactive is unrecoverable.

`DeveloperSubscriptionsRepository.ts:84` already does this correctly (`.update({ active: false, updated_at: this.knex.fn.now() })`). The main table was the outlier.

## Why it mattered today

While investigating a cancellation, the frozen timestamp read as *"this row was created inactive in Nov 2024 and never touched"* — which points straight at a subscriber who paid for twenty months without ever receiving paid features. Serious enough to warrant a refund conversation.

The real explanation was that the column is never maintained, and the row had been deactivated normally minutes earlier by their cancellation. **A diagnostic signal that inverts the conclusion is worse than no signal at all** — that's what this fixes.

## The change

All five update paths now stamp `updated_at`:

| File | Path |
|---|---|
| `SubscriptionService.ts` | `softDeleteLocalSubscription` (immediate cancel) |
| `SubscriptionService.ts` | `deactivateSubscription` (by row id) |
| `updateStripeSubscriptions.ts` | `updateExistingSubscription`, status-changed branch |
| `updateStripeSubscriptions.ts` | `updateExistingSubscription`, refresh branch |
| `reconcileActiveSubscriptions.ts` | `deactivateRow` (the startup sweep) |
| `stripe.ts` | `updateStoreSubscription`'s upsert `.merge()` |

Uses `new Date()` rather than `knex.fn.now()` — the job helpers receive a mocked `db` with no `fn`, and app-clock vs DB-clock is indistinguishable here (same box). Inserts are untouched; the column default already handles those.

No migration — `updated_at` has existed on this table all along, it was just never written.

## Tests

Written failing first, and they failed for the right reason (`Received: {"active": false}` — the field simply absent), then made to pass:

- `SubscriptionService.test.ts` — both soft-delete tests assert `updated_at instanceof Date`; new test for `deactivateSubscription`
- `reconcileActiveSubscriptions.test.ts` — all three deactivation assertions extended
- `updateStripeSubscriptions.test.ts` — two new tests, one per branch (status-changed and refresh)

The sqlite fixtures in `stripe.test.ts` gained `created_at`/`updated_at`. Worth noting these are **real-database** integration tests, and they caught the missing column immediately — the fixture had drifted from the migration, which is exactly the gap `.claude/rules/testing.md` warns about for mocked-repo-only coverage.

## Verification

- **Full server suite: 653 suites / 6031 tests passed.** Only failure is the documented environmental `getPageCount.test.ts` (needs `pdfinfo`).
- `npx tsc -p . --noEmit` — exit 0.
- `pnpm format:check` — clean tree-wide (3840 files).
- Sonar not run locally (no `SONAR_TOKEN` on this box); Automatic Analysis covers the push.

This touches Stripe integration files, so flagging it explicitly: the diff adds a timestamp field to existing update payloads and changes no gate, no query predicate, and no access decision. `isPaying` and `hasAnkifyAccess` read `active`, which is untouched.

Browser check: not applicable — no `web/src/` files in the diff.

No changelog entry — internal data-integrity fix, no user-visible behavior change.
