### PR TITLE
feat: prefill the feedback email for signed-in users

### DIFF
--- a/web/src/components/FeedbackWidget/FeedbackWidget.i18n.test.tsx
+++ b/web/src/components/FeedbackWidget/FeedbackWidget.i18n.test.tsx
@@ -9,6 +9,16 @@ vi.mock('../../lib/backend/get2ankiApi', () => ({
   get2ankiApi: () => ({ submitEmojiFeedback: vi.fn() }),
 }));
 
+vi.mock('../../lib/hooks/useUserLocals', () => ({
+  useUserLocals: () => ({
+    data: undefined,
+    isLoading: false,
+    error: null,
+    isError: false,
+    refetch: vi.fn(),
+  }),
+}));
+
 describe('FeedbackWidget in German', () => {
   beforeEach(async () => {
     await i18n.changeLanguage('de');

--- a/web/src/components/FeedbackWidget/FeedbackWidget.test.tsx
+++ b/web/src/components/FeedbackWidget/FeedbackWidget.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FeedbackWidget } from './FeedbackWidget';
+
+vi.mock('../../lib/hooks/useUserLocals', () => ({
+  useUserLocals: vi.fn(),
+}));
+
+const submitEmojiFeedback = vi.fn().mockResolvedValue(undefined);
+vi.mock('../../lib/backend/get2ankiApi', () => ({
+  get2ankiApi: () => ({
+    submitEmojiFeedback,
+  }),
+}));
+
+import { useUserLocals } from '../../lib/hooks/useUserLocals';
+
+const mockUseUserLocals = vi.mocked(useUserLocals);
+
+function userLocalsWith(email: string | undefined) {
+  return {
+    data: email == null ? undefined : { user: { email } },
+    isLoading: false,
+    error: null,
+    isError: false,
+    refetch: vi.fn(),
+  } as unknown as ReturnType<typeof useUserLocals>;
+}
+
+function pickRating() {
+  fireEvent.click(screen.getAllByRole('button')[0]);
+}
+
+describe('FeedbackWidget email prefill', () => {
+  beforeEach(() => {
+    submitEmojiFeedback.mockClear();
+  });
+
+  it('prefills the email input with the signed-in email', () => {
+    mockUseUserLocals.mockReturnValue(userLocalsWith('a@b.com'));
+    render(<FeedbackWidget page="/upload" />);
+
+    pickRating();
+
+    expect(screen.getByRole('textbox', { name: /email/i })).toHaveValue(
+      'a@b.com'
+    );
+  });
+
+  it('leaves the email input empty when logged out', () => {
+    mockUseUserLocals.mockReturnValue(userLocalsWith(undefined));
+    render(<FeedbackWidget page="/upload" />);
+
+    pickRating();
+
+    expect(screen.getByRole('textbox', { name: /email/i })).toHaveValue('');
+  });
+
+  it('submits a typed-over address instead of the prefill', async () => {
+    mockUseUserLocals.mockReturnValue(userLocalsWith('a@b.com'));
+    render(<FeedbackWidget page="/upload" />);
+
+    pickRating();
+    fireEvent.change(screen.getByRole('textbox', { name: /email/i }), {
+      target: { value: 'typed@x.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send/i }));
+
+    await waitFor(() =>
+      expect(submitEmojiFeedback).toHaveBeenCalledWith(
+        expect.any(Number),
+        '/upload',
+        undefined,
+        'typed@x.com'
+      )
+    );
+  });
+});

--- a/web/src/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/web/src/components/FeedbackWidget/FeedbackWidget.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { get2ankiApi } from '../../lib/backend/get2ankiApi';
+import { useUserLocals } from '../../lib/hooks/useUserLocals';
 import styles from './FeedbackWidget.module.css';
 
 type WidgetStatus = 'idle' | 'sending' | 'sent' | 'error';
@@ -24,10 +25,18 @@ export function FeedbackWidget({
   compact = false,
 }: Readonly<FeedbackWidgetProps>) {
   const { t } = useTranslation('marketing');
+  const { data: userLocals } = useUserLocals();
+  const userEmail = userLocals?.user?.email;
   const [selectedRating, setSelectedRating] = useState<number | null>(null);
   const [comment, setComment] = useState('');
   const [email, setEmail] = useState('');
   const [status, setStatus] = useState<WidgetStatus>('idle');
+
+  useEffect(() => {
+    if (userEmail) {
+      setEmail((prev) => (prev === '' ? userEmail : prev));
+    }
+  }, [userEmail]);
 
   async function handleSubmit() {
     if (selectedRating == null) return;

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-31-feedback-email-prefill.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-31-feedback-email-prefill.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-31-feedback-email-prefill",
+  "date": "2026-07-31",
+  "type": "feature",
+  "title": "Feedback form fills in your email when you're signed in, so we can reply"
+}


### PR DESCRIPTION
## What

Prefills the FeedbackWidget's optional email input with the signed-in user's address. Context: only 2 of 79 feedback submissions since 2026-05-13 carried an email — today's toggle-recognition report was reachable only because that reporter happened to type theirs. Anonymous visitors see the empty field exactly as before.

## Trio synthesis (pm + designer + engineer, run in parallel)

- **pm:** no product reason to block — the address is already held for signed-in users; prefilling makes the existing field visibly true. Implicit prefill over a consent checkbox (the visible, editable, clearable field IS the consent surface). Metric: share of submissions with a usable email, baseline 2.5%, target ≥60% of signed-in submitters; guardrail: submission volume stays flat (candor-chill check).
- **designer:** silent prefill into the normal input, not a hint-only treatment (standard pattern, least state, obviously editable). No new locale keys — the existing `emailHint` reads correctly in both states. `data-hj-suppress` already on the input; no new DOM privacy exposure.
- **engineer:** read `data?.user?.email` (same field UpsellCard uses), sync-until-edited via a functional-updater effect so a late hook resolve never clobbers edits; server's `parseEmail` path needs no change; the i18n test needed the `useUserLocals` mock added in the same PR (it would throw otherwise); no new 401/redirect risk — `useUserLocals` is already called app-wide and react-query dedups.

**Agreements:** ship implicit prefill, no checkbox, no copy changes, no server changes. **Conflicts:** none — designer's optional hint-polish was skipped (10-locale churn for a nuance; pm and engineer neutral).

**Expected impact:** email-attach rate on feedback (read from `emoji_feedback`) from 2.5% toward the majority of signed-in submitters within ~30 days; makes rating-1 reports actionable support contacts.

## Decisions made overnight (please review)

- Implicit prefill, no "you may contact me" checkbox — trio unanimous; the editable field is the consent surface and the hint line states the purpose. If you want the checkbox anyway, say so and it's a small follow-up.
- Kept `feedback.emailHint` unchanged in all locales (designer's optional rewording skipped to avoid 10-locale churn).

## Tests

- New `FeedbackWidget.test.tsx`: prefills for signed-in, stays empty logged-out, typed-over address wins at submit (3/3).
- `FeedbackWidget.i18n.test.tsx` gained the required `useUserLocals` mock.
- Full web suite 2779 passed / 0 failed; web tsc clean; `pnpm format:check` clean tree-wide; oxlint clean on changed files.
- Sonar: not run locally; PR decoration will report.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: machine-backed — `pnpm --filter 2anki-web test:golden-path` 2/2 green after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7TQQrHY4ttkng9To493Nd
