### PR TITLE
fix: redirect expired sessions to login, survive locked storage

### DIFF
--- a/web/src/lib/backend/Backend.test.ts
+++ b/web/src/lib/backend/Backend.test.ts
@@ -8,6 +8,7 @@ vi.mock('./api', () => ({
   del: vi.fn(),
   get: vi.fn(),
   post: vi.fn(),
+  redirectToLogin: vi.fn(),
 }));
 
 // Helper function to create a mock Response
@@ -426,6 +427,29 @@ describe('Backend', () => {
       vi.mocked(api.get).mockResolvedValue(undefined);
 
       await expect(backend.listSettings()).resolves.toEqual({ items: [] });
+    });
+  });
+
+  describe('favorites on an expired session', () => {
+    it('addFavorite redirects to login on 401 instead of failing the toggle', async () => {
+      vi.mocked(api.post).mockResolvedValue(createMockResponse(401, false));
+
+      await expect(backend.addFavorite('page-1', 'page')).resolves.toBe(false);
+      expect(api.redirectToLogin).toHaveBeenCalled();
+    });
+
+    it('deleteFavorite redirects to login on 401', async () => {
+      vi.mocked(api.post).mockResolvedValue(createMockResponse(401, false));
+
+      await expect(backend.deleteFavorite('page-1')).resolves.toBe(false);
+      expect(api.redirectToLogin).toHaveBeenCalled();
+    });
+
+    it('addFavorite does not redirect on a plain failure', async () => {
+      vi.mocked(api.post).mockResolvedValue(createMockResponse(500, false));
+
+      await expect(backend.addFavorite('page-1', 'page')).resolves.toBe(false);
+      expect(api.redirectToLogin).not.toHaveBeenCalled();
     });
   });
 

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -14,9 +14,9 @@ import getObjectIcon, { ObjectIcon } from '../notion/getObjectIcon';
 import { Rules, Settings } from '../types';
 import { UserNotice, isIntentionalBackendNotice } from '../errors/UserNotice';
 import { AnkifyStats } from '../../pages/AnkifyPage/stats/types';
-import { del, get, getLoginURL, patch, post } from './api';
+import { del, get, getLoginURL, patch, post, redirectToLogin } from './api';
 import { getResourceUrl } from './getResourceUrl';
-import { CONFLICT, OK } from './http';
+import { CONFLICT, OK, UNAUTHORIZED } from './http';
 
 export class TrackerSchemaError extends Error {
   readonly missing: string[];
@@ -410,11 +410,19 @@ export class Backend {
 
   async addFavorite(id: string, type: string | null): Promise<boolean> {
     const response = await post(`${this.baseURL}favorite/create`, { id, type });
+    if (response.status === UNAUTHORIZED) {
+      redirectToLogin();
+      return false;
+    }
     return response.status === OK;
   }
 
   async deleteFavorite(id: string): Promise<boolean> {
     const response = await post(`${this.baseURL}favorite/remove`, { id });
+    if (response.status === UNAUTHORIZED) {
+      redirectToLogin();
+      return false;
+    }
     return response.status === OK;
   }
 

--- a/web/src/lib/backend/api.ts
+++ b/web/src/lib/backend/api.ts
@@ -34,7 +34,7 @@ function isNonAuthPath(pathname: string): boolean {
   });
 }
 
