### PR TITLE
test: give the six assertion-less tests real assertions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,8 @@ openapi.json
 # copies of this same repo, so they must never be staged, typechecked, or swept
 # into a test run from the main checkout.
 .claude/worktrees/
+
+# sonar-scanner working directory, created by a local `sonar-scanner` run.
+# Local CLI scans need SONAR_TOKEN scoped to the laer-smart org; see
+# .claude/rules/sonar.md.
+.scannerwork/

--- a/src/lib/parser/DeckParser.test.ts
+++ b/src/lib/parser/DeckParser.test.ts
@@ -622,12 +622,6 @@ test('Colours', async () => {
   expect(deck.cards[0].back.includes('block-color')).toBe(true);
 });
 
-test.skip('HTML Regression Test', (t) => {
-  t.fail(
-    'please automate HTML regression check. Use this page https://www.notion.so/HTML-test-4aa53621a84a4660b69e9953f3938685.'
-  );
-});
-
 test('Nested Toggles', async () => {
   const deck = await getDeck(
     'Nested Toggles.html',

--- a/src/services/events/EventsSink.test.ts
+++ b/src/services/events/EventsSink.test.ts
@@ -107,11 +107,30 @@ describe('EventsSink', () => {
     await expect(sink.waitForPendingFlush()).resolves.toBeUndefined();
   });
 
-  it('start is idempotent', () => {
+  it('start is idempotent — a second start adds no second timer', () => {
+    // This test previously called start twice and stop once with no assertion,
+    // so it passed no matter what start() did. A leaked second interval would
+    // double every periodic flush; the guard in start() is the thing under test.
     const { repo } = makeFakeRepository();
-    const sink = new EventsSink(repo, { flushIntervalMs: 1000 });
-    sink.start();
-    sink.start();
-    sink.stop();
+    const setIntervalSpy = jest.spyOn(global, 'setInterval');
+    const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+
+    try {
+      const sink = new EventsSink(repo, { flushIntervalMs: 1000 });
+
+      sink.start();
+      sink.start();
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+
+      sink.stop();
+      expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+
+      // A second stop must not throw or clear anything it does not own.
+      sink.stop();
+      expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      setIntervalSpy.mockRestore();
+      clearIntervalSpy.mockRestore();
+    }
   });
 });

--- a/web/src/pages/SharedDecksPage/SharedDecksPage.test.tsx
+++ b/web/src/pages/SharedDecksPage/SharedDecksPage.test.tsx
@@ -33,7 +33,7 @@ describe('SharedDecksPage', () => {
 
     renderPage();
 
-    await screen.findByText('No public decks yet');
+    expect(await screen.findByText('No public decks yet')).toBeVisible();
   });
 
   it('renders each deck with title, card count, and a view link', async () => {
@@ -104,6 +104,8 @@ describe('SharedDecksPage', () => {
 
     renderPage();
 
-    await screen.findByText("Couldn't load the shared library. Try again.");
+    expect(
+      await screen.findByText("Couldn't load the shared library. Try again.")
+    ).toBeVisible();
   });
 });

--- a/web/tests/rules-and-card-options.spec.ts
+++ b/web/tests/rules-and-card-options.spec.ts
@@ -171,7 +171,13 @@ test.describe('RulesPage', () => {
 
     await page.getByRole('button', { name: /Save changes/ }).click();
 
-    await Promise.all([rulesSave, settingsSave]);
+    const [rulesRequest, settingsRequest] = await Promise.all([
+      rulesSave,
+      settingsSave,
+    ]);
+
+    expect(rulesRequest.method()).toBe('POST');
+    expect(settingsRequest.method()).toBe('POST');
   });
 
   test('Save changes navigates back to returnTo', async ({ page }) => {
@@ -267,5 +273,7 @@ test.describe('CardOptionsPage', () => {
 
     await page.getByRole('button', { name: '← Back' }).click();
     await page.waitForURL('**/rules/page-1');
+
+    expect(page.url()).toContain('/rules/page-1');
   });
 });


### PR DESCRIPTION
Clears all 6 `typescript:S2699` **BLOCKER** findings. They were not equally broken, so the fixes differ.

## One genuinely passed unconditionally

`src/services/events/EventsSink.test.ts` — `start is idempotent` called `start()` twice and `stop()` once with **no assertion**. A leaked second interval (which would double every periodic flush) could never have failed it.

Now spies `setInterval`/`clearInterval` and asserts one timer created across two starts, one cleared, and that a second `stop()` clears nothing it doesn't own.

**Mutation-tested**, so the assertion demonstrably has teeth:

```
# guard removed from start():
Expected number of calls: 1
Received number of calls: 2
Tests: 1 failed, 5 passed
# guard restored:
Tests: 6 passed
```

## One was dead scaffolding

`src/lib/parser/DeckParser.test.ts` — the HTML-regression case was `test.skip` **and** called `t.fail(...)`, which is ava syntax that would throw rather than fail under jest. It had never run in any form. Deleted; the intent lives on in the export-drift canary, and git history keeps the note.

## Four were weaker than an explicit assertion, but never vacuous

`findByText`, `waitForRequest` and `waitForURL` all **throw on timeout**, so these tests do fail when the behaviour breaks — worth stating plainly, because "6 tests that verify nothing" would have been the wrong summary:

- `SharedDecksPage.test.tsx:28,100` → `expect(await screen.findByText(...)).toBeVisible()`
- `rules-and-card-options.spec.ts:155` → destructures the awaited requests and asserts `.method() === 'POST'`
- `rules-and-card-options.spec.ts:260` → adds `expect(page.url()).toContain('/rules/page-1')`, matching the pattern already used ~25 lines away in the same file

## Also

Ignores `.scannerwork/`, the working directory a local `sonar-scanner` run drops in the repo root. A run during this session created it — empty, so git never saw it, but a successful scan would fill it.

## Why this matters beyond the finding

I have leaned on "6,078 tests green" as the regression safety net repeatedly this week, including when setting the risk tiers for the Sonar sweep. One of those tests asserted nothing and another had never executed. `.claude/rules/testing.md` already forbids both ("Do not write a test that asserts only 'did not throw'", "Do not commit `.only`/`.skip`) — it was a rule with no sensor behind it. Sonar's `S2699` is that sensor, and it now reports zero.

## Verification

- **Server: 656 suites / 6080 tests passed.** Only failure is the documented environmental `getPageCount.test.ts` (needs `pdfinfo`).
- **Web: 353 files / 2767 tests passed.**
- `npx tsc -p . --noEmit` and `pnpm --filter 2anki-web typecheck` — both exit 0. `pnpm format:check` clean tree-wide.
- The two Playwright changes were **not executed locally** (they need the mock API server); they are type-checked and lint-clean, and CI's `playwright` job covers them.

Browser check: not applicable — the only `web/src/` change is a test file; no runtime code and no rendered output is touched.

No changelog entry — test-only change plus one gitignore line, no user-visible behavior change.
