### PR TITLE
feat: drop bot contact-form submissions with a honeypot field

### DIFF
--- a/src/controllers/IndexController/IndexController.test.ts
+++ b/src/controllers/IndexController/IndexController.test.ts
@@ -174,4 +174,44 @@ describe('IndexController.contactUs', () => {
     expect(res.status).toHaveBeenCalledWith(400);
     expect(mockSendContactConfirmationEmail).not.toHaveBeenCalled();
   });
+
+  it('drops a submission with a filled honeypot: 200, no row, no email', async () => {
+    const controller = new IndexController();
+    const res = buildRes();
+
+    await controller.contactUs(
+      buildReq({
+        name: 'Mona Bot',
+        email: 'bot@example.com',
+        message: VALID_MESSAGE,
+        website: 'https://spam.example.ru',
+      }),
+      res
+    );
+    await flushAsync();
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(mockInsertReturning).not.toHaveBeenCalled();
+    expect(mockSendContactEmail).not.toHaveBeenCalled();
+    expect(mockSendContactConfirmationEmail).not.toHaveBeenCalled();
+  });
+
+  it('treats an empty honeypot field as human and saves the submission', async () => {
+    const controller = new IndexController();
+    const res = buildRes();
+
+    await controller.contactUs(
+      buildReq({
+        email: 'user@example.com',
+        message: VALID_MESSAGE,
+        website: '',
+      }),
+      res
+    );
+    await flushAsync();
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(mockInsertReturning).toHaveBeenCalled();
+    expect(mockSendContactEmail).toHaveBeenCalled();
+  });
 });

--- a/src/controllers/IndexController/IndexController.ts
+++ b/src/controllers/IndexController/IndexController.ts
@@ -7,6 +7,10 @@ import {
   CONTACT_ACK_COOLDOWN_MS,
 } from '../../lib/email/shouldSendContactAck';
 import { normalizeEmail } from '../../lib/email/isValidEmailShape';
