### PR TITLE
fix: embed every local audio file on a card, in any common format

### DIFF
--- a/src/lib/anki/format.test.ts
+++ b/src/lib/anki/format.test.ts
@@ -1,0 +1,31 @@
+import { isValidAudioFile } from './format';
+
+describe('isValidAudioFile', () => {
+  it.each([
+    'recording.mp3',
+    'voice memo.m4a',
+    'lecture.wav',
+    'note.ogg',
+    'note.oga',
+    'clip.opus',
+    'song.flac',
+    'stream.aac',
+    'browser-recording.webm',
+    'UPPER.MP3',
+    'Nested/Dir/audio.M4A',
+  ])('accepts %s', (name) => {
+    expect(isValidAudioFile(name)).toBe(true);
+  });
+
+  it.each([
+    'document.pdf',
+    'image.png',
+    'video.mp4',
+    'archive.zip',
+    'page.html',
+    'mp3', // no dot — the suffix alone is not a file
+    'audio.mp3.txt',
+  ])('rejects %s', (name) => {
+    expect(isValidAudioFile(name)).toBe(false);
+  });
+});

--- a/src/lib/anki/format.ts
+++ b/src/lib/anki/format.ts
@@ -1,5 +1,19 @@
 export const DECK_NAME_SUFFIX = 'apkg';
-export const AUDIO_FILE_SUFFIX = 'mp3';
+
+// Formats Anki's bundled player handles. Notion keeps the original extension
+// of whatever the user uploaded or recorded (iOS voice memos are .m4a,
+// browser recordings .webm), so mp3-only meant most real audio never embedded.
+export const AUDIO_FILE_SUFFIXES = [
+  'mp3',
+  'm4a',
+  'wav',
+  'ogg',
+  'oga',
+  'opus',
+  'flac',
+  'aac',
+  'webm',
+];
 
 export const isValidDeckName = (filename: string) =>
   filename.endsWith(`.${DECK_NAME_SUFFIX}`);
@@ -7,5 +21,7 @@ export const isValidDeckName = (filename: string) =>
 export const addDeckNameSuffix = (filename: string) =>
   `${filename}.${DECK_NAME_SUFFIX}`;
 
-export const isValidAudioFile = (filename: string) =>
-  filename.endsWith(`.${AUDIO_FILE_SUFFIX}`);
+export const isValidAudioFile = (filename: string) => {
+  const lower = filename.toLowerCase();
+  return AUDIO_FILE_SUFFIXES.some((suffix) => lower.endsWith(`.${suffix}`));
+};

--- a/src/lib/parser/DeckParser.test.ts
+++ b/src/lib/parser/DeckParser.test.ts
@@ -1908,3 +1908,85 @@ describe('Notion export image with host glued to relative path', () => {
     expect(downloadMediaOrSkipMock).not.toHaveBeenCalled();
   });
 });
