### PR TITLE
feat: log a structural census when a conversion ships no cards

### DIFF
--- a/src/infrastracture/adapters/fileConversion/documentStructureCensus.test.ts
+++ b/src/infrastracture/adapters/fileConversion/documentStructureCensus.test.ts
@@ -1,0 +1,102 @@
+import JSZip from 'jszip';
+
+import { censusFromHtml, censusUploadedFile } from './documentStructureCensus';
+
+async function minimalDocx(paragraphText: string): Promise<Buffer> {
+  const zip = new JSZip();
+  zip.file(
+    '[Content_Types].xml',
+    `<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`
+  );
+  zip.file(
+    '_rels/.rels',
+    `<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`
+  );
+  zip.file(
+    'word/document.xml',
+    `<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body><w:p><w:r><w:t>${paragraphText}</w:t></w:r></w:p></w:body>
+</w:document>`
+  );
+  return zip.generateAsync({ type: 'nodebuffer' });
+}
+
+describe('censusFromHtml', () => {
+  it('counts headings, paragraphs, list items, tables, and toggles', () => {
+    const html = `
+      <h1>Chapter</h1>
+      <h2>Section</h2>
+      <p>One</p><p>Two</p>
+      <ul><li>a</li><li>b</li><li>c</li></ul>
+      <ol><li>d</li></ol>
+      <table><tr><td>x</td></tr></table>
+      <details><summary>t</summary>body</details>
+    `;
+    expect(censusFromHtml(html)).toEqual({
+      chars: html.length,
+      headings: 2,
+      paragraphs: 2,
+      lists: 2,
+      listItems: 4,
+      tables: 1,
+      toggles: 1,
+      images: 0,
+    });
+  });
+
+  it('returns zero counts for empty input', () => {
+    expect(censusFromHtml('')).toEqual({
+      chars: 0,
+      headings: 0,
+      paragraphs: 0,
+      lists: 0,
+      listItems: 0,
+      tables: 0,
+      toggles: 0,
+      images: 0,
+    });
+  });
+
+  it('counts images', () => {
+    const html = '<p><img src="a.png" /><img src="b.png" /></p>';
+    expect(censusFromHtml(html).images).toBe(2);
+  });
+});
+
+describe('censusUploadedFile', () => {
+  it('censuses an HTML upload directly from its buffer', async () => {
+    const html = '<h1>T</h1><ul><li>q</li><li>a</li></ul>';
+    const census = await censusUploadedFile({
+      originalname: 'page.html',
+      buffer: Buffer.from(html),
+    });
+    expect(census).toMatchObject({ headings: 1, listItems: 2 });
+  });
+
+  it('converts a DOCX upload and censuses the resulting HTML', async () => {
+    const docx = await minimalDocx('Docx body text');
+    const census = await censusUploadedFile({
+      originalname: 'notes.docx',
+      buffer: docx,
+    });
+    expect(census).not.toBeNull();
+    expect(census!.paragraphs).toBeGreaterThanOrEqual(1);
+    expect(census!.chars).toBeGreaterThan(0);
+  });
+
+  it('returns null for an unreadable or binary non-docx file', async () => {
+    const census = await censusUploadedFile({
+      originalname: 'deck.apkg',
+      buffer: Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00]),
+    });
+    expect(census).toBeNull();
+  });
+});

--- a/src/infrastracture/adapters/fileConversion/documentStructureCensus.ts
+++ b/src/infrastracture/adapters/fileConversion/documentStructureCensus.ts
@@ -1,0 +1,51 @@
+import * as cheerio from 'cheerio';
+
+import { convertDocxToHTML } from './convertDocxToHTML';
+
+export interface DocumentStructureCensus {
+  chars: number;
+  headings: number;
+  paragraphs: number;
+  lists: number;
+  listItems: number;
+  tables: number;
+  toggles: number;
+  images: number;
+}
+
+const TEXTUAL_EXTENSIONS = /\.(html?|md|markdown|txt|csv)$/i;
+
+export function censusFromHtml(html: string): DocumentStructureCensus {
+  const $ = cheerio.load(html);
+  return {
+    chars: html.length,
+    headings: $('h1, h2, h3, h4, h5, h6').length,
+    paragraphs: $('p').length,
+    lists: $('ul, ol').length,
+    listItems: $('li').length,
+    tables: $('table').length,
+    toggles: $('details').length,
+    images: $('img').length,
+  };
+}
+
+export async function censusUploadedFile(file: {
+  originalname: string;
+  buffer: Buffer | undefined;
+}): Promise<DocumentStructureCensus | null> {
+  const { originalname, buffer } = file;
+  if (buffer == null) {
+    return null;
+  }
+  try {
+    if (/\.docx$/i.test(originalname)) {
+      return censusFromHtml(await convertDocxToHTML(buffer));
+    }
+    if (TEXTUAL_EXTENSIONS.test(originalname)) {
+      return censusFromHtml(buffer.toString('utf8'));
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -48,6 +48,7 @@ import {
 } from '../usecases/jobs/jobFailureReason';
 import { DeckTooLargeError } from '../lib/parser/exporters/DeckTooLargeError';
 import { getOwner } from '../lib/User/getOwner';
+import { censusUploadedFile } from '../infrastracture/adapters/fileConversion/documentStructureCensus';
 import { formatDeckName } from '../lib/formatDeckName';
 import {
   CheckMonthlyCardLimitUseCase,
@@ -345,6 +346,18 @@ function logNoPackageDiagnostics(uploadedFiles: UploadedFile[]) {
       console.info(
         `  display:contents=${hasDisplayContents} .toggle=${hasToggleClass} <details=${hasDetails}`
       );
+      // Structural shape, not content — makes the zero-card class
+      // reproducible from logs alone (#3966). Fire and forget: the census
+      // may re-run a DOCX conversion and must never delay the response.
+      censusUploadedFile({ originalname: file.originalname, buffer: contents })
+        .then((census) => {
+          if (census != null) {
+            console.info(
+              `  census=${JSON.stringify(census)} name=${file.originalname}`
+            );
+          }
+        })
+        .catch(() => {});
     } catch (readErr) {
       console.error(`  could not read file: ${readErr}`);
     }


### PR DESCRIPTION
## What

Adds the instrumentation #3966 names as its next step: when a conversion produces zero packages, the `[no-package]` diagnostics now log a structural census of each uploaded file — heading/paragraph/list/table/toggle/image counts plus character length, never content. DOCX files are converted through the existing mammoth adapter first, so the census describes the document Claude and the parser actually saw.

This makes the ~20k-char DOCX zero-card class reproducible from prod logs alone (the one-shot upload path persists no upload row, so today the failing documents are unrecoverable).

## Not in this PR

The underlying instability — the same 22k-char document shipping 68 cards at 12:10 and zero at 12:51 — stays open on #3966. This PR only makes the next occurrence diagnosable.

## Tests

- New `documentStructureCensus.test.ts` (6 tests): HTML census counts, empty input, images, direct HTML uploads, a real in-memory DOCX through mammoth, binary non-DOCX returns null.
- Full server suite: 6229 passed / 2 failed — both the documented environmental `getPageCount` pdfinfo failures. `tsc -p . --noEmit` clean, `pnpm format:check` clean tree-wide.
- Sonar: local scanner not run (no SONAR_TOKEN in env; see #3934); PR decoration will report.

No changelog entry — internal observability, no user-visible behavior change.

Contributes to #3966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