-function redirectToLogin() {
+export function redirectToLogin() {
   const currentPath = globalThis.location?.pathname ?? '';
   if (isNonAuthPath(currentPath)) return;
   globalThis.location.href = '/login';

--- a/web/src/pages/MagicLinkPage/MagicLinkPage.test.tsx
+++ b/web/src/pages/MagicLinkPage/MagicLinkPage.test.tsx
@@ -48,6 +48,27 @@ describe('MagicLinkPage', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders when localStorage access throws (locked-down Safari)', () => {
+    mockValidateMagicToken.mockReturnValue(new Promise(() => {}));
+    const throwingStorage = new Proxy(
+      {},
+      {
+        get() {
+          throw new ReferenceError("Can't find variable: localStorage");
+        },
+      }
+    );
+    vi.stubGlobal('localStorage', throwingStorage);
+    try {
+      renderMagicLinkPage('?token=abc123');
+      expect(
+        screen.getByRole('heading', { name: 'Verifying your link' })
+      ).toBeInTheDocument();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('announces the verifying state to screen readers', () => {
     mockValidateMagicToken.mockReturnValue(new Promise(() => {}));
     renderMagicLinkPage('?token=abc123');

--- a/web/src/pages/MagicLinkPage/MagicLinkPage.tsx
+++ b/web/src/pages/MagicLinkPage/MagicLinkPage.tsx
@@ -18,9 +18,13 @@ function MagicLinkPage() {
   const [searchParams] = useSearchParams();
   const [, setCookie] = useCookies(['token']);
   const [state, setState] = useState<MagicLinkState>({ status: 'loading' });
-  const [retryEmail, setRetryEmail] = useState(
-    () => localStorage.getItem('email') ?? ''
-  );
+  const [retryEmail, setRetryEmail] = useState(() => {
+    try {
+      return localStorage.getItem('email') ?? '';
+    } catch {
+      return '';
+    }
+  });
   const [retrySending, setRetrySending] = useState(false);
   const [retryDone, setRetryDone] = useState(false);
 

--- a/web/src/pages/SearchPage/components/SearchObjectEntry/SearchObjectEntry.test.tsx
+++ b/web/src/pages/SearchPage/components/SearchObjectEntry/SearchObjectEntry.test.tsx
@@ -20,6 +20,11 @@ vi.mock('../../../../lib/backend/get2ankiApi', () => ({
   get2ankiApi: () => ({ convert: mockConvert }),
 }));
 
+const mockRedirectToLogin = vi.fn();
+vi.mock('../../../../lib/backend/api', () => ({
+  redirectToLogin: () => mockRedirectToLogin(),
+}));
+
 function renderEntry(
   overrides: Partial<Parameters<typeof SearchObjectEntry>[0]> = {}
 ) {
@@ -84,6 +89,22 @@ describe('SearchObjectEntry convert button', () => {
 
   it('shows idle label "Convert" with accessible name "Convert to Anki" initially', () => {
     renderEntry();
+    expect(
+      screen.getByRole('button', { name: 'Convert to Anki' })
+    ).toBeInTheDocument();
+  });
+
+  it('on 401: redirects to login instead of showing an error card', async () => {
+    const setError = vi.fn();
+    mockConvert.mockResolvedValue({ status: 401 });
+
+    renderEntry({ setError });
+    fireEvent.click(screen.getByRole('button', { name: 'Convert to Anki' }));
+
+    await waitFor(() => {
+      expect(mockRedirectToLogin).toHaveBeenCalled();
+    });
+    expect(setError).not.toHaveBeenCalled();
     expect(
       screen.getByRole('button', { name: 'Convert to Anki' })
     ).toBeInTheDocument();
@@ -184,24 +205,5 @@ describe('SearchObjectEntry convert button', () => {
         screen.getByText("Couldn't queue this page. Try again.")
       ).toBeInTheDocument();
     });
-  });
-
-  it('on 401: calls setError with an Error, not raw JSON', async () => {
-    mockConvert.mockResolvedValue({
-      status: 401,
-      text: async () => '{"message":"Authentication required"}',
-    });
-
-    const setError = vi.fn();
-    renderEntry({ setError });
-    fireEvent.click(screen.getByRole('button', { name: 'Convert to Anki' }));
-
-    await waitFor(() => {
-      expect(setError).toHaveBeenCalledOnce();
-    });
-
-    const errorArg = setError.mock.calls[0][0];
-    expect(errorArg).toBeInstanceOf(Error);
-    expect(typeof errorArg).not.toBe('string');
   });
 });

--- a/web/src/pages/SearchPage/components/SearchObjectEntry/index.tsx
+++ b/web/src/pages/SearchPage/components/SearchObjectEntry/index.tsx
@@ -5,6 +5,7 @@ import { ErrorHandlerType } from '../../../../components/errors/helpers/getError
 import DotsHorizontal from '../../../../components/icons/DotsHorizontal';
 import EyeIcon from '../../../../components/icons/EyeIcon';
 import { get2ankiApi } from '../../../../lib/backend/get2ankiApi';
+import { redirectToLogin } from '../../../../lib/backend/api';
 import NotionObject from '../../../../lib/interfaces/NotionObject';
 import { BlockIcon } from '../BlockIcon';
 import styles from './SearchObjectEntry.module.css';
@@ -71,8 +72,8 @@ function SearchObjectEntry(props: Readonly<Props>) {
         } else if (response.status === 402) {
           setStatus('paywall');
         } else if (response.status === 401) {
-          setStatus('error');
-          setError(new Error('Authentication required'));
+          setStatus('idle');
+          redirectToLogin();
         } else {
           setStatus('error');
         }

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-31-expired-session-redirects.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-31-expired-session-redirects.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-31-expired-session-redirects",
+  "date": "2026-07-31",
+  "type": "fix",
+  "title": "An expired session sends you to sign in instead of a dead-end error when converting or favoriting, and magic links open in locked-down Safari"
+}


### PR DESCRIPTION
## What

Works the actionable groups from the 2026-07-31 tracked prod error review. Three shared a theme — recoverable client states surfaced as dead-end errors:

- **"Authentication required" on /notion (group 3):** the search-page convert button's 401 branch rendered an error card via `setError`. An expired session now routes to `/login` (`redirectToLogin`, newly exported from `api.ts` — `post()` has no auto-redirect, unlike `get()`), leaving the button idle for after sign-in.
- **"Favorit konnte nicht aktualisiert werden" on /rules (group 6):** `addFavorite`/`deleteFavorite` returned `false` on 401, throwing the localized failure toast. Both now redirect to login on 401; a plain non-auth failure still shows the toast (tested).
- **"Can't find variable: localStorage" on /auth/magic (group 7):** `MagicLinkPage` read `localStorage` bare in a `useState` initializer — throws in locked-down/private Safari before the page renders, breaking magic-link sign-in for exactly the users most likely to use magic links. The read is guarded; the page verifies the token regardless of storage availability.

Groups needing no code (documented in the review file): #1 chunk-load failures — the `chunkReload` auto-recovery has covered these since May, tracker records the pre-reload error; #2 502s — blue-green deploy-window blips, 4 in two months; #4 AnkiConnect sync status 2 — already fixed by #3842's `ChangesRequired` matcher, the single occurrence predates it by a day; #5 register copy — intentional anti-enumeration message from #3844.

## Decisions

- The old "401 shows an error card" test asserted the behavior this PR deliberately replaces — swapped for the redirect-contract test in the same file, per the replace-don't-delete rule.
- `redirectToLogin` stays NON_AUTH-path aware, so the redirect is a no-op on public pages.

## Tests

- `Backend.test.ts`: favorite 401 → redirect + false; plain 500 → no redirect. `SearchObjectEntry.test.tsx`: 401 convert → redirect, no error card, button stays. `MagicLinkPage.test.tsx`: renders with a throwing localStorage proxy.
- Full web suite 2783 passed / 0 failed; web tsc clean; `pnpm format:check` clean tree-wide.
- Sonar: PR decoration will report.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: machine-backed — `pnpm --filter 2anki-web test:golden-path` 2/2 green after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7TQQrHY4ttkng9To493Nd
