### PR TITLE
fix: clear 49 of 59 Sonar vulnerabilities and bugs

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -12,7 +12,7 @@ sonar.sources=src,web/src
 sonar.tests=src,web/src,web/tests
 sonar.test.inclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx,web/tests/**
 
-sonar.exclusions=src/templates/**,src/migrations/**,src/test/fixtures/**,src/data_layer/public/**,src/config/swagger.ts,src/services/EmailService/templates/**,web/build/**,web/mock-server/**,web/src/generated/**,web/src/schemas/**,web/src/react-app-env.d.ts,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
+sonar.exclusions=src/templates/**,src/migrations/**,src/test/fixtures/**,src/lib/parser/__fixtures__/**,src/data_layer/public/**,src/config/swagger.ts,src/services/EmailService/templates/**,web/build/**,web/mock-server/**,web/src/generated/**,web/src/schemas/**,web/src/react-app-env.d.ts,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
 
 sonar.coverage.exclusions=src/templates/**,src/migrations/**,src/test/fixtures/**,src/data_layer/public/**,src/config/swagger.ts,web/mock-server/**,web/src/generated/**,web/src/schemas/**,web/src/react-app-env.d.ts,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
 
@@ -24,7 +24,7 @@ sonar.typescript.file.suffixes=.ts,.tsx
 # Waivers mirror sonar-project.properties. gen1/gen2 blanket-ignore the
 # generated folders, which are also excluded above — kept because the belt and
 # braces cost nothing and generated code must never raise a finding.
-sonar.issue.ignore.multicriteria=mock1,mock2,test1,test2,gen1,gen2,email1,email2,email3,email4
+sonar.issue.ignore.multicriteria=mock1,mock2,test1,test2,gen1,gen2,email1,email2,email3,email4,i18n1,jitter1,jitter2,upload1
 sonar.issue.ignore.multicriteria.mock1.ruleKey=javascript:S5122
 sonar.issue.ignore.multicriteria.mock1.resourceKey=web/mock-server/**
 sonar.issue.ignore.multicriteria.mock2.ruleKey=javascript:S5689
@@ -49,3 +49,21 @@ sonar.issue.ignore.multicriteria.email3.ruleKey=Web:S6819
 sonar.issue.ignore.multicriteria.email3.resourceKey=src/services/EmailService/templates/**
 sonar.issue.ignore.multicriteria.email4.ruleKey=css:S7924
 sonar.issue.ignore.multicriteria.email4.resourceKey=src/services/EmailService/templates/**
+
+# i18n1: the locale JSON carries UI strings for the password screens ("Forgot
+# password?", "New password"), which the secret detector reads as credentials.
+# jitter1/jitter2: retry backoff jitter is not a security context — see the
+# S2245 carve-out in .claude/rules/security.md. Do NOT swap these for crypto.
+# upload1: every multer instance under src/routes/ already declares an explicit
+# limits.fileSize cap (10MB chat/contact/occlusion, 25MB feedback, 50MB PDF
+# retry, 100MB apkg). S5693 asks you to confirm the cap is safe; it is, and the
+# rule cannot tell. If you add a NEW upload route, set limits.fileSize on it —
+# this waiver will hide a missing cap.
+sonar.issue.ignore.multicriteria.i18n1.ruleKey=json:S2068
+sonar.issue.ignore.multicriteria.i18n1.resourceKey=web/src/lib/i18n/locales/**
+sonar.issue.ignore.multicriteria.jitter1.ruleKey=typescript:S2245
+sonar.issue.ignore.multicriteria.jitter1.resourceKey=src/services/NotionService/helpers/withRetry.ts
+sonar.issue.ignore.multicriteria.jitter2.ruleKey=typescript:S2245
+sonar.issue.ignore.multicriteria.jitter2.resourceKey=src/lib/storage/jobs/helpers/withStripeRetry.ts
+sonar.issue.ignore.multicriteria.upload1.ruleKey=typescript:S5693
+sonar.issue.ignore.multicriteria.upload1.resourceKey=src/routes/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,7 +11,7 @@ sonar.sources=src,web/src
 sonar.tests=src,web/src,web/tests
 sonar.test.inclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx,web/tests/**
 
-sonar.exclusions=src/templates/**,src/migrations/**,src/test/fixtures/**,src/data_layer/public/**,src/config/swagger.ts,src/services/EmailService/templates/**,web/build/**,web/mock-server/**,web/src/generated/**,web/src/schemas/**,web/src/react-app-env.d.ts,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
+sonar.exclusions=src/templates/**,src/migrations/**,src/test/fixtures/**,src/lib/parser/__fixtures__/**,src/data_layer/public/**,src/config/swagger.ts,src/services/EmailService/templates/**,web/build/**,web/mock-server/**,web/src/generated/**,web/src/schemas/**,web/src/react-app-env.d.ts,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
 
 sonar.coverage.exclusions=src/templates/**,src/migrations/**,src/test/fixtures/**,src/data_layer/public/**,src/config/swagger.ts,web/mock-server/**,web/src/generated/**,web/src/schemas/**,web/src/react-app-env.d.ts,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
 
@@ -38,7 +38,7 @@ sonar.typescript.file.suffixes=.ts,.tsx
 # rendering. The whole templates folder is excluded via sonar.exclusions
 # but the Web plugin discovers HTML files independently, so each rule
 # needs an explicit waiver to keep the gate clean.
-sonar.issue.ignore.multicriteria=mock1,mock2,test1,test2,gen1,gen2,email1,email2,email3,email4
+sonar.issue.ignore.multicriteria=mock1,mock2,test1,test2,gen1,gen2,email1,email2,email3,email4,i18n1,jitter1,jitter2,upload1
 sonar.issue.ignore.multicriteria.mock1.ruleKey=javascript:S5122
 sonar.issue.ignore.multicriteria.mock1.resourceKey=web/mock-server/**
 sonar.issue.ignore.multicriteria.mock2.ruleKey=javascript:S5689
@@ -61,3 +61,21 @@ sonar.issue.ignore.multicriteria.email4.ruleKey=css:S7924
 sonar.issue.ignore.multicriteria.email4.resourceKey=src/services/EmailService/templates/**
 
 sonar.qualitygate.wait=true
+
+# i18n1: the locale JSON carries UI strings for the password screens ("Forgot
+# password?", "New password"), which the secret detector reads as credentials.
+# jitter1/jitter2: retry backoff jitter is not a security context — see the
+# S2245 carve-out in .claude/rules/security.md. Do NOT swap these for crypto.
+# upload1: every multer instance under src/routes/ already declares an explicit
+# limits.fileSize cap (10MB chat/contact/occlusion, 25MB feedback, 50MB PDF
+# retry, 100MB apkg). S5693 asks you to confirm the cap is safe; it is, and the
+# rule cannot tell. If you add a NEW upload route, set limits.fileSize on it —
+# this waiver will hide a missing cap.
+sonar.issue.ignore.multicriteria.i18n1.ruleKey=json:S2068
+sonar.issue.ignore.multicriteria.i18n1.resourceKey=web/src/lib/i18n/locales/**
+sonar.issue.ignore.multicriteria.jitter1.ruleKey=typescript:S2245
+sonar.issue.ignore.multicriteria.jitter1.resourceKey=src/services/NotionService/helpers/withRetry.ts
+sonar.issue.ignore.multicriteria.jitter2.ruleKey=typescript:S2245
+sonar.issue.ignore.multicriteria.jitter2.resourceKey=src/lib/storage/jobs/helpers/withStripeRetry.ts
+sonar.issue.ignore.multicriteria.upload1.ruleKey=typescript:S5693
+sonar.issue.ignore.multicriteria.upload1.resourceKey=src/routes/**

--- a/src/KnexConfig.test.ts
+++ b/src/KnexConfig.test.ts
@@ -1,5 +1,19 @@
 type MigrationsConfig = { disableMigrationsListValidation?: boolean };
 
+function loadWholeConfigWithoutDatabaseUrl() {
+  jest.resetModules();
+  const original = process.env.DATABASE_URL;
+  delete process.env.DATABASE_URL;
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const config = require('./KnexConfig').default;
+  if (original === undefined) {
+    delete process.env.DATABASE_URL;
+  } else {
+    process.env.DATABASE_URL = original;
+  }
+  return config as { connection: string };
+}
+
 function loadConfigWith(localDev: string | undefined) {
   jest.resetModules();
   const original = process.env.LOCAL_DEV;
@@ -31,5 +45,33 @@ describe('KnexConfig migrations validation', () => {
 
   it('keeps strict validation when LOCAL_DEV is not exactly "true"', () => {
     expect(loadConfigWith('false').disableMigrationsListValidation).toBe(false);
+  });
+});
+
+describe('KnexConfig local fallback connection', () => {
+  // The fallback DSN once embedded a real username and password in a public
+  // repo (CWE-798, secrets:S6698). It must stay credential-free.
+  it('falls back to a localhost DSN carrying no credentials', () => {
+    const connection = loadWholeConfigWithoutDatabaseUrl().connection;
+
+    expect(connection).toBe('postgresql://localhost:5432/n');
+    expect(connection).not.toContain('@');
+    expect(connection).not.toMatch(/:\/\/[^/]*:[^/]*@/);
+  });
+
+  it('prefers DATABASE_URL when it is set', () => {
+    const original = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = 'postgresql://example-host:5432/example';
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const config = require('./KnexConfig').default as { connection: string };
+
+    expect(config.connection).toBe('postgresql://example-host:5432/example');
+
+    if (original === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = original;
+    }
   });
 });

--- a/src/KnexConfig.ts
+++ b/src/KnexConfig.ts
@@ -1,9 +1,16 @@
 import { Knex } from 'knex';
 
+// This fallback used to embed a real username and password (CWE-798) in a
+// public repo. The fallback itself stays, so local dev and the data_layer tests
+// reach a localhost Postgres without extra setup, but it carries no credentials:
+// libpq falls back to the OS user, and anything needing a password sets
+// DATABASE_URL. Never put credentials back in here — `secrets:S6698` will catch
+// it, and so will KnexConfig.test.ts.
+const LOCAL_FALLBACK_DATABASE_URL = 'postgresql://localhost:5432/n';
+
 const KnexConfig: Knex.Config = {
   client: 'pg',
-  connection:
-    process.env.DATABASE_URL || 'postgresql://aa:focaccia@localhost:5432/n',
+  connection: process.env.DATABASE_URL || LOCAL_FALLBACK_DATABASE_URL,
   pool: {
     min: 2,
     max: 20,

--- a/src/controllers/CardOptionsController/CardOptionsController.ts
+++ b/src/controllers/CardOptionsController/CardOptionsController.ts
@@ -7,6 +7,7 @@ import supportedOptions from './supportedOptions';
 import CardOption from '../../lib/parser/Settings/CardOption';
 import { unwrapStoredSettingsPayload } from '../../lib/parser/Settings/unwrapStoredSettingsPayload';
 import { CardOptionDetail } from './CardOptionDetail';
+import { sanitizeForLog } from '../../lib/log/sanitizeForLog';
 
 interface DeleteAllUseCase {
   execute(owner: string): Promise<void>;
@@ -20,7 +21,7 @@ class CardOptionsController {
   ) {}
 
   async createSetting(req: Request, res: Response) {
-    console.info(`/settings/create ${req.params.id}`);
+    console.info(`/settings/create ${sanitizeForLog(req.params.id)}`);
     const { settings } = req.body;
     const owner = getOwner(res);
 

--- a/src/controllers/IndexController/IndexController.ts
+++ b/src/controllers/IndexController/IndexController.ts
@@ -15,7 +15,14 @@ class IndexController {
 
   async contactUs(req: express.Request, res: express.Response) {
     const { name, email, message } = req.body;
-    console.info('Contact Us', name, email, message);
+    // Never log the name, address or message body. This used to print all three
+    // into the prod log, which is a CWE-532 leak of exactly the identifiers
+    // .claude/rules/support-confidentiality.md exists to keep out of artifacts.
+    // Shape only — enough to confirm the form arrived and see obvious abuse.
+    console.info('Contact Us submission received', {
+      hasName: typeof name === 'string' && name.trim().length > 0,
+      messageLength: typeof message === 'string' ? message.length : 0,
+    });
     if (!email || !message) {
       return res.status(400).send({ error: 'Missing email or message' });
     }

--- a/src/lib/debug/preserveFilesForDebugging.ts
+++ b/src/lib/debug/preserveFilesForDebugging.ts
@@ -6,6 +6,7 @@ import express from 'express';
 
 import { getRandomUUID } from '../../shared/helpers/getRandomUUID';
 import { UploadedFile } from '../storage/types';
+import { sanitizeForLog } from '../../lib/log/sanitizeForLog';
 
 export function preserveFilesForDebugging(
   request: express.Request,
@@ -45,7 +46,9 @@ export function preserveFilesForDebugging(
       );
       const fileContents = fs.readFileSync(file.path);
       fs.writeFileSync(destPath, fileContents);
-      console.log(`Copied file ${file.path} to ${destPath}`);
+      console.log(
+        `Copied file ${sanitizeForLog(file.path)} to ${sanitizeForLog(destPath)}`
+      );
     });
   } catch (error) {
     console.error(`Error in preserveFilesForDebugging: ${error}`);

--- a/src/lib/log/sanitizeForLog.test.ts
+++ b/src/lib/log/sanitizeForLog.test.ts
@@ -1,0 +1,61 @@
+import { MAX_LOGGED_LENGTH, sanitizeForLog } from './sanitizeForLog';
+
+const CR = String.fromCharCode(0x0d);
+const LF = String.fromCharCode(0x0a);
+const NUL = String.fromCharCode(0x00);
+const ESC = String.fromCharCode(0x1b);
+const DEL = String.fromCharCode(0x7f);
+
+describe('sanitizeForLog', () => {
+  it('leaves an ordinary value untouched', () => {
+    expect(sanitizeForLog('https://2anki.net')).toBe('https://2anki.net');
+  });
+
+  it('keeps spaces and hyphens, which an earlier regex draft destroyed', () => {
+    expect(sanitizeForLog('a b-c')).toBe('a b-c');
+  });
+
+  it.each([
+    ['CR', CR],
+    ['LF', LF],
+    ['NUL', NUL],
+    ['ESC', ESC],
+    ['DEL', DEL],
+  ])('replaces %s so it cannot forge a log line', (_name, control) => {
+    const sanitized = sanitizeForLog(`before${control}after`);
+
+    expect(sanitized).toBe('before?after');
+    expect(sanitized).not.toContain(control);
+  });
+
+  it('defeats a full forged log line', () => {
+    const forged = `evil.example.com${CR}${LF}[events] admin granted access`;
+
+    expect(sanitizeForLog(forged)).toBe(
+      'evil.example.com??[events] admin granted access'
+    );
+  });
+
+  it('caps a flooding value', () => {
+    const sanitized = sanitizeForLog('x'.repeat(MAX_LOGGED_LENGTH + 50));
+
+    expect(sanitized).toHaveLength(MAX_LOGGED_LENGTH + 1);
+    expect(sanitized.endsWith('…')).toBe(true);
+  });
+
+  it('does not cap a value exactly at the limit', () => {
+    expect(sanitizeForLog('x'.repeat(MAX_LOGGED_LENGTH))).toHaveLength(
+      MAX_LOGGED_LENGTH
+    );
+  });
+
+  it('serializes non-string values', () => {
+    expect(sanitizeForLog({ id: 7 })).toBe('{"id":7}');
+    expect(sanitizeForLog(42)).toBe('42');
+    expect(sanitizeForLog(null)).toBe('null');
+  });
+
+  it('reports undefined rather than throwing', () => {
+    expect(sanitizeForLog(undefined)).toBe('undefined');
+  });
+});

--- a/src/lib/log/sanitizeForLog.ts
+++ b/src/lib/log/sanitizeForLog.ts
@@ -1,0 +1,43 @@
+const MAX_LOGGED_LENGTH = 200;
+
+const CONTROL_PLACEHOLDER = '?';
+const DEL_CODE_POINT = 0x7f;
+const FIRST_PRINTABLE_CODE_POINT = 0x20;
+
+/**
+ * Makes a user-controlled value safe to interpolate into a log line.
+ *
+ * Without this, a value containing CR/LF forges log entries: a crafted origin
+ * header or page id can inject a whole extra line into the prod log and hide or
+ * misattribute real activity (CWE-117, tssecurity:S5145). Control characters are
+ * replaced rather than dropped, so a tampered value still reads as tampered
+ * instead of becoming plausible text, and the result is capped so one caller
+ * cannot flood the log.
+ *
+ * Implemented with a code-point scan rather than a control-character regex
+ * because the escape-heavy regex form is easy to get subtly wrong (an early
+ * draft of this file shipped `[ -]`, which replaced spaces and hyphens and no
+ * control characters at all).
+ *
+ * This is for values that are safe to see in plaintext. It is NOT a substitute
+ * for omitting secrets and PII — tokens, passwords, email addresses and message
+ * bodies must not be logged at all, sanitized or otherwise (CWE-532).
+ */
+export function sanitizeForLog(value: unknown): string {
+  const asText = typeof value === 'string' ? value : JSON.stringify(value);
+  if (asText == null) return 'undefined';
+
+  let collapsed = '';
+  for (const character of asText) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    const isControl =
+      codePoint < FIRST_PRINTABLE_CODE_POINT || codePoint === DEL_CODE_POINT;
+    collapsed += isControl ? CONTROL_PLACEHOLDER : character;
+  }
+
+  return collapsed.length > MAX_LOGGED_LENGTH
+    ? `${collapsed.slice(0, MAX_LOGGED_LENGTH)}…`
+    : collapsed;
+}
+
+export { MAX_LOGGED_LENGTH };

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -1233,10 +1233,7 @@ export class DeckParser {
   }
 
   totalCardCount() {
-    if (this.payload.length === 0) {
-      return 0;
-    }
-    return this.payload.map((p) => p.cardCount).reduce((a, b) => a + b);
+    return this.payload.reduce((total, p) => total + p.cardCount, 0);
   }
 
   private loadDOM(contents: string) {

--- a/src/routes/EmailRedirectRouter.test.ts
+++ b/src/routes/EmailRedirectRouter.test.ts
@@ -188,3 +188,38 @@ describe('EmailRedirectRouter', () => {
     });
   });
 });
