### PR TITLE
fix: point Sonar at the laer-smart project and enforce config parity

### DIFF
--- a/.claude/rules/sonar.md
+++ b/.claude/rules/sonar.md
@@ -1,8 +1,27 @@
 # SonarCloud quality gate
 
-The gate blocks merges when **Security Rating on New Code < A**. Security issues are the only category that regularly causes failures — reliability and maintainability rarely flip. But maintainability code smells (cognitive complexity, function nesting, redundant assertions, non-native interactive elements) still land on every PR and have to be cleared one push at a time. Run Sonar locally to find them before they bounce off CI.
+## State as of 2026-07-30 — verified, not assumed
 
-**The PR gate is SonarCloud Automatic Analysis, which reads `.sonarcloud.properties` — NOT the `sonar-project.properties` the local `sonar-scanner` uses.** They are two different configs. An exclusion or rule waiver added only to `sonar-project.properties` silences the local scanner but does nothing to the merge gate; the finding still lands on the PR. When you add an exclusion, **mirror it into both files** or the gate won't honor it.
+**There is currently no quality gate. Sonar blocks nothing.** This file previously claimed "the gate blocks merges when Security Rating on New Code < A." That was false and nobody had checked it. What the API actually returns:
+
+```
+GET /api/qualitygates/project_status?projectKey=Laer-Smart_2anki.net
+  {"projectStatus":{"status":"NONE","conditions":[],"periods":[]}}
+```
+
+`status: NONE`, zero conditions, and — note — an **empty `periods`** array, meaning no New Code period is defined. Without one, a "on New Code" condition cannot evaluate even after a gate is attached. Both have to be set in the SonarCloud UI.
+
+**No Sonar check appears on PRs.** Verified across seven merged PRs on 2026-07-29: every `statusCheckRollup` contained only `static`, `test`, `build`, `playwright`. Analyses land on `main` **after** merge, keyed to the merge commit. So writing "Automatic Analysis covers the push" in a PR body is misleading — nothing Sonar sees runs before the merge decision.
+
+**The org moved from `2anki` to `laer-smart`, which changed the project key.** The live project is `Laer-Smart_2anki.net`; the old `2anki_server` in org `2anki` kept auto-scanning `main` for weeks afterwards (34 analyses, most recent the same day), so the breakage was invisible — a stale project was quietly absorbing the scans. `sonar-project.properties` now points at the new key, and `src/lib/sonarConfigParity.test.ts` asserts it.
+
+Re-verify all three with `curl` before trusting any of it again; this block is a snapshot, and the last snapshot went stale without anyone noticing.
+
+## Two configs, read by two different scanners
+
+**Automatic Analysis reads `.sonarcloud.properties`; the local `sonar-scanner` CLI reads `sonar-project.properties`.** An exclusion or waiver added to only one is silently ignored by the other, so "clean locally" can coexist with a noisy PR scan.
+
+This drifted in practice: on 2026-07-30, `src/data_layer/public/**` (thousands of lines of kanel-generated code) and the four email-template waivers existed **only** in the CLI config, so the PR-side scan was analysing all of it. **`src/lib/sonarConfigParity.test.ts` now enforces parity** — it compares all three exclusion lists, the waiver set, and that every waiver has a `ruleKey` and `resourceKey` in both files. Add an exclusion to one file and that test goes red. Only `projectKey`, `organization`, `sonar.javascript.lcov.reportPaths`, and `sonar.qualitygate.wait` are legitimately CLI-only.
 
 ## Run Sonar locally before pushing — required for non-trivial code changes
 

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,17 +1,30 @@
+# Read by SonarCloud Automatic Analysis (the PR-side scan) — NOT by the local
+# `sonar-scanner` CLI, which reads sonar-project.properties. The two files must
+# carry the same exclusions and waivers: anything added to only one is silently
+# ignored by the other. Deliberate differences are limited to keys Automatic
+# Analysis does not use (projectKey/organization come from the repo binding,
+# lcov paths need a local coverage run, qualitygate.wait is CLI-only).
+#
+# Drift found 2026-07-30: src/data_layer/public/** and the email-template
+# waivers existed only in sonar-project.properties, so the PR-side scan was
+# analysing thousands of lines of kanel-generated code and every email template.
 sonar.sources=src,web/src
 sonar.tests=src,web/src,web/tests
 sonar.test.inclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx,web/tests/**
 
-sonar.exclusions=src/templates/**,src/migrations/**,src/test/fixtures/**,src/config/swagger.ts,web/build/**,web/mock-server/**,web/src/generated/**,web/src/schemas/**,web/src/react-app-env.d.ts,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
+sonar.exclusions=src/templates/**,src/migrations/**,src/test/fixtures/**,src/data_layer/public/**,src/config/swagger.ts,src/services/EmailService/templates/**,web/build/**,web/mock-server/**,web/src/generated/**,web/src/schemas/**,web/src/react-app-env.d.ts,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
 
-sonar.coverage.exclusions=src/templates/**,src/migrations/**,src/test/fixtures/**,src/config/swagger.ts,web/mock-server/**,web/src/generated/**,web/src/schemas/**,web/src/react-app-env.d.ts,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
+sonar.coverage.exclusions=src/templates/**,src/migrations/**,src/test/fixtures/**,src/data_layer/public/**,src/config/swagger.ts,web/mock-server/**,web/src/generated/**,web/src/schemas/**,web/src/react-app-env.d.ts,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
 
-sonar.cpd.exclusions=src/migrations/**,web/src/generated/**,web/src/schemas/**,web/src/pages/OpsPage/performanceTypes.ts,web/src/pages/ConvertLandingPage/convertLandingConfig.ts,web/src/pages/ConvertHubPage/convertHubGroups.ts,web/src/pages/LandingPage/copy/**,src/controllers/CardOptionsController/supportedOptions.ts,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
+sonar.cpd.exclusions=src/migrations/**,src/data_layer/public/**,web/src/generated/**,web/src/schemas/**,web/src/pages/OpsPage/performanceTypes.ts,web/src/pages/ConvertLandingPage/convertLandingConfig.ts,web/src/pages/ConvertHubPage/convertHubGroups.ts,web/src/pages/LandingPage/copy/**,src/controllers/CardOptionsController/supportedOptions.ts,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
 
 sonar.javascript.file.suffixes=.js,.jsx
 sonar.typescript.file.suffixes=.ts,.tsx
 
-sonar.issue.ignore.multicriteria=mock1,mock2,test1,test2,gen1,gen2
+# Waivers mirror sonar-project.properties. gen1/gen2 blanket-ignore the
+# generated folders, which are also excluded above — kept because the belt and
+# braces cost nothing and generated code must never raise a finding.
+sonar.issue.ignore.multicriteria=mock1,mock2,test1,test2,gen1,gen2,email1,email2,email3,email4
 sonar.issue.ignore.multicriteria.mock1.ruleKey=javascript:S5122
 sonar.issue.ignore.multicriteria.mock1.resourceKey=web/mock-server/**
 sonar.issue.ignore.multicriteria.mock2.ruleKey=javascript:S5689
@@ -24,3 +37,15 @@ sonar.issue.ignore.multicriteria.gen1.ruleKey=*
 sonar.issue.ignore.multicriteria.gen1.resourceKey=web/src/generated/**
 sonar.issue.ignore.multicriteria.gen2.ruleKey=*
 sonar.issue.ignore.multicriteria.gen2.resourceKey=web/src/schemas/**
+# Email template HTML uses table layout, deprecated presentational attributes,
+# and borderline contrast on purpose — email clients require those patterns. The
+# folder is excluded above, but the Web plugin discovers HTML independently, so
+# each rule still needs an explicit waiver.
+sonar.issue.ignore.multicriteria.email1.ruleKey=Web:S1827
+sonar.issue.ignore.multicriteria.email1.resourceKey=src/services/EmailService/templates/**
+sonar.issue.ignore.multicriteria.email2.ruleKey=Web:S5257
+sonar.issue.ignore.multicriteria.email2.resourceKey=src/services/EmailService/templates/**
+sonar.issue.ignore.multicriteria.email3.ruleKey=Web:S6819
+sonar.issue.ignore.multicriteria.email3.resourceKey=src/services/EmailService/templates/**
+sonar.issue.ignore.multicriteria.email4.ruleKey=css:S7924
+sonar.issue.ignore.multicriteria.email4.resourceKey=src/services/EmailService/templates/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,11 @@
-sonar.projectKey=2anki_server
-sonar.organization=2anki
+# The repo moved from the `2anki` SonarCloud org to `laer-smart`, which changed
+# the project key. The old project (`2anki_server` in org `2anki`) kept
+# auto-scanning `main` for weeks afterwards, so nothing looked broken — but it is
+# a different project from the one now bound to the repo, and it has no quality
+# gate. Verify with:
+#   curl -s "https://sonarcloud.io/api/components/show?component=Laer-Smart_2anki.net"
+sonar.projectKey=Laer-Smart_2anki.net
+sonar.organization=laer-smart
 
 sonar.sources=src,web/src
 sonar.tests=src,web/src,web/tests
@@ -32,7 +38,7 @@ sonar.typescript.file.suffixes=.ts,.tsx
 # rendering. The whole templates folder is excluded via sonar.exclusions
 # but the Web plugin discovers HTML files independently, so each rule
 # needs an explicit waiver to keep the gate clean.
-sonar.issue.ignore.multicriteria=mock1,mock2,test1,test2,email1,email2,email3,email4
+sonar.issue.ignore.multicriteria=mock1,mock2,test1,test2,gen1,gen2,email1,email2,email3,email4
 sonar.issue.ignore.multicriteria.mock1.ruleKey=javascript:S5122
 sonar.issue.ignore.multicriteria.mock1.resourceKey=web/mock-server/**
 sonar.issue.ignore.multicriteria.mock2.ruleKey=javascript:S5689
@@ -41,6 +47,10 @@ sonar.issue.ignore.multicriteria.test1.ruleKey=javascript:S2068
 sonar.issue.ignore.multicriteria.test1.resourceKey=web/tests/**
 sonar.issue.ignore.multicriteria.test2.ruleKey=javascript:S1481
 sonar.issue.ignore.multicriteria.test2.resourceKey=web/tests/**
+sonar.issue.ignore.multicriteria.gen1.ruleKey=*
+sonar.issue.ignore.multicriteria.gen1.resourceKey=web/src/generated/**
+sonar.issue.ignore.multicriteria.gen2.ruleKey=*
+sonar.issue.ignore.multicriteria.gen2.resourceKey=web/src/schemas/**
 sonar.issue.ignore.multicriteria.email1.ruleKey=Web:S1827
 sonar.issue.ignore.multicriteria.email1.resourceKey=src/services/EmailService/templates/**
 sonar.issue.ignore.multicriteria.email2.ruleKey=Web:S5257

--- a/src/lib/sonarConfigParity.test.ts
+++ b/src/lib/sonarConfigParity.test.ts
@@ -1,0 +1,122 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Two Sonar configs exist and they are read by different scanners:
+//   sonar-project.properties  — the local `sonar-scanner` CLI
+//   .sonarcloud.properties    — SonarCloud Automatic Analysis (the PR-side scan)
+// An exclusion or waiver added to only one is silently ignored by the other, so
+// a "clean locally" run can coexist with a noisy PR scan. Found 2026-07-30:
+// src/data_layer/public/** (kanel-generated) and the email-template waivers
+// existed only in the CLI config, so the PR-side scan analysed all of it.
+//
+// Keys legitimately absent from .sonarcloud.properties, because Automatic
+// Analysis does not use them: projectKey/organization come from the repo
+// binding, lcov paths require a local coverage run, qualitygate.wait is CLI-only.
+const CLI_ONLY_KEYS = new Set([
+  'sonar.projectKey',
+  'sonar.organization',
+  'sonar.javascript.lcov.reportPaths',
+  'sonar.qualitygate.wait',
+]);
+
+function parseProperties(relativePath: string): Map<string, string> {
+  const raw = fs.readFileSync(
+    path.resolve(__dirname, '../..', relativePath),
+    'utf8'
+  );
+  const entries = new Map<string, string>();
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed === '' || trimmed.startsWith('#') || !trimmed.includes('=')) {
+      continue;
+    }
+    const separator = trimmed.indexOf('=');
+    entries.set(
+      trimmed.slice(0, separator).trim(),
+      trimmed.slice(separator + 1).trim()
+    );
+  }
+  return entries;
+}
+
+const cli = parseProperties('sonar-project.properties');
+const autoScan = parseProperties('.sonarcloud.properties');
+
+const asSet = (value: string | undefined): Set<string> =>
+  new Set(
+    (value ?? '')
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+  );
+
+describe('Sonar config parity between the CLI and Automatic Analysis', () => {
+  it.each([
+    'sonar.exclusions',
+    'sonar.coverage.exclusions',
+    'sonar.cpd.exclusions',
+  ])('keeps %s identical in both files', (key) => {
+    const onlyInCli = [...asSet(cli.get(key))].filter(
+      (entry) => !asSet(autoScan.get(key)).has(entry)
+    );
+    const onlyInAutoScan = [...asSet(autoScan.get(key))].filter(
+      (entry) => !asSet(cli.get(key)).has(entry)
+    );
+
+    expect({ onlyInCli, onlyInAutoScan }).toEqual({
+      onlyInCli: [],
+      onlyInAutoScan: [],
+    });
+  });
+
+  it('declares the same rule waivers in both files', () => {
+    const cliWaivers = asSet(cli.get('sonar.issue.ignore.multicriteria'));
+    const autoScanWaivers = asSet(
+      autoScan.get('sonar.issue.ignore.multicriteria')
+    );
+
+    expect([...cliWaivers].sort()).toEqual([...autoScanWaivers].sort());
+  });
+
+  it('gives every declared waiver a ruleKey and resourceKey in both files', () => {
+    for (const [label, config] of [
+      ['sonar-project.properties', cli],
+      ['.sonarcloud.properties', autoScan],
+    ] as const) {
+      for (const waiver of asSet(
+        config.get('sonar.issue.ignore.multicriteria')
+      )) {
+        expect({
+          label,
+          waiver,
+          ruleKey: config.get(
+            `sonar.issue.ignore.multicriteria.${waiver}.ruleKey`
+          ),
+          resourceKey: config.get(
+            `sonar.issue.ignore.multicriteria.${waiver}.resourceKey`
+          ),
+        }).toEqual({
+          label,
+          waiver,
+          ruleKey: expect.any(String),
+          resourceKey: expect.any(String),
+        });
+      }
+    }
+  });
+
+  it('leaves only the CLI-specific keys out of the Automatic Analysis config', () => {
+    const missing = [...cli.keys()].filter(
+      (key) => !autoScan.has(key) && !CLI_ONLY_KEYS.has(key)
+    );
+
+    expect(missing).toEqual([]);
+  });
+
+  it('points the CLI at the laer-smart project the repo is bound to', () => {
+    // The repo moved orgs; the stale key pointed at a different project that
+    // kept scanning main and had no quality gate, so nothing looked wrong.
+    expect(cli.get('sonar.projectKey')).toBe('Laer-Smart_2anki.net');
+    expect(cli.get('sonar.organization')).toBe('laer-smart');
+  });
+});


### PR DESCRIPTION
## What was broken

The repo moved from the `2anki` SonarCloud org to `laer-smart`, which changed the project key. `sonar-project.properties` still named the old one.

**The breakage was invisible because a stale project kept absorbing the scans:**

| Project | Org | Analyses | Gate |
|---|---|---|---|
| `Laer-Smart_2anki.net` — actually bound to this repo | `laer-smart` | **0** | none |
| `2anki_server` — stale | `2anki` | 34, most recent 2026-07-29 17:55 | none |

So anyone glancing at SonarCloud saw recent activity on `main`. It was the wrong project.

## Config drift — the PR scan was analysing generated code

Automatic Analysis reads `.sonarcloud.properties`; the local CLI reads `sonar-project.properties`. These had drifted:

- `src/data_layer/public/**` — thousands of lines of kanel-generated code — was excluded **only** in the CLI config, in all three of `sonar.exclusions`, `coverage.exclusions`, and `cpd.exclusions`.
- `src/services/EmailService/templates/**` and its four `Web:`/`css:` waivers existed **only** in the CLI config.

Net effect: a local run reported clean while the PR-side scan chewed through generated code and every email template. Both files now carry the same exclusions and waivers.

## Enforcement, not prose

`src/lib/sonarConfigParity.test.ts` (7 tests) is the mechanism — the "mirror it into both files" instruction has been in `.claude/rules/sonar.md` the whole time and drifted anyway. It asserts:

- all three exclusion lists are set-identical across both files
- the declared waiver sets match
- every declared waiver has both a `ruleKey` and a `resourceKey` **in both files**
- no CLI key is missing from the AutoScan config except the four that are legitimately CLI-only (`projectKey`, `organization`, lcov paths, `qualitygate.wait`)
- the CLI points at `Laer-Smart_2anki.net` / `laer-smart`

Add an exclusion to one file and the suite goes red.

## A false claim in the rule doc

`.claude/rules/sonar.md` opened with "The gate blocks merges when **Security Rating on New Code < A**." Verified false:

```
GET /api/qualitygates/project_status?projectKey=Laer-Smart_2anki.net
  {"projectStatus":{"status":"NONE","conditions":[],"periods":[]}}
```

No gate, no conditions, and an **empty `periods`** array — no New Code period is defined, so an "on New Code" condition could not evaluate even once a gate is attached. Both need setting in the SonarCloud UI. Seven PRs merged 2026-07-29 also show no Sonar entry in any `statusCheckRollup`; analyses land on `main` after merge, so "Automatic Analysis covers the push" (which I wrote in several PR bodies yesterday) is misleading — nothing Sonar sees runs before the merge decision.

Replaced with the verified state plus the `curl` commands to re-check it, and labelled as a snapshot — the previous claim went stale without anyone noticing, which is the actual failure mode here.

## Still needs doing in the SonarCloud UI (not possible from the repo)

1. **Attach a quality gate** to `Laer-Smart_2anki.net` (e.g. Sonar way, or a custom one with Security Rating on New Code = A).
2. **Define a New Code period** — "Number of days: 30" suits this repo, since `projectVersion` is `not provided` so "Previous version" has nothing to anchor to.
3. **Turn off AutoScan on the stale `2anki_server`** (or delete it), so two projects stop scanning one repo.

Merging this PR is also a push to `main`, which is what AutoScan waits for — the onboarding page can sit on "refreshing in a few moments" indefinitely if no push has landed since it was enabled.

## Verification

- Full server suite: **655 suites / 6050 tests passed**. Only failure is the documented environmental `getPageCount.test.ts` (needs `pdfinfo`).
- `npx tsc -p . --noEmit` — exit 0. `pnpm format:check` — clean tree-wide.
- Project/gate/analysis state read from the SonarCloud API, quoted above rather than assumed.

Browser check: not applicable — no `web/src/` files in the diff.

No changelog entry — CI configuration and internal docs, no user-visible behavior change.
