### PR TITLE
fix: make the production heap ceiling actually reach the process

### DIFF
--- a/ecosystem.blue-green.config.js
+++ b/ecosystem.blue-green.config.js
@@ -1,10 +1,33 @@
-// Blue-green variant of ecosystem.config.js. Two identical apps on two ports;
-// the deploy script (scripts/deploy-blue-green.sh) starts exactly one at a time
-// with `pm2 start ecosystem.blue-green.config.js --only server-<color>`.
+// Blue-green variant. Two identical apps on two ports; the deploy script
+// (scripts/deploy-blue-green.sh) starts exactly one at a time with
+// `pm2 start ecosystem.blue-green.config.js --only server-<color>`.
 //
-// This file is NOT used by the automated deploy yet. The live workflow still
-// uses the single-app ecosystem.config.js. See Documentation/deploy/blue-green.md
-// for the rollout plan and the manual Apache steps this pairs with.
+// This IS the live deploy path — deploy.2anki.net.yml runs deploy-blue-green.sh,
+// which reads this file. There is no ecosystem.config.js in the repo.
+// See Documentation/deploy/blue-green.md for the Apache pairing.
+
+// V8 sizes its heap from argv/NODE_OPTIONS at boot, so the ceiling has to reach
+// the process before node starts. Two channels are declared because the obvious
+// one silently does not work here:
+//
+//   node_args  — pm2 stores it (`pm2 describe` prints the interpreter arg) but
+//                did not put it on the spawned command line. On 2026-07-29 the
+//                live process ran as a bare `node src/server.js` while pm2
+//                reported --max-old-space-size=16384, so the real limit was
+//                node's ~4144MB default. The main thread OOM-crashed at 4189MB
+//                (FATAL ERROR: NewSpace::EnsureCurrentCapacity) and pm2 restarted
+//                it. Prior OOMs on 2026-07-18 have the same signature.
+//   NODE_OPTIONS in env — pm2 puts this in the child's environment before exec,
+//                which is early enough for V8. This is the one that takes effect.
+//
+// Do NOT move this into the box's .env: that file is read by dotenv at runtime,
+// after the heap is already sized, so a NODE_OPTIONS there is inert. Prod had
+// exactly that (8192) and it never applied.
+//
+// Verify after deploy — config is not proof, the command line is:
+//   tr '\0' ' ' < /proc/$(pgrep -f src/server.js | head -1)/cmdline
+const MAX_OLD_SPACE_MB = 8192;
+
 const base = {
   script: 'src/server.js',
   exec_mode: 'fork',
@@ -20,8 +43,10 @@ const base = {
   // Safe to be generous: blue-green serves users on the new color while the old
   // color drains, so this only delays reaping the retired process.
   kill_timeout: 90000,
-  node_args: '--max-old-space-size=16384',
+  node_args: `--max-old-space-size=${MAX_OLD_SPACE_MB}`,
 };
+
+const nodeOptions = `--max-old-space-size=${MAX_OLD_SPACE_MB}`;
 
 module.exports = {
   apps: [
@@ -32,6 +57,7 @@ module.exports = {
         NODE_ENV: 'production',
         PORT: 3000,
         GIT_SHA: process.env.GIT_SHA,
+        NODE_OPTIONS: nodeOptions,
       },
     },
     {
@@ -41,6 +67,7 @@ module.exports = {
         NODE_ENV: 'production',
         PORT: 3001,
         GIT_SHA: process.env.GIT_SHA,
+        NODE_OPTIONS: nodeOptions,
       },
     },
   ],

--- a/scripts/deploy-blue-green.sh
+++ b/scripts/deploy-blue-green.sh
@@ -107,6 +107,28 @@ export RELEASE
 # Bring up the next color; pm2 keeps the current color serving on its port.
 run pm2 start "$ECOSYSTEM" --only "server-$NEXT" --update-env
 
+# The heap ceiling is declared in the ecosystem config, but declaring it is not
+# the same as the process getting it: pm2 stored --max-old-space-size and then
+# spawned a bare `node src/server.js` anyway, so prod ran at node's ~4144MB
+# default until it OOM-crashed there on 2026-07-29. Config was green the whole
+# time. Assert against the spawned process instead, so a silently-dropped flag
+# fails the deploy rather than waiting for the next out-of-memory crash.
+if [ "$DRY_RUN" != "1" ]; then
+  NEXT_PID="$(pm2 pid "server-$NEXT" 2>/dev/null | tr -d '[:space:]')"
+  if [ -n "$NEXT_PID" ] && [ -r "/proc/$NEXT_PID/environ" ]; then
+    if tr '\0' '\n' < "/proc/$NEXT_PID/environ" \
+      | grep -q -- '--max-old-space-size='; then
+      log "heap ceiling verified on server-$NEXT (pid $NEXT_PID)"
+    else
+      log "server-$NEXT (pid $NEXT_PID) started WITHOUT a heap ceiling — removing it; current color still live"
+      run pm2 delete "server-$NEXT"
+      exit 1
+    fi
+  else
+    log "WARNING: could not read the environment of server-$NEXT — heap ceiling unverified"
+  fi
+fi
+
 if ! wait_for_sha "http://127.0.0.1:$NEXT_PORT$HEALTH_PATH"; then
   log "server-$NEXT failed health check on :$NEXT_PORT — removing it; current color still live"
   run pm2 delete "server-$NEXT"

--- a/src/lib/ecosystemHeapLimit.test.ts
+++ b/src/lib/ecosystemHeapLimit.test.ts
@@ -1,0 +1,58 @@
+import path from 'node:path';
+
+// The blue-green ecosystem config is what scripts/deploy-blue-green.sh feeds to
+// `pm2 start`, so it is the only place the production heap ceiling is declared.
+// On 2026-07-29 the ceiling was declared via node_args alone; pm2 stored it but
+// never put it on the spawned command line, so the process ran at node's ~4144MB
+// default and the main thread OOM-crashed at 4189MB. NODE_OPTIONS in the app env
+// is the channel that actually reaches V8 before it sizes the heap.
+const config = require(
+  path.resolve(__dirname, '../../ecosystem.blue-green.config.js')
+) as {
+  apps: Array<{
+    name: string;
+    node_args?: string;
+    env: Record<string, unknown>;
+  }>;
+};
+
+const HEAP_FLAG = /--max-old-space-size=(\d+)/;
+
+describe('blue-green ecosystem config — heap ceiling', () => {
+  it('declares both colors', () => {
+    expect(config.apps.map((app) => app.name).sort()).toEqual([
+      'server-blue',
+      'server-green',
+    ]);
+  });
+
+  it.each(['server-blue', 'server-green'])(
+    'sets NODE_OPTIONS heap ceiling for %s so V8 sees it before boot',
+    (name) => {
+      const app = config.apps.find((candidate) => candidate.name === name)!;
+      const nodeOptions = app.env.NODE_OPTIONS;
+
+      expect(typeof nodeOptions).toBe('string');
+      expect(nodeOptions as string).toMatch(HEAP_FLAG);
+    }
+  );
+
+  it.each(['server-blue', 'server-green'])(
+    'raises %s well above node default so a 4144MB ceiling cannot return',
+    (name) => {
+      const app = config.apps.find((candidate) => candidate.name === name)!;
+      const megabytes = Number.parseInt(
+        HEAP_FLAG.exec(app.env.NODE_OPTIONS as string)![1],
+        10
+      );
+
+      expect(megabytes).toBeGreaterThanOrEqual(8192);
+    }
+  );
+
+  it('keeps node_args and NODE_OPTIONS on the same value so they cannot drift', () => {
+    for (const app of config.apps) {
+      expect(app.node_args).toBe(app.env.NODE_OPTIONS);
+    }
+  });
+});


### PR DESCRIPTION
## What happened

Prod OOM-crashed today at **12:32 UTC**. pm2 auto-restarted it (`↺ 1`), so the outage was brief, but it was a real crash:

```
FATAL ERROR: NewSpace::EnsureCurrentCapacity Allocation failed - JavaScript heap out of memory
[1838953] 1873798 ms: Scavenge (interleaved) 4189.6 (4285.1) -> 4189.6 (4299.6) MB
```

It died at **4189MB**. That is node's **~4144MB default** ceiling — not the 16384 the ecosystem config declared, and not the 8192 the box's `.env` declared. **Neither setting was ever in effect.**

## Root cause — two independent failures, same symptom

**1. pm2 stored `node_args` and did not use it.**

```
pm2 describe server-green  →  interpreter args : --max-old-space-size=16384
/proc/<pid>/cmdline        →  node /home/alemayhu/.../src/server.js
```

The flag is in pm2's config and absent from the actual command line. Confirmed live: `require('v8').getHeapStatistics().heap_size_limit` on the box reports **4144MB**.

**2. `NODE_OPTIONS` in the box's `.env` cannot work by construction.** dotenv reads that file at runtime, long after V8 has sized the heap. A heap flag there is inert no matter what it says.

So both channels someone reasonably expected to work were silently doing nothing, and every dashboard was green the entire time.

## The fix

Declare it through the app `env`, which pm2 places in the child's environment **before exec** — early enough for V8 to read. Both `node_args` and `NODE_OPTIONS` now derive from one `MAX_OLD_SPACE_MB` constant so they cannot drift apart again.

**Chose 8192, not the 16384 previously named.** The box has 32GB shared with Postgres and four Piscina workers already capped at 1024MB old-gen each. 8192 doubles today's *effective* ceiling with real headroom, and matches the value someone had already chosen in prod `.env`. Raising it further is a one-line change — flagging the discrepancy rather than silently keeping 16384.

## Making the failure visible

The dangerous part was not the wrong number, it was that **config looked correct while reality differed for at least 11 days** (prior OOMs: 2026-07-18). So `deploy-blue-green.sh` now reads the spawned process's own environment and fails the deploy if no ceiling is present:

```bash
tr '\0' '\n' < "/proc/$NEXT_PID/environ" | grep -q -- '--max-old-space-size='
```

On failure it deletes only the **newly started** color and exits non-zero — identical to the existing health-check rollback, so the live color keeps serving. If `/proc` is unreadable it warns instead of blocking (fail-open, matching the script's other tooling guards).

`src/lib/ecosystemHeapLimit.test.ts` asserts both colors carry a ceiling ≥8192 and that the two declarations stay equal. These fail against the previous config.

## What this does NOT fix

**This raises the ceiling; it does not prove there is no leak.** Before the crash I sampled RSS every 45s: `5.4 → 5.6 → 5.8 → 5.9 → 5.9 → 6.0GB`, CPU pinned at ~105%, monotonic with no dip. Worker heaps are already bounded (1024MB cap + recycling every 50 tasks, added in #3637/#3722 after the July 18 OOMs). What grows on the **main thread** is still unexplained — the log at crash time showed a heavy Notion `getBlocks` stream, which is the obvious next place to look.

Net effect: the same growth now has 8GB of runway instead of 4GB, and a silently-missing ceiling can no longer reach production. A follow-up issue for the main-thread growth is worth filing separately.

## Verification

- Full server suite: **654 suites / 6037 tests passed**. Only failure is the documented environmental `getPageCount.test.ts` (needs `pdfinfo`).
- `npx tsc -p . --noEmit` — exit 0. `pnpm format:check` — clean tree-wide.
- `bash -n scripts/deploy-blue-green.sh` — syntax clean.
- The new deploy gate is **prod-only** and could not be exercised end-to-end locally: `DRY_RUN=1` stops earlier, at the `cd` to the prod checkout path. Logic is guarded by `DRY_RUN != 1` and a `/proc` readability check.
- Sonar not run locally (no `SONAR_TOKEN` on this box); Automatic Analysis covers the push.

Browser check: not applicable — no `web/src/` files in the diff.

No changelog entry — deploy configuration, no user-visible behavior change.