+
+describe('card audio embedding', () => {
+  function audioParser(
+    bodyHtml: string,
+    extraFiles: { name: string; contents: Buffer }[]
+  ) {
+    const html = `<html><head><title>Audio Deck</title></head><body><article>
+<ul class="toggle"><li><details open="">
+  <summary>Hear it</summary>
+  <div>${bodyHtml}</div>
+</details></li></ul>
+</article></body></html>`;
+    return new DeckParser({
+      name: 'deck.html',
+      settings: new CardOption({ cherry: 'false' }),
+      files: [{ name: 'deck.html', contents: html }, ...extraFiles],
+      noLimits: true,
+      workspace: new Workspace(true, 'fs'),
+    });
+  }
+
+  test('embeds a non-mp3 audio link and appends a sound tag', async () => {
+    const parser = audioParser(
+      '<figure><div class="source"><a href="Audio%20Deck/recording.m4a">recording.m4a</a></div></figure>',
+      [{ name: 'Audio Deck/recording.m4a', contents: Buffer.from('fake-m4a') }]
+    );
+    const ws = new Workspace(true, 'fs');
+
+    await parser.writeDeckInfo(ws);
+    const card = parser.payload[0].cards[0];
+
+    expect(card.back).toMatch(/\[sound:[^\]]+\.m4a\]/);
+    expect(card.media.some((m) => m.endsWith('.m4a'))).toBe(true);
+  });
+
+  test('embeds every audio link on the card, not only the first', async () => {
+    const parser = audioParser(
+      '<figure><div class="source"><a href="Audio%20Deck/first.mp3">first.mp3</a></div></figure>' +
+        '<figure><div class="source"><a href="Audio%20Deck/second.wav">second.wav</a></div></figure>',
+      [
+        { name: 'Audio Deck/first.mp3', contents: Buffer.from('fake-mp3') },
+        { name: 'Audio Deck/second.wav', contents: Buffer.from('fake-wav') },
+      ]
+    );
+    const ws = new Workspace(true, 'fs');
+
+    await parser.writeDeckInfo(ws);
+    const card = parser.payload[0].cards[0];
+
+    expect(card.back).toMatch(/\[sound:[^\]]+\.mp3\]/);
+    expect(card.back).toMatch(/\[sound:[^\]]+\.wav\]/);
+    expect(card.media).toHaveLength(2);
+  });
+
+  test('embeds an html5 audio element and removes the dead player', async () => {
+    const parser = audioParser(
+      '<audio controls="" src="Audio%20Deck/note.ogg"></audio>',
+      [{ name: 'Audio Deck/note.ogg', contents: Buffer.from('fake-ogg') }]
+    );
+    const ws = new Workspace(true, 'fs');
+
+    await parser.writeDeckInfo(ws);
+    const card = parser.payload[0].cards[0];
+
+    expect(card.back).toMatch(/\[sound:[^\]]+\.ogg\]/);
+    expect(card.back).not.toContain('<audio');
+  });
+
+  test('leaves remote audio URLs alone', async () => {
+    const parser = audioParser(
+      '<a href="https://example.com/episode.mp3">episode</a>',
+      []
+    );
+    const ws = new Workspace(true, 'fs');
+
+    await parser.writeDeckInfo(ws);
+    const card = parser.payload[0].cards[0];
+
+    expect(card.back).not.toContain('[sound:');
+    expect(card.media).toHaveLength(0);
+  });
+});

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -710,23 +710,25 @@ export class DeckParser {
     });
   }
 
