### PR TITLE
feat: show the structure-rescue notice on upload results

### DIFF
--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -955,6 +955,93 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     );
   });
 
+  it('sets X-Structure-Rescued to the shipped rescue rule on a single-deck sync upload', async () => {
+    MockGeneratePackagesUseCase.mockImplementation(
+      () =>
+        ({
+          execute: jest.fn().mockResolvedValue({
+            packages: [
+              {
+                name: 'deck',
+                cardCount: 8,
+                mcqCount: 0,
+                mcqSkippedCount: 0,
+                inducedRule: { rule: 'heading', outcome: 'rescue_shipped' },
+              },
+            ],
+            warnings: [],
+          }),
+        }) as unknown as InstanceType<typeof GeneratePackagesUseCase>
+    );
+
+    const service = new UploadService(
+      buildRepository(),
+      {} as JobRepository,
+      buildUsersRepo()
+    );
+    const req = buildRequest();
+    const { res, capturedStatus } = buildResponse();
+
+    await service.handleUpload(req, res);
+
+    expect(capturedStatus()).toBe(200);
+    expect(res.set).toHaveBeenCalledWith('X-Structure-Rescued', 'heading');
+  });
+
+  it('does not set X-Structure-Rescued when the rescue was rejected', async () => {
+    MockGeneratePackagesUseCase.mockImplementation(
+      () =>
+        ({
+          execute: jest.fn().mockResolvedValue({
+            packages: [
+              {
+                name: 'deck',
+                cardCount: 8,
+                mcqCount: 0,
+                mcqSkippedCount: 0,
+                inducedRule: { rule: 'bullets', outcome: 'rescue_rejected' },
+              },
+            ],
+            warnings: [],
+          }),
+        }) as unknown as InstanceType<typeof GeneratePackagesUseCase>
+    );
+
+    const service = new UploadService(
+      buildRepository(),
+      {} as JobRepository,
+      buildUsersRepo()
+    );
+    const req = buildRequest();
+    const { res } = buildResponse();
+
+    await service.handleUpload(req, res);
+
+    expect(res.set).not.toHaveBeenCalledWith(
+      'X-Structure-Rescued',
+      expect.anything()
+    );
+  });
+
+  it('does not set X-Structure-Rescued when no rescue ran', async () => {
+    mockPackages([{ name: 'deck', cardCount: 12 }]);
+
+    const service = new UploadService(
+      buildRepository(),
+      {} as JobRepository,
+      buildUsersRepo()
+    );
+    const req = buildRequest();
+    const { res } = buildResponse();
+
+    await service.handleUpload(req, res);
+
+    expect(res.set).not.toHaveBeenCalledWith(
+      'X-Structure-Rescued',
+      expect.anything()
+    );
+  });
+
   it('surfaces a skipped-locked-PDF note on X-Warning when a ZIP entry stays locked', async () => {
     const lockedWarning =
       '2 password-protected PDFs were skipped: Ch1.pdf, Ch2.pdf. Unlock each in Preview or Adobe Reader, save a copy, and upload them on their own.';

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -134,6 +134,7 @@ interface BatchUploadResponse {
   warning?: string;
   droppedImageCount?: number;
   emptyBackCount?: number;
+  structureRescuedRule?: string;
 }
 
 const MARKDOWN_HEURISTIC_WARNING =
@@ -192,6 +193,15 @@ function uploadInputFormat(files: UploadedFile[] | undefined): string {
   if (dot < 0 || dot === name.length - 1) return 'unknown';
   const ext = name.slice(dot + 1).toLowerCase();
   return KNOWN_INPUT_FORMATS.has(ext) ? ext : 'other';
+}
+
+function shippedRescueRule(
+  packages: { inducedRule?: InducedRescue }[]
+): string | undefined {
+  const shipped = packages.find(
+    (p) => p.inducedRule?.outcome === 'rescue_shipped'
+  );
+  return shipped?.inducedRule?.rule;
 }
 
 function sumDroppedImages(packages: { droppedImageCount?: number }[]): number {
@@ -1176,6 +1186,11 @@ class UploadService {
         res.set('X-Over-Split', '1');
         exposedHeaders.push('X-Over-Split');
       }
+      const rescuedRule = shippedRescueRule(packages);
+      if (rescuedRule != null) {
+        res.set('X-Structure-Rescued', rescuedRule);
+        exposedHeaders.push('X-Structure-Rescued');
+      }
       const warningText = resolveUploadWarning(warnings);
       if (warningText) {
         res.set('X-Warning', warningText);
@@ -1228,7 +1243,8 @@ class UploadService {
           ws,
           resolveUploadWarning(warnings),
           sumDroppedImages(packages),
-          totalEmptyBackCount
+          totalEmptyBackCount,
+          shippedRescueRule(packages)
         )
       );
   }
@@ -1237,7 +1253,8 @@ class UploadService {
     ws: Workspace,
     warning: string | null = null,
     droppedImageCount = 0,
-    emptyBackCount = 0
+    emptyBackCount = 0,
+    structureRescuedRule?: string
   ): Promise<BatchUploadResponse> {
     const apkgFilenames = (await fs.promises.readdir(ws.location)).filter(
       (filename) => filename.endsWith('.apkg')
@@ -1256,6 +1273,7 @@ class UploadService {
       ...(warning ? { warning } : {}),
       ...(droppedImageCount > 0 ? { droppedImageCount } : {}),
       ...(emptyBackCount > 0 ? { emptyBackCount } : {}),
+      ...(structureRescuedRule == null ? {} : { structureRescuedRule }),
     };
   }
 

--- a/web/src/pages/DownloadsPage/components/StructureRescuedNotice.tsx
+++ b/web/src/pages/DownloadsPage/components/StructureRescuedNotice.tsx
@@ -5,16 +5,18 @@ import { StructureRescueRule } from '../helpers/parseStructureRescuedPayload';
 
 interface StructureRescuedNoticeProps {
   rule: StructureRescueRule;
+  source?: 'notion' | 'upload';
 }
 
 export function StructureRescuedNotice({
   rule,
+  source = 'notion',
 }: Readonly<StructureRescuedNoticeProps>) {
   const { t } = useTranslation('downloadsx');
 
   useEffect(() => {
-    track('structure_rescued_notice_shown', { rule });
-  }, [rule]);
+    track('structure_rescued_notice_shown', { rule, source });
+  }, [rule, source]);
 
   const structure = t(`structureRescued.structures.${rule}`);
 

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -40,6 +40,7 @@ vi.mock('../../../../lib/hooks/useCardUsage', () => ({
 import { useUserLocals } from '../../../../lib/hooks/useUserLocals';
 import { useCardUsage } from '../../../../lib/hooks/useCardUsage';
 import { get2ankiApi } from '../../../../lib/backend/get2ankiApi';
+import { track } from '../../../../lib/analytics/track';
 
 const mockUseUserLocals = vi.mocked(useUserLocals);
 const mockUseCardUsage = vi.mocked(useCardUsage);
@@ -439,6 +440,71 @@ describe('UploadForm analytics events', () => {
     });
 
     expect(gtag).not.toHaveBeenCalledWith('event', 'conversion_success');
+  });
+
+  it('shows the structure-rescue notice when the X-Structure-Rescued header is present', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        redirected: false,
+        status: 200,
+        headers: new Headers({
+          'Content-Type': 'application/octet-stream',
+          'Content-Disposition': 'attachment; filename="deck.apkg"',
+          'X-Card-Count': '5',
+          'X-Structure-Rescued': 'heading',
+        }),
+        blob: () => Promise.resolve(new Blob(['fake'])),
+      })
+    );
+
+    const { container } = renderUploadForm(
+      <UploadForm setErrorMessage={vi.fn()} />
+    );
+
+    const form = container.querySelector('form')!;
+    await act(async () => {
+      form.dispatchEvent(
+        new Event('submit', { bubbles: true, cancelable: true })
+      );
+    });
+
+    expect(
+      screen.getByText(/Cards built from the headings/)
+    ).toBeInTheDocument();
+    expect(track).toHaveBeenCalledWith('structure_rescued_notice_shown', {
+      rule: 'heading',
+      source: 'upload',
+    });
+  });
+
+  it('does not show the structure-rescue notice on a normal conversion', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        redirected: false,
+        status: 200,
+        headers: new Headers({
+          'Content-Type': 'application/octet-stream',
+          'Content-Disposition': 'attachment; filename="deck.apkg"',
+          'X-Card-Count': '5',
+        }),
+        blob: () => Promise.resolve(new Blob(['fake'])),
+      })
+    );
+
+    const { container } = renderUploadForm(
+      <UploadForm setErrorMessage={vi.fn()} />
+    );
+
+    const form = container.querySelector('form')!;
+    await act(async () => {
+      form.dispatchEvent(
+        new Event('submit', { bubbles: true, cancelable: true })
+      );
+    });
+
+    expect(screen.queryByText(/Cards built from the/)).toBeNull();
   });
 
   it('posts to /api/upload/dropbox when the chooser returns a file', async () => {

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -18,6 +18,7 @@ import {
 import { getDownloadFileName } from '../../../DownloadsPage/helpers/getDownloadFileName';
 import { ImageDropNotice } from '../../../DownloadsPage/components/ImageDropNotice';
 import { EmptyBackNotice } from '../../../DownloadsPage/components/EmptyBackNotice';
+import { StructureRescuedNotice } from '../../../DownloadsPage/components/StructureRescuedNotice';
 import { ConversionResult } from '../../../DownloadsPage/components/ConversionResult/ConversionResult';
 import { OverSplitNotice } from './OverSplitNotice';
 import { getEmptyDeckChatPrompt } from '../../helpers/getEmptyDeckChatPrompt';
@@ -285,6 +286,8 @@ function UploadForm({
     emptyBackCount,
     setEmptyBackCount,
     setOverSplit,
+    structureRescuedRule,
+    setStructureRescuedRule,
     mcqDrawerOpen,
     setMcqDrawerOpen,
     mcqShowAnswer,
@@ -367,6 +370,7 @@ function UploadForm({
     setProgressWidth,
     setBatchResult,
     setZoneState,
+    setStructureRescuedRule,
   };
 
   const { data: userLocals } = useUserLocals();
@@ -973,6 +977,11 @@ function UploadForm({
           <OverSplitNotice cardCount={cardCount} />
         </div>
       )}
+      {structureRescuedRule != null && (
+        <div className={formStyles.warningInline}>
+          <StructureRescuedNotice rule={structureRescuedRule} source="upload" />
+        </div>
+      )}
       {showFallback && (
         <button
           type="button"
@@ -1033,6 +1042,14 @@ function UploadForm({
         {emptyBackCount > 0 && (
           <div className={formStyles.warningInline}>
             <EmptyBackNotice count={emptyBackCount} multipleDecks />
+          </div>
+        )}
+        {structureRescuedRule != null && (
+          <div className={formStyles.warningInline}>
+            <StructureRescuedNotice
+              rule={structureRescuedRule}
+              source="upload"
+            />
           </div>
         )}
         <ul className={formStyles.deckList}>

--- a/web/src/pages/UploadPage/components/UploadForm/hooks/useUploadFormState.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/hooks/useUploadFormState.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { UploadErrorBody } from '../../../../../types/UploadErrorBody';
+import type { StructureRescueRule } from '../../../../DownloadsPage/helpers/parseStructureRescuedPayload';
 import type { UploadSource } from '../UploadSourceChips';
 
 export type ZoneState =
@@ -27,6 +28,7 @@ export interface BatchResult {
   warning?: string;
   droppedImageCount?: number;
   emptyBackCount?: number;
+  structureRescuedRule?: string;
 }
 
 export interface LockedPdfInfo {
@@ -51,6 +53,8 @@ export function useUploadFormState(onReset: () => void) {
   const [droppedImageCount, setDroppedImageCount] = useState<number>(0);
   const [emptyBackCount, setEmptyBackCount] = useState<number>(0);
   const [overSplit, setOverSplit] = useState(false);
+  const [structureRescuedRule, setStructureRescuedRule] =
+    useState<StructureRescueRule | null>(null);
   const [mcqDrawerOpen, setMcqDrawerOpen] = useState(false);
   const [mcqShowAnswer, setMcqShowAnswer] = useState(false);
   const [warningMessage, setWarningMessage] = useState<string | null>(null);
@@ -87,6 +91,7 @@ export function useUploadFormState(onReset: () => void) {
     setDroppedImageCount(0);
     setEmptyBackCount(0);
     setOverSplit(false);
+    setStructureRescuedRule(null);
     setMcqDrawerOpen(false);
     setMcqShowAnswer(false);
     setWarningMessage(null);
@@ -131,6 +136,8 @@ export function useUploadFormState(onReset: () => void) {
     setEmptyBackCount,
     overSplit,
     setOverSplit,
+    structureRescuedRule,
+    setStructureRescuedRule,
     mcqDrawerOpen,
     setMcqDrawerOpen,
     mcqShowAnswer,

--- a/web/src/pages/UploadPage/components/UploadForm/uploadResponse.test.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/uploadResponse.test.ts
@@ -23,6 +23,7 @@ function buildHandlers(): ConversionSuccessHandlers {
     setProgressWidth: vi.fn(),
     setBatchResult: vi.fn(),
     setZoneState: vi.fn(),
+    setStructureRescuedRule: vi.fn(),
   };
 }
 
@@ -173,6 +174,62 @@ describe('applyConversionSuccess', () => {
     await applyConversionSuccess(singleDeckResponse(), handlers);
 
     expect(handlers.setOverSplit).toHaveBeenCalledWith(false);
+  });
+
+  it('reads the rescue rule from the X-Structure-Rescued header on a single deck', async () => {
+    const handlers = buildHandlers();
+
+    await applyConversionSuccess(
+      singleDeckResponse({ 'X-Structure-Rescued': 'heading' }),
+      handlers
+    );
+
+    expect(handlers.setStructureRescuedRule).toHaveBeenCalledWith('heading');
+  });
+
+  it('sets the rescue rule to null when the X-Structure-Rescued header is absent', async () => {
+    const handlers = buildHandlers();
+
+    await applyConversionSuccess(singleDeckResponse(), handlers);
+
+    expect(handlers.setStructureRescuedRule).toHaveBeenCalledWith(null);
+  });
+
+  it('ignores an unknown value in the X-Structure-Rescued header', async () => {
+    const handlers = buildHandlers();
+
+    await applyConversionSuccess(
+      singleDeckResponse({ 'X-Structure-Rescued': 'not-a-rule' }),
+      handlers
+    );
+
+    expect(handlers.setStructureRescuedRule).toHaveBeenCalledWith(null);
+  });
+
+  it('reads structureRescuedRule from the batch JSON body', async () => {
+    const handlers = buildHandlers();
+    const response = {
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+      json: () =>
+        Promise.resolve({
+          kind: 'batch',
+          workspaceId: 'ws-1',
+          deckCount: 1,
+          decks: [
+            {
+              name: 'A',
+              filename: 'A.apkg',
+              downloadUrl: '/download/ws-1/A.apkg',
+            },
+          ],
+          bulkUrl: '/download/ws-1/bulk',
+          structureRescuedRule: 'columns',
+        }),
+    } as unknown as Response;
+
+    await applyConversionSuccess(response, handlers);
+
+    expect(handlers.setStructureRescuedRule).toHaveBeenCalledWith('columns');
   });
 
   it('reads droppedImageCount from the batch JSON body', async () => {

--- a/web/src/pages/UploadPage/components/UploadForm/uploadResponse.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/uploadResponse.ts
@@ -1,4 +1,8 @@
 import getHeadersFilename from '../../helpers/getHeadersFilename';
+import {
+  STRUCTURE_RESCUE_RULES,
+  type StructureRescueRule,
+} from '../../../DownloadsPage/helpers/parseStructureRescuedPayload';
 import type { BatchResult, ZoneState } from './hooks/useUploadFormState';
 
 export function resolveDeckName(headers: Headers): string {
@@ -40,6 +44,16 @@ export interface ConversionSuccessHandlers {
   setProgressWidth: (value: number) => void;
   setBatchResult: (value: BatchResult) => void;
   setZoneState: (value: ZoneState) => void;
+  setStructureRescuedRule: (value: StructureRescueRule | null) => void;
+}
+
+export function parseStructureRescuedValue(
+  value: unknown
+): StructureRescueRule | null {
+  return typeof value === 'string' &&
+    (STRUCTURE_RESCUE_RULES as readonly string[]).includes(value)
+    ? (value as StructureRescueRule)
+    : null;
 }
 
 function isBatchResult(value: unknown): value is BatchResult {
@@ -62,6 +76,9 @@ export async function applyConversionSuccess(
       handlers.setBatchResult(body);
       handlers.setDroppedImageCount(body.droppedImageCount ?? 0);
       handlers.setEmptyBackCount(body.emptyBackCount ?? 0);
+      handlers.setStructureRescuedRule(
+        parseStructureRescuedValue(body.structureRescuedRule)
+      );
       handlers.setProgressWidth(100);
       handlers.setZoneState('multiDeck');
       return;
@@ -85,6 +102,9 @@ export async function applyConversionSuccess(
     parseNonNegativeIntHeader(response.headers, 'X-Empty-Back-Count')
   );
   handlers.setOverSplit(response.headers.get('X-Over-Split') === '1');
+  handlers.setStructureRescuedRule(
+    parseStructureRescuedValue(response.headers.get('X-Structure-Rescued'))
+  );
   const blob = await response.blob();
   handlers.setDownloadLink(globalThis.URL.createObjectURL(blob));
   handlers.setProgressWidth(100);

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-31-upload-structure-rescue-notice.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-31-upload-structure-rescue-notice.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-31-upload-structure-rescue-notice",
+  "date": "2026-07-31",
+  "type": "feature",
+  "title": "Uploaded files rescued from their headings, bullets, or Q&A now say so on the result screen, like Notion pages already do"
+}


### PR DESCRIPTION
## What

The structure rescue (#3908) ships on both conversion paths, but the provenance notice only rendered for Notion jobs — the upload majority (~157 of the 227 monthly empty-deck failures) silently became structure-derived decks with no explanation. This adds the missing transport on the synchronous upload delivery and renders the existing notice from it.

Closes #3909

## How

- **Server:** when any package's rescue shipped (`inducedRule.outcome === 'rescue_shipped'`, same predicate the Notion path uses in `performConversion`), the single-deck sync response carries `X-Structure-Rescued: <rule>` (exposed via `Access-Control-Expose-Headers`, mirroring `X-Over-Split`/`X-Dropped-Assets`), and the multi-deck batch JSON carries `structureRescuedRule`.
- **Web:** `applyConversionSuccess` parses both transports, validates the value against the known rule set, and the upload success + multi-deck screens render the existing `StructureRescuedNotice` — same component, same 10-locale `structureRescued` strings, unchanged.
- **Analytics:** `StructureRescuedNotice` gains an optional `source` prop (`'notion'` default, `'upload'` from the upload form) on the existing `structure_rescued_notice_shown` event, so the adoption review can split the two surfaces. No new event name — both allowlists untouched.

## Decisions made overnight (please review)

- Transport: chose the `X-Structure-Rescued` response header + batch JSON field over persisting a job-signal row — the sync path already delivers all its result metadata via exposed `X-*` headers, and the issue asked to mirror that existing transport. Assumption: no need for the notice to survive a page refresh on the upload path (the deck object URL doesn't survive one either). If that's wrong, this needs the uploads-table variant instead.
- Copy: reused the existing `structureRescued.*` strings verbatim per the issue ("no new copy needed"). Note the en string says "on this page" — mildly page-flavored for a file upload, but changing it was explicitly out of scope.
- Scope: covered both the single-deck header and the multi-deck batch field; deliberately did NOT add persistence, a Downloads-page row indicator for past uploads, or any new locale keys.

## Tests

- Server: `UploadService.test.ts` — header set on shipped rescue, absent on rejected rescue, absent when no rescue ran (62/62 green).
- Web: `uploadResponse.test.ts` — header parse, unknown-value rejection, batch-field parse; `UploadForm.test.tsx` — notice renders with the tracked `source: 'upload'`, absent on a normal conversion.
- Full suites: server jest 6154 passed / 2 failed — both the documented environmental `getPageCount` pdfinfo failure; web vitest 2776 passed, 0 failed.
- `pnpm format:check` clean tree-wide; oxlint clean on changed lines; server + web tsc clean.
- Sonar: not run locally (overnight run; relying on the PR quality-gate decoration — flag anything it surfaces).

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: machine-backed — `pnpm --filter 2anki-web test:golden-path` 2/2 green (375px viewport, console-error assertions) after installing the Playwright chromium binary. The notice itself is an exact structural mirror of the adjacent `EmptyBackNotice`/`OverSplitNotice` render sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7TQQrHY4ttkng9To493Nd