+import {
+  HONEYPOT_FIELD,
+  isHoneypotTripped,
+} from '../../lib/email/isHoneypotTripped';
 
 class IndexController {
   public getIndex(_request: express.Request, response: express.Response) {
@@ -23,6 +27,12 @@ class IndexController {
       hasName: typeof name === 'string' && name.trim().length > 0,
       messageLength: typeof message === 'string' ? message.length : 0,
     });
+    // Silent 200 so the bot reads success and doesn't adapt. Nothing is
+    // saved and no email fires — support never sees the probe.
+    if (isHoneypotTripped(req.body[HONEYPOT_FIELD])) {
+      console.info('Contact Us submission dropped by honeypot');
+      return res.status(200).send();
+    }
     if (!email || !message) {
       return res.status(400).send({ error: 'Missing email or message' });
     }

--- a/src/lib/email/isHoneypotTripped.test.ts
+++ b/src/lib/email/isHoneypotTripped.test.ts
@@ -1,0 +1,22 @@
+import { isHoneypotTripped } from './isHoneypotTripped';
+
+describe('isHoneypotTripped', () => {
+  it.each([
+    ['undefined (field absent from the request)', undefined],
+    ['null', null],
+    ['empty string (human left the hidden field alone)', ''],
+    ['whitespace only', '   '],
+    ['empty array (repeated empty field)', []],
+  ])('stays quiet for %s', (_label, value) => {
+    expect(isHoneypotTripped(value)).toBe(false);
+  });
+
+  it.each([
+    ['a URL a bot autofilled', 'https://spam.example.ru'],
+    ['a phone-shaped probe', '9285284646'],
+    ['an array with a value', ['gotcha']],
+    ['a single character', 'x'],
+  ])('trips for %s', (_label, value) => {
+    expect(isHoneypotTripped(value)).toBe(true);
+  });
+});

--- a/src/lib/email/isHoneypotTripped.ts
+++ b/src/lib/email/isHoneypotTripped.ts
@@ -1,0 +1,8 @@
+// The contact form renders this field visually hidden and skipped by keyboard
+// and screen readers, so a human never fills it. Bots autofill every input
+// they find, and "website" is deliberate bait — autofillers target the name.
+export const HONEYPOT_FIELD = 'website';
+
+export function isHoneypotTripped(value: unknown): boolean {
+  return value != null && String(value).trim().length > 0;
+}

--- a/web/src/lib/backend/Backend.contactUs.test.ts
+++ b/web/src/lib/backend/Backend.contactUs.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Backend } from './Backend';
+
+vi.mock('./api', () => ({
+  del: vi.fn(),
+  get: vi.fn(),
+  post: vi.fn(),
+  redirectToLogin: vi.fn(),
+}));
+
+describe('Backend.contactUs', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function stubFetch() {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true } as Response);
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+  }
+
+  it('always sends the honeypot field, empty for humans', async () => {
+    const fetchMock = stubFetch();
+
+    await new Backend().contactUs('A', 'a@example.com', 'hello there');
+
+    const body = fetchMock.mock.calls[0][1]?.body as FormData;
+    expect(body.get('website')).toBe('');
+    expect(body.get('name')).toBe('A');
+    expect(body.get('email')).toBe('a@example.com');
+    expect(body.get('message')).toBe('hello there');
+  });
+
+  it('forwards a filled honeypot value untouched', async () => {
+    const fetchMock = stubFetch();
+
+    await new Backend().contactUs(
+      'Bot',
+      'bot@example.com',
+      'buy things',
+      [],
+      'https://spam.example.ru'
+    );
+
+    const body = fetchMock.mock.calls[0][1]?.body as FormData;
+    expect(body.get('website')).toBe('https://spam.example.ru');
+  });
+});

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -1150,12 +1150,14 @@ export class Backend {
     name: string,
     email: string,
     message: string,
-    files?: File[]
+    files?: File[],
+    website?: string
   ): Promise<void> {
     const form = new FormData();
     form.append('name', name);
     form.append('email', email);
     form.append('message', message);
+    form.append('website', website ?? '');
     for (const file of files ?? []) {
       form.append('attachments', file);
     }

--- a/web/src/pages/ContactPage/ContactPage.honeypot.test.tsx
+++ b/web/src/pages/ContactPage/ContactPage.honeypot.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ContactPage } from './ContactPage';
+
+const contactUs = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../../lib/backend/get2ankiApi', () => ({
+  get2ankiApi: () => ({ contactUs }),
+}));
+
+function fillVisibleFields() {
+  fireEvent.change(
+    document.getElementById('contact-name') as HTMLInputElement,
+    {
+      target: { value: 'A Human' },
+    }
+  );
+  fireEvent.change(
+    document.getElementById('contact-email') as HTMLInputElement,
+    { target: { value: 'human@example.com' } }
+  );
+  fireEvent.change(
+    document.getElementById('contact-message') as HTMLTextAreaElement,
+    { target: { value: 'My deck came back empty.' } }
+  );
+}
+
+describe('ContactPage honeypot', () => {
+  it('hides the bait field from assistive tech and keyboard', () => {
+    render(<ContactPage />);
+    const field = document.getElementById(
+      'contact-website'
+    ) as HTMLInputElement;
+
+    expect(field).not.toBeNull();
+    expect(field.tabIndex).toBe(-1);
+    expect(field.closest('[aria-hidden="true"]')).not.toBeNull();
+    expect(screen.queryByRole('textbox', { name: 'Website' })).toBeNull();
+  });
+
+  it('submits an empty honeypot value for a human', async () => {
+    render(<ContactPage />);
+    fillVisibleFields();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+
+    await waitFor(() =>
+      expect(contactUs).toHaveBeenCalledWith(
+        'A Human',
+        'human@example.com',
+        'My deck came back empty.',
+        [],
+        ''
+      )
+    );
+  });
+
+  it('forwards whatever a bot typed into the bait field', async () => {
+    render(<ContactPage />);
+    fillVisibleFields();
+    fireEvent.change(
+      document.getElementById('contact-website') as HTMLInputElement,
+      { target: { value: 'https://spam.example.ru' } }
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+
+    await waitFor(() =>
+      expect(contactUs).toHaveBeenCalledWith(
+        'A Human',
+        'human@example.com',
+        'My deck came back empty.',
+        [],
+        'https://spam.example.ru'
+      )
+    );
+  });
+});

--- a/web/src/pages/ContactPage/ContactPage.module.css
+++ b/web/src/pages/ContactPage/ContactPage.module.css
@@ -86,3 +86,11 @@
 .fileRemove:hover {
   color: var(--color-text-primary);
 }
+
+.honeypot {
+  position: absolute;
+  left: -9999px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}

--- a/web/src/pages/ContactPage/ContactPage.tsx
+++ b/web/src/pages/ContactPage/ContactPage.tsx
@@ -12,6 +12,7 @@ export function ContactPage() {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [message, setMessage] = useState('');
+  const [website, setWebsite] = useState('');
   const [files, setFiles] = useState<File[]>([]);
   const [status, setStatus] = useState<FormStatus>('idle');
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -35,11 +36,12 @@ export function ContactPage() {
     event.preventDefault();
     setStatus('sending');
     try {
-      await get2ankiApi().contactUs(name, email, message, files);
+      await get2ankiApi().contactUs(name, email, message, files, website);
       setStatus('sent');
       setName('');
       setEmail('');
       setMessage('');
+      setWebsite('');
       setFiles([]);
       if (fileInputRef.current) fileInputRef.current.value = '';
     } catch {
@@ -71,6 +73,18 @@ export function ContactPage() {
           )}
 
           <form onSubmit={handleSubmit}>
+            <div className={contactStyles.honeypot} aria-hidden="true">
+              <label htmlFor="contact-website">Website</label>
+              <input
+                id="contact-website"
+                type="text"
+                name="website"
+                tabIndex={-1}
+                autoComplete="off"
+                value={website}
+                onChange={(e) => setWebsite(e.target.value)}
+              />
+            </div>
             <div className={styles.field}>
               <label htmlFor="contact-name">{t('contact.nameLabel')}</label>
               <input


### PR DESCRIPTION
## What

A bot probed the contact form this weekend (dot-shuffled gmail address, message = a bare phone number). The ack-cooldown gate already blocked the backscatter email, but every probe still lands a `feedback` row and relays to support@. This adds the classic honeypot: a visually hidden `website` field that autofillers can't resist.

- **Server**: `isHoneypotTripped` in `src/lib/email/` — any non-empty value in the field makes `contactUs` return a silent 200 with no DB row and no email (bot reads success, doesn't adapt, support never sees it).
- **Web**: hidden bait field on `/contact` — off-screen positioning (not `display:none`, which some bots skip), `aria-hidden`, `tabIndex={-1}`, `autoComplete="off"`, so keyboard and screen-reader users never encounter it.
- Chosen over captcha: one probe in 14 days doesn't justify friction on the surface where frustrated subscribers reach us (6 of the last 7 messages are billing issues from paying users).

No changelog entry — spam protection, no user-visible behavior change.

## Tests

- `isHoneypotTripped.test.ts` — trips on any value, quiet on absent/empty/whitespace.
- `IndexController.test.ts` — filled honeypot: 200, no insert, no emails; empty honeypot: normal save path.
- `ContactPage.honeypot.test.tsx` — field hidden from AT and keyboard; human submits empty value; bot value forwarded.
- `Backend.contactUs.test.ts` — FormData always carries the field.

Server tsc clean, full web vitest 2788 passed, lint clean (pre-existing warnings only), `pnpm format:check` clean.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: machine-backed — `pnpm --filter 2anki-web test:golden-path` 2/2 passed on this branch.
