### PR TITLE
fix: declare UTF-8 source encoding for Sonar

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -18,6 +18,15 @@ sonar.coverage.exclusions=src/templates/**,src/migrations/**,src/test/fixtures/*
 
 sonar.cpd.exclusions=src/migrations/**,src/data_layer/public/**,web/src/generated/**,web/src/schemas/**,web/src/pages/OpsPage/performanceTypes.ts,web/src/pages/ConvertLandingPage/convertLandingConfig.ts,web/src/pages/ConvertHubPage/convertHubGroups.ts,web/src/pages/LandingPage/copy/**,src/controllers/CardOptionsController/supportedOptions.ts,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
 
+# Declared explicitly because the scanner otherwise falls back to the JVM default
+# charset, which is US-ASCII in a bare Automatic Analysis container. 1045 of the
+# ~3960 scanned source files contain non-ASCII bytes — the ja/ru/de locale JSON,
+# em-dashes in comments, ellipses in copy — so every one of them failed to decode
+# and the last analysis reported "There are problems with file encoding in the
+# source code" (2026-07-30). Nothing was actually mis-encoded: all 4064 tracked
+# source files decode as UTF-8 cleanly, and none carry a BOM.
+sonar.sourceEncoding=UTF-8
+
 sonar.javascript.file.suffixes=.js,.jsx
 sonar.typescript.file.suffixes=.ts,.tsx
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -19,6 +19,15 @@ sonar.cpd.exclusions=src/migrations/**,src/data_layer/public/**,web/src/generate
 
 sonar.javascript.lcov.reportPaths=coverage/lcov.info,web/coverage/lcov.info
 
+# Declared explicitly because the scanner otherwise falls back to the JVM default
+# charset, which is US-ASCII in a bare Automatic Analysis container. 1045 of the
+# ~3960 scanned source files contain non-ASCII bytes — the ja/ru/de locale JSON,
+# em-dashes in comments, ellipses in copy — so every one of them failed to decode
+# and the last analysis reported "There are problems with file encoding in the
+# source code" (2026-07-30). Nothing was actually mis-encoded: all 4064 tracked
+# source files decode as UTF-8 cleanly, and none carry a BOM.
+sonar.sourceEncoding=UTF-8
+
 sonar.javascript.file.suffixes=.js,.jsx
 sonar.typescript.file.suffixes=.ts,.tsx
 

--- a/src/lib/sonarConfigParity.test.ts
+++ b/src/lib/sonarConfigParity.test.ts
@@ -113,6 +113,19 @@ describe('Sonar config parity between the CLI and Automatic Analysis', () => {
     expect(missing).toEqual([]);
   });
 
+  it.each([
+    ['sonar-project.properties', 'cli'],
+    ['.sonarcloud.properties', 'autoScan'],
+  ])('declares UTF-8 source encoding in %s', (_label, which) => {
+    // Left undeclared, the scanner falls back to the JVM default charset —
+    // US-ASCII in a bare Automatic Analysis container — and fails to decode the
+    // ~1000 source files containing non-ASCII bytes, which is what produced the
+    // "problems with file encoding" warning on 2026-07-30.
+    const config = which === 'cli' ? cli : autoScan;
+
+    expect(config.get('sonar.sourceEncoding')).toBe('UTF-8');
+  });
+
   it('points the CLI at the laer-smart project the repo is bound to', () => {
     // The repo moved orgs; the stale key pointed at a different project that
     // kept scanning main and had no quality gate, so nothing looked wrong.


### PR DESCRIPTION
## The warning

The last SonarCloud analysis reported:

> There are problems with file encoding in the source code. Please check the scanner logs for more details.

## Nothing is mis-encoded

Decoded **every** tracked source file as UTF-8 in Python:

```
checked: 4064
invalid utf-8: 0
with UTF-8 BOM: 0
```

## The actual cause

Neither `sonar-project.properties` nor `.sonarcloud.properties` declared `sonar.sourceEncoding`, so the scanner falls back to the **JVM default charset** — US-ASCII in a bare Automatic Analysis container.

**1045 of the ~3960 scanned source files contain non-ASCII bytes:** the `ja`/`ru`/`de` locale JSON, em-dashes in comments, ellipses in user-facing copy. Every one of them fails to decode under a US-ASCII assumption. Valid files, wrong reader.

Declared in **both** files (the CLI and Automatic Analysis read different ones), and asserted in `src/lib/sonarConfigParity.test.ts` — 9 tests now — so it can't be dropped from one of them again.

## How the diagnosis nearly went wrong

Recording this because the wrong answer looked convincing. An `iconv`-based sweep reported **12 locale files as invalid UTF-8**, which would have pointed the fix at rewriting those files. Two independent tooling artifacts stacked up:

1. macOS `iconv` emits `Inappropriate ioctl for device` and a non-zero exit for reasons unrelated to encoding — so a `!iconv …` test reads as "invalid" on perfectly good files.
2. A shell loop over `git ls-files` **without NUL delimiters** word-split the `src/test/fixtures/` filenames that contain spaces into fragments, which then failed to open and were reported as encoding failures.

Python's `bytes.decode('utf-8')` over the same set found zero errors. The lesson is the same one from the heap-ceiling and Sonar-scope mistakes this week: a tool reporting a failure is not the same as the failure existing — check with a second, independent method before acting on it.

## Verification

- `src/lib/sonarConfigParity.test.ts` — 9 passed.
- `npx tsc -p . --noEmit` — exit 0. `pnpm format:check` — clean tree-wide.
- The real check is the next analysis: the warning should be gone, and file/line counts should rise slightly as previously-undecodable files start being analysed. Worth confirming on this PR's own Sonar run.

Browser check: not applicable — no `web/src/` files in the diff.

No changelog entry — CI configuration only, no user-visible behavior change.