+
+describe('resolveEmailDestination', () => {
+  // The redirect target must always be a string this module owns, never the
+  // caller's — an off-site value reaching res.redirect is an open redirect
+  // (tssecurity:S5146), and a phished 2anki email link is the realistic abuse.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { resolveEmailDestination } = require('./EmailRedirectRouter') as {
+    resolveEmailDestination: (requested: string | null) => string;
+  };
+
+  it.each(['/', '/upload', '/pricing', '/login'])(
+    'passes through the allowlisted destination %s',
+    (destination) => {
+      expect(resolveEmailDestination(destination)).toBe(destination);
+    }
+  );
+
+  it.each([
+    ['https://evil.example.com', 'absolute off-site URL'],
+    ['//evil.example.com', 'protocol-relative URL'],
+    ['/upload/../../etc/passwd', 'traversal out of an allowed path'],
+    ['/uploadX', 'prefix of an allowed path'],
+    ['javascript:alert(1)', 'script scheme'],
+    ['', 'empty string'],
+    ['constructor', 'Object.prototype key'],
+    ['__proto__', 'prototype-pollution key'],
+    ['toString', 'inherited method name'],
+  ])('falls back to / for %s (%s)', (requested) => {
+    expect(resolveEmailDestination(requested)).toBe('/');
+  });
+
+  it('falls back to / when no destination was supplied', () => {
+    expect(resolveEmailDestination(null)).toBe('/');
+  });
+});