-  getMP3File(input: string) {
-    return this.ensureNotNull(input, () => {
-      try {
-        const m = input.match(/<a\s+(?:[^>]*?\s+)?href=(["'])(.*?)\1/i);
-        if (!m || m.length < 3) {
-          return null;
-        }
-        const ma = m[2];
-        if (!isValidAudioFile(ma) || ma.startsWith('http')) {
-          return null;
-        }
-        return ma;
-      } catch (error) {
-        console.error(error);
-        return null;
+  getLocalAudioFiles(input: string): string[] {
+    if (!input) return [];
+    const found: string[] = [];
+    const seen = new Set<string>();
+    const patterns = [
+      /<a\s+(?:[^>]*?\s+)?href=(["'])(.*?)\1/gi,
+      /<audio[^>]*?\ssrc=(["'])(.*?)\1/gi,
+      /<source[^>]*?\ssrc=(["'])(.*?)\1/gi,
+    ];
+    for (const pattern of patterns) {
+      for (const match of input.matchAll(pattern)) {
+        const target = match[2];
+        if (!target || target.startsWith('http')) continue;
+        if (!isValidAudioFile(target) || seen.has(target)) continue;
+        seen.add(target);
+        found.push(target);
       }
-    });
+    }
+    return found;
   }
 
   treatBoldAsInput(input: string, inline: boolean) {
@@ -911,26 +913,52 @@ export class DeckParser {
   }
 
   private embedCardAudio(card: Note, ws: Workspace) {
-    const audiofile = this.getMP3File(card.back);
-    if (!audiofile) return;
+    const audioFiles = this.getLocalAudioFiles(card.back);
+    if (audioFiles.length === 0) return;
 
-    if (this.settings.removeMP3Links) {
-      card.back = card.back.replace(
-        /<figure.*<a\shref=["'].*\.mp3["']>.*<\/a>.*<\/figure>/,
-        ''
+    const dom = cheerio.load(card.back);
+    const embedded: string[] = [];
+
+    for (const audiofile of audioFiles) {
+      const newFileName = embedFile({
+        exporter: this.customExporter,
+        files: this.files,
+        filePath: global.decodeURIComponent(audiofile),
+        workspace: ws,
+        fallbackWorkspaceLocation: this.workspace.location,
+      });
+      if (!newFileName) continue;
+      embedded.push(newFileName);
+
+      const anchors = dom(`a[href="${audiofile}"]`);
+      if (this.settings.removeMP3Links) {
+        anchors.each((_i, el) => {
+          const figure = dom(el).closest('figure');
+          if (figure.length > 0) figure.remove();
+          else dom(el).remove();
+        });
+      }
+      // A left-behind <audio> element points at a path that no longer exists
+      // inside the .apkg, so it renders as a dead player; the [sound:] tag
+      // below is the working replacement.
+      dom(`audio[src="${audiofile}"], source[src="${audiofile}"]`).each(
+        (_i, el) => {
+          const element = dom(el);
+          const player = element.closest('audio');
+          if (player.length > 0) player.remove();
+          else element.remove();
+        }
       );
     }
-    const newFileName = embedFile({
-      exporter: this.customExporter,
-      files: this.files,
-      filePath: global.decodeURIComponent(audiofile),
-      workspace: ws,
-      fallbackWorkspaceLocation: this.workspace.location,
-    });
-    if (newFileName) {
-      card.back += `[sound:${newFileName}]`;
+
+    if (embedded.length === 0) return;
+
+    let back = dom('body').html() ?? card.back;
+    for (const newFileName of embedded) {
+      back += `[sound:${newFileName}]`;
       card.media.push(newFileName);
     }
+    card.back = back;
   }
 
   private appendCardVideoEmbeds(card: Note) {

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-02-audio-in-uploads.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-02-audio-in-uploads.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-02-audio-in-uploads",
+  "date": "2026-08-02",
+  "type": "fix",
+  "title": "Audio in uploaded exports plays on your cards — m4a, wav, ogg and more, and every clip, not just the first mp3"
+}


### PR DESCRIPTION
Reported via in-app feedback on /upload: "audio source is not add properly."

## Root cause

`embedCardAudio` embedded audio only when it was the **first** anchor link on the card back **and** ended in lowercase `.mp3`:

- Notion keeps the original extension of whatever the user uploaded or recorded — iOS voice memos are `.m4a`, browser recordings `.webm`, plus `.wav`/`.ogg` uploads. All rejected.
- A second audio file on the same card was never seen (non-global first-match).
- `<audio src>` / `<source src>` elements were invisible to the anchor-only regex.
- `.MP3` failed the case-sensitive check.

Result: the audio file stayed a dead relative link on the card while the media never entered the `.apkg`.

## Fix

- `AUDIO_FILE_SUFFIXES` (mp3, m4a, wav, ogg, oga, opus, flac, aac, webm), matched case-insensitively.
- `getLocalAudioFiles` collects **every** local audio reference on the card back — anchors plus html5 `audio`/`source` elements; remote http(s) URLs stay untouched.
- Each file embeds as bundled media with its own `[sound:]` tag; dead `<audio>` players whose file moved into the package are removed. `removeMP3Links` now strips the matched figure for every embedded format, not just the first `.mp3`.

Front-side audio is deliberately out of scope — the current contract (audio plays from the back) is unchanged; flag if you want listening-card fronts to embed too.

## Tests

- `format.test.ts` (new) — accepted/rejected extension matrix, case-insensitivity.
- `DeckParser.test.ts` — m4a embeds with `[sound:]`, multiple files all embed, `<audio>` element embeds and the dead player is removed, remote URLs untouched.
- Full server suite: 6204 passed; only failure is the documented environmental `getPageCount` (missing `pdfinfo`).

Sonar: not run locally; relying on the PR quality-gate comment.

Browser check: not applicable — server-side parser change; the only web/src file is a changelog JSON entry.


Closes #3962
