### PR TITLE
fix: exclude what AutoScan's inert waivers were meant to hide

### DIFF
--- a/.claude/rules/sonar.md
+++ b/.claude/rules/sonar.md
@@ -35,6 +35,12 @@ Re-verify with `curl` before trusting any of this; it is a snapshot, and two suc
 
 This drifted in practice: on 2026-07-30, `src/data_layer/public/**` (thousands of lines of kanel-generated code) and the four email-template waivers existed **only** in the CLI config, so the PR-side scan was analysing all of it. **`src/lib/sonarConfigParity.test.ts` now enforces parity** — it compares all three exclusion lists, the waiver set, and that every waiver has a `ruleKey` and `resourceKey` in both files. Add an exclusion to one file and that test goes red. Only `projectKey`, `organization`, `sonar.javascript.lcov.reportPaths`, and `sonar.qualitygate.wait` are legitimately CLI-only.
 
+**Automatic Analysis honours a closed property list — `sonar.issue.ignore.multicriteria` is NOT on it (verified 2026-07-31 against the AutoScan docs; #3933).** AutoScan reads only: `sonar.sources`, `sonar.tests`, the `*.inclusions`/`*.exclusions` families (`sonar.exclusions`, `sonar.inclusions`, `sonar.test.exclusions`, `sonar.test.inclusions`), `sonar.sourceEncoding`, `sonar.cpd.exclusions`, and two language-version keys this repo doesn't use. Consequences:
+
+- Every multicriteria waiver is **inert on the PR-side scan** — this is why 22 findings survived the #3930 sweep with a C security rating. The waivers still work for local `sonar-scanner` runs and are kept for that.
+- To silence something on the PR scan, either add a `sonar.exclusions` path (done for `web/src/lib/i18n/locales/**` — the json:S2068 "password" false positives — and `web/src/setupTests.ts` — the S1186 observer stubs) or resolve it once in the SonarCloud UI.
+- **Standing UI actions for Alexander (repo config cannot do these):** mark the 11× `typescript:S5693` findings on `src/routes/**` as reviewed/won't-fix (every multer instance already caps `limits.fileSize`; leaving them findings-with-a-verdict is safer than a blanket suppression that would hide a future uncapped route), and mark the 2× `typescript:S2245` jitter hotspots reviewed (security.md carve-out). Same mechanism as the existing `tssecurity` false positives on `instrumentedAxios.ts`.
+
 ## Run Sonar locally before pushing — required for non-trivial code changes
 
 **When it's required:** any PR that adds or significantly modifies a function, component, controller, or use case. Skip only for pure dependency bumps, doc/changelog edits, test-only changes, or single-line typo fixes.

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -12,7 +12,7 @@ sonar.sources=src,web/src
 sonar.tests=src,web/src,web/tests
 sonar.test.inclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx,web/tests/**
 
-sonar.exclusions=src/templates/**,src/migrations/**,src/test/fixtures/**,src/lib/parser/__fixtures__/**,src/data_layer/public/**,src/config/swagger.ts,src/services/EmailService/templates/**,web/build/**,web/mock-server/**,web/src/generated/**,web/src/schemas/**,web/src/react-app-env.d.ts,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
+sonar.exclusions=src/templates/**,src/migrations/**,src/test/fixtures/**,src/lib/parser/__fixtures__/**,src/data_layer/public/**,src/config/swagger.ts,src/services/EmailService/templates/**,web/build/**,web/mock-server/**,web/src/generated/**,web/src/schemas/**,web/src/react-app-env.d.ts,web/src/lib/i18n/locales/**,web/src/setupTests.ts,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
 
 sonar.coverage.exclusions=src/templates/**,src/migrations/**,src/test/fixtures/**,src/data_layer/public/**,src/config/swagger.ts,web/mock-server/**,web/src/generated/**,web/src/schemas/**,web/src/react-app-env.d.ts,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
 
@@ -30,10 +30,15 @@ sonar.sourceEncoding=UTF-8
 sonar.javascript.file.suffixes=.js,.jsx
 sonar.typescript.file.suffixes=.ts,.tsx
 
-# Waivers mirror sonar-project.properties. gen1/gen2 blanket-ignore the
-# generated folders, which are also excluded above — kept because the belt and
-# braces cost nothing and generated code must never raise a finding.
-sonar.issue.ignore.multicriteria=mock1,mock2,test1,test2,gen1,gen2,email1,email2,email3,email4,i18n1,jitter1,jitter2,upload1
+# Waivers mirror sonar-project.properties — but Automatic Analysis does NOT
+# read sonar.issue.ignore.multicriteria at all (verified 2026-07-31 against the
+# AutoScan docs: its supported-property list is sources/tests, the
+# *.inclusions/*.exclusions families, sourceEncoding, and cpd.exclusions).
+# Every waiver below is inert in THIS file and kept only so the parity test
+# holds the two files identical for the keys both scanners share. Anything
+# that must be quiet on the PR-side scan needs a sonar.exclusions entry above
+# or a one-time UI resolution (S5693 group + S2245 hotspots — see #3933).
+sonar.issue.ignore.multicriteria=mock1,mock2,test1,test2,gen1,gen2,email1,email2,email3,email4,jitter1,jitter2,upload1
 sonar.issue.ignore.multicriteria.mock1.ruleKey=javascript:S5122
 sonar.issue.ignore.multicriteria.mock1.resourceKey=web/mock-server/**
 sonar.issue.ignore.multicriteria.mock2.ruleKey=javascript:S5689
@@ -59,17 +64,11 @@ sonar.issue.ignore.multicriteria.email3.resourceKey=src/services/EmailService/te
 sonar.issue.ignore.multicriteria.email4.ruleKey=css:S7924
 sonar.issue.ignore.multicriteria.email4.resourceKey=src/services/EmailService/templates/**
 
-# i18n1: the locale JSON carries UI strings for the password screens ("Forgot
-# password?", "New password"), which the secret detector reads as credentials.
 # jitter1/jitter2: retry backoff jitter is not a security context — see the
 # S2245 carve-out in .claude/rules/security.md. Do NOT swap these for crypto.
 # upload1: every multer instance under src/routes/ already declares an explicit
-# limits.fileSize cap (10MB chat/contact/occlusion, 25MB feedback, 50MB PDF
-# retry, 100MB apkg). S5693 asks you to confirm the cap is safe; it is, and the
-# rule cannot tell. If you add a NEW upload route, set limits.fileSize on it —
-# this waiver will hide a missing cap.
-sonar.issue.ignore.multicriteria.i18n1.ruleKey=json:S2068
-sonar.issue.ignore.multicriteria.i18n1.resourceKey=web/src/lib/i18n/locales/**
+# limits.fileSize cap. If you add a NEW upload route, set limits.fileSize on
+# it — the local waiver would hide a missing cap; the PR scan still flags it.
 sonar.issue.ignore.multicriteria.jitter1.ruleKey=typescript:S2245
 sonar.issue.ignore.multicriteria.jitter1.resourceKey=src/services/NotionService/helpers/withRetry.ts
 sonar.issue.ignore.multicriteria.jitter2.ruleKey=typescript:S2245

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,7 +11,7 @@ sonar.sources=src,web/src
 sonar.tests=src,web/src,web/tests
 sonar.test.inclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx,web/tests/**
 
-sonar.exclusions=src/templates/**,src/migrations/**,src/test/fixtures/**,src/lib/parser/__fixtures__/**,src/data_layer/public/**,src/config/swagger.ts,src/services/EmailService/templates/**,web/build/**,web/mock-server/**,web/src/generated/**,web/src/schemas/**,web/src/react-app-env.d.ts,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
+sonar.exclusions=src/templates/**,src/migrations/**,src/test/fixtures/**,src/lib/parser/__fixtures__/**,src/data_layer/public/**,src/config/swagger.ts,src/services/EmailService/templates/**,web/build/**,web/mock-server/**,web/src/generated/**,web/src/schemas/**,web/src/react-app-env.d.ts,web/src/lib/i18n/locales/**,web/src/setupTests.ts,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
 
 sonar.coverage.exclusions=src/templates/**,src/migrations/**,src/test/fixtures/**,src/data_layer/public/**,src/config/swagger.ts,web/mock-server/**,web/src/generated/**,web/src/schemas/**,web/src/react-app-env.d.ts,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
 
@@ -31,8 +31,19 @@ sonar.sourceEncoding=UTF-8
 sonar.javascript.file.suffixes=.js,.jsx
 sonar.typescript.file.suffixes=.ts,.tsx
 
-# Rule waivers — mock server is intentionally permissive (CORS, HTTP verbs);
-# test fixtures may carry placeholder credentials for completeness.
+# Rule waivers — LOCAL CLI SCANS ONLY. Verified 2026-07-31 against the
+# Automatic Analysis docs: AutoScan reads a closed property list (sources,
+# tests, the *.inclusions/*.exclusions families, sourceEncoding,
+# cpd.exclusions) and sonar.issue.ignore.multicriteria is NOT on it, so every
+# waiver below is inert on the PR-side scan (#3933 — the 22 findings that
+# survived the #3930 sweep were all under these waivers). The waivers still
+# suppress noise when running sonar-scanner locally; anything that must be
+# quiet on the PR scan needs a sonar.exclusions entry (like the locale JSON
+# and setupTests.ts above) or a one-time UI resolution:
+#   - typescript:S5693 on src/routes/** (upload1): leave open, mark reviewed
+#     in the UI — a blanket suppression would hide a future uncapped route.
+#   - typescript:S2245 jitter hotspots (jitter1/2): mark the hotspots reviewed
+#     in the UI; see the carve-out in .claude/rules/security.md.
 #
 # Note on instrumentedAxios.ts (tssecurity:S5144 / S7044): the taint-analysis
 # engine cannot follow the URL through measure() -> validateAndResolveUrl()
@@ -46,8 +57,8 @@ sonar.typescript.file.suffixes=.ts,.tsx
 # (Gmail, Outlook, Apple Mail) require these patterns for cross-client
 # rendering. The whole templates folder is excluded via sonar.exclusions
 # but the Web plugin discovers HTML files independently, so each rule
-# needs an explicit waiver to keep the gate clean.
-sonar.issue.ignore.multicriteria=mock1,mock2,test1,test2,gen1,gen2,email1,email2,email3,email4,i18n1,jitter1,jitter2,upload1
+# needs an explicit waiver to keep the local gate clean.
+sonar.issue.ignore.multicriteria=mock1,mock2,test1,test2,gen1,gen2,email1,email2,email3,email4,jitter1,jitter2,upload1
 sonar.issue.ignore.multicriteria.mock1.ruleKey=javascript:S5122
 sonar.issue.ignore.multicriteria.mock1.resourceKey=web/mock-server/**
 sonar.issue.ignore.multicriteria.mock2.ruleKey=javascript:S5689
@@ -71,17 +82,13 @@ sonar.issue.ignore.multicriteria.email4.resourceKey=src/services/EmailService/te
 
 sonar.qualitygate.wait=true
 
-# i18n1: the locale JSON carries UI strings for the password screens ("Forgot
-# password?", "New password"), which the secret detector reads as credentials.
 # jitter1/jitter2: retry backoff jitter is not a security context — see the
 # S2245 carve-out in .claude/rules/security.md. Do NOT swap these for crypto.
 # upload1: every multer instance under src/routes/ already declares an explicit
 # limits.fileSize cap (10MB chat/contact/occlusion, 25MB feedback, 50MB PDF
 # retry, 100MB apkg). S5693 asks you to confirm the cap is safe; it is, and the
 # rule cannot tell. If you add a NEW upload route, set limits.fileSize on it —
-# this waiver will hide a missing cap.
-sonar.issue.ignore.multicriteria.i18n1.ruleKey=json:S2068
-sonar.issue.ignore.multicriteria.i18n1.resourceKey=web/src/lib/i18n/locales/**
+# this waiver will hide a missing cap (locally; the PR scan still flags it).
 sonar.issue.ignore.multicriteria.jitter1.ruleKey=typescript:S2245
 sonar.issue.ignore.multicriteria.jitter1.resourceKey=src/services/NotionService/helpers/withRetry.ts
 sonar.issue.ignore.multicriteria.jitter2.ruleKey=typescript:S2245


### PR DESCRIPTION
## What

#3933's hypothesis is now verified, not inferred: **Automatic Analysis does not read `sonar.issue.ignore.multicriteria` at all.** The AutoScan docs list a closed set of supported properties — `sonar.sources`, `sonar.tests`, the `*.inclusions`/`*.exclusions` families, `sonar.sourceEncoding`, `sonar.cpd.exclusions`, plus two language keys we don't use. Every one of the 14 waivers has been inert on the PR-side scan since it was written; that's the exact arithmetic of the 22 findings that survived the #3930 sweep and the C security rating.

Closes #3933

## The fix, per the issue's own decision framework

- **9× `json:S2068` (locale JSON "password" strings):** `web/src/lib/i18n/locales/**` moves to `sonar.exclusions` in BOTH config files — translation strings have no analyzable logic, and exclusions are honoured by both scanners. The i18n1 waiver is removed (fully replaced).
- **5× `typescript:S1186` (`web/src/setupTests.ts` observer stubs, the #3935 item blocked on this issue):** same treatment — excluded in both files. Vitest still uses the file; only Sonar stops analysing it.
- **11× `typescript:S5693` (multer upload caps) and 2× `typescript:S2245` (retry jitter): deliberately NOT suppressed.** The issue itself makes the argument — a blanket waiver would hide a future uncapped upload route. These need a one-time reviewed/won't-fix in the SonarCloud UI, which only you can click; they're now recorded as **standing UI actions** in `.claude/rules/sonar.md` alongside the existing `tssecurity` FP procedure.
- Comments in both config files now state plainly that the remaining waivers act on local CLI scans only, and `.claude/rules/sonar.md` documents the verified AutoScan property allowlist.

## Expected effect on the next main analysis

Vulnerabilities drop 26 → ~17 (the 9 locale S2068s vanish); the remaining 13 open findings clear only after your UI pass, taking security to ~A. No rating math is promised beyond that — #3930's over-claim is the cautionary tale.

## Decisions made overnight (please review)

- Kept the inert waiver block in `.sonarcloud.properties` rather than stripping it: the parity test holds both files identical for shared keys, and a deliberate asymmetry would need a test carve-out plus explanation. Assumption: config symmetry beats minimalism here. If you'd rather strip the dead block, the parity test's waiver assertions need the same edit.
- Excluded ALL rules for locale JSON + setupTests.ts (that's what `sonar.exclusions` does) instead of leaving them analysed with open findings. i18n key parity is already enforced by our own vitest suite, and setupTests is scaffolding.

## Tests

- `src/lib/sonarConfigParity.test.ts` 9/9 green (exclusion lists and waiver sets stay mirrored).
- No runtime code touched; config + docs only. No changelog entry — internal tooling.
- The proof lands on this PR itself: its own AutoScan run should report the locale-JSON findings gone on new code / next main analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7TQQrHY4ttkng9To493Nd
