### PR TITLE
refactor: drop the three no-op awaits Sonar flagged as S4123

### DIFF
--- a/src/services/NotionService/BlockHandler/BlockHandler.ts
+++ b/src/services/NotionService/BlockHandler/BlockHandler.ts
@@ -512,7 +512,7 @@ class BlockHandler {
       }
       // Look for cloze deletion cards
       if (!ankiNote.mcq && this.settings.isCloze) {
-        const clozeCard = await getClozeDeletionCard(block);
+        const clozeCard = getClozeDeletionCard(block);
         if (clozeCard) {
           isBasicType = false;
           ankiNote.copyValues(clozeCard);
@@ -530,7 +530,7 @@ class BlockHandler {
       }
       // Look for input cards
       if (!ankiNote.mcq && this.settings.useInput) {
-        const inputCard = await getInputCard(rules, block);
+        const inputCard = getInputCard(rules, block);
         if (inputCard) {
           isBasicType = false;
           ankiNote.copyValues(inputCard);

--- a/src/services/NotionService/helpers/blockToStaticMarkup.tsx
+++ b/src/services/NotionService/helpers/blockToStaticMarkup.tsx
@@ -95,7 +95,7 @@ export const blockToStaticMarkup = async (
       back += file;
       break;
     case 'paragraph':
-      back += await BlockParagraph(c, handler);
+      back += BlockParagraph(c, handler);
       break;
     case 'code':
       back += BlockCode(c, handler);


### PR DESCRIPTION
## What

#3935 flagged the 3× `typescript:S4123` findings (await on a non-Promise) as "the one group worth actually investigating — an await on a non-thenable is a no-op, which sometimes means a missing `async` on the awaited function and a genuinely unsequenced operation in the parser hot path. Read these three before dismissing them."

Read all three. Verdict: **no hidden bug in any of them** — each awaited function is genuinely synchronous, so nothing was ever unsequenced:

- `BlockHandler.ts` — `getClozeDeletionCard(block)` and `getInputCard(rules, block)` are plain sync functions returning `Note | undefined` (`src/services/NotionService/helpers/`).
- `blockToStaticMarkup.tsx:98` — `BlockParagraph(c, handler)` synchronously returns rendered static markup.

The fix is removing the three `await` keywords. Awaiting a plain value only defers resumption by a microtask; each result is consumed immediately and sequentially, so removal cannot change observable behavior. This clears 3 of the 55 CRITICAL smells with a 3-word diff.

Contributes to #3935 — the issue stays open as the standing record for the rest of its backlog (the `S6544`/`S6959` group still needs per-PR characterizing tests; the 45 cognitive-complexity findings stay deliberately untouched; the `setupTests.ts` S1186 exclusion ships in https://github.com/2anki/server/pull/3943).

## Tests

- Full server suite: 6151 passed / 2 failed — both the documented environmental `getPageCount` pdfinfo failure. `tsc` clean, `pnpm format:check` clean tree-wide.
- No new tests: no behavior changed; the cloze, input-card, and paragraph render paths are already covered by their existing suites.
- Sonar: not run locally (overnight run; PR decoration will confirm the S4123s clear).

No changelog entry — internal refactor, no user-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7TQQrHY4ttkng9To493Nd
