### PR TITLE
fix: scan card audio with cheerio, not backtracking regexes

### DIFF
--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -710,27 +710,6 @@ export class DeckParser {
     });
   }
 
-  getLocalAudioFiles(input: string): string[] {
-    if (!input) return [];
-    const found: string[] = [];
-    const seen = new Set<string>();
-    const patterns = [
-      /<a\s+(?:[^>]*?\s+)?href=(["'])(.*?)\1/gi,
-      /<audio[^>]*?\ssrc=(["'])(.*?)\1/gi,
-      /<source[^>]*?\ssrc=(["'])(.*?)\1/gi,
-    ];
-    for (const pattern of patterns) {
-      for (const match of input.matchAll(pattern)) {
-        const target = match[2];
-        if (!target || target.startsWith('http')) continue;
-        if (!isValidAudioFile(target) || seen.has(target)) continue;
-        seen.add(target);
-        found.push(target);
-      }
-    }
-    return found;
-  }
-
   treatBoldAsInput(input: string, inline: boolean) {
     const dom = cheerio.load(input);
     const underlines = dom('strong');
@@ -912,45 +891,73 @@ export class DeckParser {
     }
   }
 
+  private static isLocalAudioTarget(
+    target: string | undefined
+  ): target is string {
+    return (
+      target != null && !target.startsWith('http') && isValidAudioFile(target)
+    );
+  }
+
   private embedCardAudio(card: Note, ws: Workspace) {
-    const audioFiles = this.getLocalAudioFiles(card.back);
-    if (audioFiles.length === 0) return;
-
-    const dom = cheerio.load(card.back);
-    const embedded: string[] = [];
-
-    for (const audiofile of audioFiles) {
-      const newFileName = embedFile({
-        exporter: this.customExporter,
-        files: this.files,
-        filePath: global.decodeURIComponent(audiofile),
-        workspace: ws,
-        fallbackWorkspaceLocation: this.workspace.location,
-      });
-      if (!newFileName) continue;
-      embedded.push(newFileName);
-
-      const anchors = dom(`a[href="${audiofile}"]`);
-      if (this.settings.removeMP3Links) {
-        anchors.each((_i, el) => {
-          const figure = dom(el).closest('figure');
-          if (figure.length > 0) figure.remove();
-          else dom(el).remove();
-        });
-      }
-      // A left-behind <audio> element points at a path that no longer exists
-      // inside the .apkg, so it renders as a dead player; the [sound:] tag
-      // below is the working replacement.
-      dom(`audio[src="${audiofile}"], source[src="${audiofile}"]`).each(
-        (_i, el) => {
-          const element = dom(el);
-          const player = element.closest('audio');
-          if (player.length > 0) player.remove();
-          else element.remove();
-        }
-      );
+    const lower = card.back.toLowerCase();
+    if (
+      !lower.includes('<a') &&
+      !lower.includes('<audio') &&
+      !lower.includes('<source')
+    ) {
+      return;
     }
 
+    const dom = cheerio.load(card.back);
+    const resolved = new Map<string, string | null>();
+    const embedTarget = (target: string): string | null => {
+      let newFileName = resolved.get(target);
+      if (newFileName === undefined) {
+        newFileName = embedFile({
+          exporter: this.customExporter,
+          files: this.files,
+          filePath: global.decodeURIComponent(target),
+          workspace: ws,
+          fallbackWorkspaceLocation: this.workspace.location,
+        });
+        resolved.set(target, newFileName);
+      }
+      return newFileName;
+    };
+
+    dom('a[href]').each((_i, el) => {
+      const anchor = dom(el);
+      const href = anchor.attr('href');
+      if (!DeckParser.isLocalAudioTarget(href)) return;
+      if (embedTarget(href) == null) return;
+      if (this.settings.removeMP3Links) {
+        const figure = anchor.closest('figure');
+        if (figure.length > 0) figure.remove();
+        else anchor.remove();
+      }
+    });
+
+    // A left-behind <audio> element points at a path that no longer exists
+    // inside the .apkg, so it renders as a dead player; the [sound:] tag
+    // below is the working replacement.
+    dom('audio[src], source[src]').each((_i, el) => {
+      const element = dom(el);
+      const src = element.attr('src');
+      if (!DeckParser.isLocalAudioTarget(src)) return;
+      if (embedTarget(src) == null) return;
+      const player = element.closest('audio');
+      if (player.length > 0) player.remove();
+      else element.remove();
+    });
+
+    const embedded = Array.from(
+      new Set(
+        Array.from(resolved.values()).filter(
+          (name): name is string => name != null
+        )
+      )
+    );
     if (embedded.length === 0) return;
 
     let back = dom('body').html() ?? card.back;


### PR DESCRIPTION
Follow-up to https://github.com/Laer-Smart/2anki.net/pull/3960, which merged with one open Sonar finding: `typescript:S8786` on the anchor-scanning regex in `getLocalAudioFiles` — super-linear backtracking from the nested optional quantifier (`<a\s+(?:[^>]*?\s+)?href=`), running with `matchAll` over user-supplied card HTML on the conversion worker. That's ReDoS territory, so the fix is structural, not a suppression.

## Change

- Audio discovery now reuses the cheerio document the embed step already builds: one pass over `a[href]` and `audio[src], source[src]`, each target embedded once via a resolved-name map. `getLocalAudioFiles` and all three scan regexes are gone.
- Also removes the interpolation of audio paths into cheerio selectors (`a[href="${audiofile}"]`), which would have broken on filenames containing quotes or brackets — elements are now acted on directly as they're visited.

Behavior unchanged: all #3960 tests pass as written (m4a embed, multi-file, `<audio>` element removal, remote URLs untouched). Full server suite: 6208 passed; only failure is the documented environmental `getPageCount` (missing `pdfinfo`).

No changelog entry — internal hardening, no user-visible behavior change.

Browser check: not applicable — server-side parser change, no web/src files.