--- a/src/routes/EmailRedirectRouter.ts
+++ b/src/routes/EmailRedirectRouter.ts
@@ -7,12 +7,29 @@ import PriceLockInEmailRepository from '../data_layer/PriceLockInEmailRepository
 import ReEngagementRepository from '../data_layer/ReEngagementRepository';
 import { getEventsSink } from '../services/events/eventsSinkInstance';
 
-const ALLOWED_EMAIL_DESTINATIONS = new Set([
-  '/',
-  '/upload',
-  '/pricing',
-  '/login',
+// Keyed by the value that may appear in ?to=, valued by the path we redirect to.
+// A Set + `has()` guard was equally safe at runtime, but the redirect still
+// forwarded the caller's own string, so Sonar's taint engine could not tell an
+// open redirect from a checked one (tssecurity:S5146, reported BLOCKER). Looking
+// the value up here means the string handed to res.redirect is always one of
+// ours, never the caller's — the taint chain ends at the lookup instead of
+// needing a False Positive marking in the SonarCloud UI.
+// A Map, not an object literal: an object would resolve inherited keys, so
+// `?to=toString` would hand back Object.prototype.toString and interpolate a
+// function into the redirect URL. A Map has no inherited entries.
+const EMAIL_DESTINATIONS = new Map<string, string>([
+  ['/', '/'],
+  ['/upload', '/upload'],
+  ['/pricing', '/pricing'],
+  ['/login', '/login'],
 ]);
+
+const DEFAULT_EMAIL_DESTINATION = '/';
+
+export function resolveEmailDestination(requested: string | null): string {
+  if (requested == null) return DEFAULT_EMAIL_DESTINATION;
+  return EMAIL_DESTINATIONS.get(requested) ?? DEFAULT_EMAIL_DESTINATION;
+}
 
 const EmailRedirectRouter = () => {
   const router = express.Router();
@@ -56,10 +73,7 @@ const EmailRedirectRouter = () => {
     const rawDestination =
       typeof req.query.to === 'string' ? req.query.to : null;
 
-    const destination =
-      rawDestination != null && ALLOWED_EMAIL_DESTINATIONS.has(rawDestination)
-        ? rawDestination
-        : '/';
+    const destination = resolveEmailDestination(rawDestination);
 
     const domain = process.env.DOMAIN ?? 'https://2anki.net';
     const sink = getEventsSink();

--- a/src/routes/middleware/RequireAllowedOrigin.ts
+++ b/src/routes/middleware/RequireAllowedOrigin.ts
@@ -6,6 +6,7 @@ import UsersRepository from '../../data_layer/UsersRepository';
 import TokenRepository from '../../data_layer/TokenRepository';
 import { getDatabase } from '../../data_layer';
 import { configureUserLocal } from './configureUserLocal';
+import { sanitizeForLog } from '../../lib/log/sanitizeForLog';
 
 const RequireAllowedOrigin = async (
   req: Request,
@@ -18,7 +19,9 @@ const RequireAllowedOrigin = async (
   }
 
   const permitted = ALLOWED_ORIGINS.includes(origin);
-  console.info(`checking if ${origin} is whitelisted ${permitted}`);
+  console.info(
+    `checking if ${sanitizeForLog(origin)} is whitelisted ${permitted}`
+  );
   if (!permitted) {
     return res.status(403).end();
   }

--- a/src/services/EmailService/EmailService.ts
+++ b/src/services/EmailService/EmailService.ts
@@ -946,8 +946,11 @@ export class EmailService implements IEmailService {
 }
 
 export class UnimplementedEmailService implements IEmailService {
-  async sendResetEmail(email: string, token: string): Promise<void> {
-    console.info('sendResetEmail not handled', email, token);
+  async sendResetEmail(_email: string, _token: string): Promise<void> {
+    // Deliberately logs neither argument: the address is PII and the token is a
+    // live password-reset credential, so printing them put an account-takeover
+    // secret into the prod log (CWE-532).
+    console.info('sendResetEmail not handled by UnimplementedEmailService');
   }
 
   sendConversionEmail(

--- a/src/services/NotionService/NotionAPIWrapper.ts
+++ b/src/services/NotionService/NotionAPIWrapper.ts
@@ -26,6 +26,7 @@ import type { IBlocksCacheRepository } from '../../data_layer/BlocksCacheReposit
 import { isValidNotionId } from './isValidNotionId';
 import { ValidNotionType } from './types';
 import { notionCallRingBuffer } from './NotionCallRingBuffer';
+import { sanitizeForLog } from '../../lib/log/sanitizeForLog';
 
 const DEFAULT_PAGE_SIZE_LIMIT = 100 * 2;
 const SEARCH_MAX_PAGES = 20;
@@ -61,7 +62,7 @@ class NotionAPIWrapper {
     if (!isValidNotionId(id)) {
       console.info(
         '[notion] skipping pages.retrieve for non-UUID id:',
-        JSON.stringify(id).slice(0, 80)
+        sanitizeForLog(id)
       );
       return Promise.resolve(null);
     }

--- a/src/services/NotionService/helpers/getPlainText.ts
+++ b/src/services/NotionService/helpers/getPlainText.ts
@@ -6,7 +6,7 @@ export default function getPlainText(text: Text[]): string {
   if (!text || text.length === 0) {
     return '';
   }
-  return text
-    .map((t) => t.plain_text)
-    .reduce((acc, curr) => `${acc}<br>${curr}`);
+  // join, not reduce with a seed: seeding with '' would prepend a stray <br>
+  // before the first fragment. join is the operation this always was.
+  return text.map((t) => t.plain_text).join('<br>');
 }

--- a/src/services/mcp/McpServerFactory.ts
+++ b/src/services/mcp/McpServerFactory.ts
@@ -15,6 +15,7 @@ import type {
   PhotoDensity,
   PhotoMode,
 } from '../../usecases/imageOcclusion/PhotoToFlashcardsUseCase';
+import { sanitizeForLog } from '../../lib/log/sanitizeForLog';
 
 export const MCP_SERVER_NAME = '2anki';
 export const MCP_SERVER_VERSION = '1.0.0';
@@ -295,7 +296,7 @@ export function buildMcpServer(context: McpRequestContext): McpServer {
         const message =
           error instanceof Error ? error.message : 'Could not load the deck.';
         console.error(
-          `[mcp] get_deck_preview failed for ${identifier}: ${message}`
+          `[mcp] get_deck_preview failed for ${sanitizeForLog(identifier)}: ${message}`
         );
         return errorResult(message, 'preview_failed');
       }

--- a/src/usecases/ankify/ankifyStreak.ts
+++ b/src/usecases/ankify/ankifyStreak.ts
@@ -17,10 +17,14 @@ export function computeReviewStreaks(
   reviewsByDay: Array<[string, number]>,
   today: string
 ): ReviewStreaks {
+  // Day keys are ISO `YYYY-MM-DD`, where lexicographic order already equals
+  // chronological order, so a bare .sort() was correct — but it reads as the
+  // classic default-sort bug and Sonar flags it CRITICAL (typescript:S2871).
+  // Comparing explicitly says the ordering is intentional.
   const activeDays = reviewsByDay
     .filter(([, count]) => count > 0)
     .map(([day]) => day)
-    .sort();
+    .sort((a, b) => a.localeCompare(b));
 
   if (activeDays.length === 0) {
     return { currentStreak: 0, longestStreak: 0 };

--- a/src/usecases/developer/ResolveDeveloperTierUseCase.ts
+++ b/src/usecases/developer/ResolveDeveloperTierUseCase.ts
@@ -40,9 +40,15 @@ export class ResolveDeveloperTierUseCase {
     if (owned.length === 0) {
       return SANDBOX_TIER;
     }
-    const best = owned.reduce((a, b) =>
-      b.monthly_card_limit > a.monthly_card_limit ? b : a
-    );
+    // Explicit loop rather than a seedless reduce (typescript:S6959). Keeps the
+    // reduce's tie-breaking exactly: on equal limits the earlier tier wins,
+    // because the comparison is strictly greater-than.
+    let best = owned[0];
+    for (const tier of owned) {
+      if (tier.monthly_card_limit > best.monthly_card_limit) {
+        best = tier;
+      }
+    }
     return {
       tier_key: best.tier_key,
       monthly_card_limit: best.monthly_card_limit,

--- a/src/usecases/events/TrackEventUseCase.ts
+++ b/src/usecases/events/TrackEventUseCase.ts
@@ -1,5 +1,6 @@
 import { EventsSink } from '../../services/events/EventsSink';
 import { KnownEvent } from '../../types/AnalyticsEvents';
+import { sanitizeForLog } from '../../lib/log/sanitizeForLog';
 
 const PII_KEY_PATTERN = /email|token|password|filename|content|title/i;
 const PROPS_MAX_BYTES = 1024;
@@ -18,7 +19,7 @@ export class TrackEventUseCase {
   execute(input: TrackEventInput): void {
     const { name, unknown, userId, anonymousId, props } = input;
     if (unknown) {
-      console.warn(`[events] unknown event received: ${name}`);
+      console.warn(`[events] unknown event received: ${sanitizeForLog(name)}`);
     }
     const safeProps = this.stripPiiKeys(props);
     const serialized = JSON.stringify(safeProps);

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -142,10 +142,14 @@ export function HomePage({
 }: Readonly<HomePageProps>) {
   useSettingsCardsOptions(null);
   const { t } = useTranslation();
-  const mascotSrc = useMemo(
-    () => MASCOTS[Math.floor(Math.random() * MASCOTS.length)],
-    []
-  );
+  // Picking a mascot is cosmetic, but Sonar flags every Math.random as a
+  // security hotspot (typescript:S2245) regardless of intent, and crypto costs
+  // nothing here. The retry-jitter callers keep Math.random — see the S2245
+  // carve-out in .claude/rules/security.md.
+  const mascotSrc = useMemo(() => {
+    const sample = crypto.getRandomValues(new Uint32Array(1))[0];
+    return MASCOTS[sample % MASCOTS.length];
+  }, []);
   const [showAll, setShowAll] = useState(false);
   const landingViewedRef = useRef(false);
 

--- a/web/src/pages/MindmapsPage/MindmapEditor.tsx
+++ b/web/src/pages/MindmapsPage/MindmapEditor.tsx
@@ -1295,7 +1295,11 @@ export function MindmapEditor() {
       {contextMenu != null && (
         <div
           role="menu"
+          // Both handlers only stop propagation so a click or key inside the
+          // menu does not reach the dismiss handler on the surface behind it.
+          // The menu's actual controls are the buttons within.
           onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
           className={styles.contextMenu}
           style={{ top: contextMenu.y, left: contextMenu.x }}
         >


### PR DESCRIPTION
Clears **49 of 59** open Sonar vulnerabilities and bugs, including both BLOCKERs and the CRITICAL. Those three are what drive the ratings — **security E** and **reliability D** came from a handful of findings, not from the volume.

## Two were real security problems

**`src/KnexConfig.ts` — credentials in a public repo (CWE-798, `secrets:S6698`, BLOCKER).** The fallback DSN embedded a username and password. The fallback stays so local dev and the `data_layer` tests still reach a localhost Postgres, but it now carries no credentials; anything needing a password sets `DATABASE_URL`. A test asserts no credentials can come back.

**Two logs leaked PII and a live secret (CWE-532, `tssecurity:S5145`).**
- `IndexController` logged the contact form's **name, email address and full message body**. Exactly the identifiers `.claude/rules/support-confidentiality.md` exists to keep out of artifacts.
- `UnimplementedEmailService` logged an email address alongside a **live password-reset token** — an account-takeover secret in the prod log.

Both now log shape only (`hasName`, `messageLength`), never values.

## The open redirect was safe but unprovable — now it's both

`EmailRedirectRouter` already gated `?to=` behind an allowlist, but it forwarded **the caller's own string**, so the taint engine couldn't distinguish a checked redirect from an open one. It now looks the value up in a `Map`, so the string reaching `res.redirect` is always one of ours — the taint chain ends at the lookup rather than needing a UI waiver.

**The `Map` is load-bearing.** My first attempt used an object literal, which resolves inherited keys — `?to=toString` returned `Object.prototype.toString` and interpolated a function into the redirect URL. The tests I wrote first caught it. There are now cases for `__proto__`, `constructor`, `toString`, protocol-relative URLs, absolute off-site URLs and traversal.

## 33 findings needed no code change

The code was already correct and the scanner couldn't see it:

| Finding | Why it's already fine |
|---|---|
| 11× `S5693` content-length | **Every** multer instance under `src/routes/` already declares an explicit `limits.fileSize` (10/25/50/100MB) |
| 11× HTML/CSS in `src/lib/parser/__fixtures__/` | Test data that should never have been scanned — now excluded |
| 9× `json:S2068` "password" | UI strings on the reset-password screens in the locale files |
| 2× `S2245` `Math.random` | Retry-backoff jitter, already carved out in `.claude/rules/security.md` |

Each waiver comment states **what it would hide** — a new upload route without a cap is called out explicitly, so the waiver can't quietly mask a missing limit.

## Mechanical fixes

- **`ankifyStreak.ts` (CRITICAL, `S2871`)** — a false positive in substance: the keys are ISO `YYYY-MM-DD`, where lexicographic order already equals chronological. An explicit comparator says so. **Streaks were being computed correctly.**
- **3× seedless `reduce`** — fixed by expressing what each one does rather than bolting on a seed. `getPlainText` became a `join`, because seeding with `''` would have **prepended a stray `<br>`**.
- **6× log injection** — new `sanitizeForLog` helper (12 tests) replaces control characters and caps length. Built as a code-point scan, not a regex, after an early draft shipped `[ -]` — which replaced spaces and hyphens and no control characters at all.
- **`MindmapEditor`** keyboard handler beside the existing click-stop; **`HomePage`** mascot picker moved to `crypto.getRandomValues`.

## 10 deliberately left, with reasons

**Would change behaviour in ways the suite can't catch:** 3× async promise executors (`S6544`), 1× redundant try (`S4822`), 1× mixed JSX/string `reduce` (`S6959`). The `S4822` one sits in `SyncNotionPageToRacUseCase` — the exact path https://github.com/2anki/server/issues/3926 is still open on, so I'm not touching it while a memory leak is unexplained there.

**Needs the SonarCloud UI (can't be waived from config):** 2× `instrumentedAxios` taint findings — per `.claude/rules/sonar.md`, `tssecurity` rules ignore multicriteria. These need marking False Positive.

**MINOR, poor risk-to-value:** a nodemailer **sendmail** transport flagged as clear-text (local binary delivery; not worth touching mail for a MINOR), a PATH lookup in a release helper, an empty array in a dev mock script.

## Verification

- **Server: 656 suites / 6078 tests passed.** Only failure is the documented environmental `getPageCount.test.ts` (needs `pdfinfo`).
- **Web: 353 files / 2767 tests passed.** Lint warnings are all pre-existing.
- `npx tsc -p . --noEmit` and `pnpm --filter 2anki-web typecheck` — both exit 0.
- `pnpm format:check` — clean tree-wide.
- Sonar will report on this PR directly now that decoration works, so the gate result is the real check here.

Browser check: not applicable — the two `web/src/` changes are a `stopPropagation` keyboard handler mirroring the existing click handler, and a random-source swap in a mascot picker. Neither alters rendered output. The web suite covers both files.

No changelog entry — no user-visible behavior change. The one user-facing surface touched (streaks) was already producing correct output; the fix only makes the ordering explicit.
