### PR TITLE
fix: stop guessing spreadsheet headers, match named ones only

### DIFF
--- a/src/infrastracture/adapters/fileConversion/__tests__/convertXLSXToHTML.test.ts
+++ b/src/infrastracture/adapters/fileConversion/__tests__/convertXLSXToHTML.test.ts
@@ -1,7 +1,6 @@
 import { readFileSync } from 'fs';
 import Workspace from '../../../../lib/parser/WorkSpace';
 import { convertXLSXToHTML } from '../convertXLSXToHTML';
-import { looksLikeHeaderRow } from '../tabularRows';
 import { join } from 'path';
 import * as XLSX from 'xlsx';
 
@@ -34,33 +33,25 @@ function buildXlsxBuffer(rows: unknown[][]): Buffer {
   return XLSX.write(workbook, { type: 'buffer', bookType: 'xlsx' });
 }
 
-describe('looksLikeHeaderRow', () => {
-  it('treats a row of short non-numeric strings as a header', () => {
-    expect(looksLikeHeaderRow(['Term', 'Definition'] as never)).toBe(true);
-  });
-
-  it('treats a row with a numeric cell as data, not a header', () => {
-    expect(looksLikeHeaderRow(['Term', 42] as never)).toBe(false);
-  });
-
-  it('keeps a row with leading short labels but a long-form back cell as data', () => {
-    const longBack =
-      'A really long answer that runs well past the heuristic length cap used to spot label-shaped rows';
-    expect(looksLikeHeaderRow(['hello', longBack] as never)).toBe(false);
-  });
-});
-
 describe('convertXLSXToHTML header detection', () => {
-  it('skips a header row when row 0 looks like labels', () => {
+  it('keeps every row of a headerless short-text sheet (#3945)', () => {
     const buffer = buildXlsxBuffer([
-      ['Term', 'Definition'],
-      ['hola', 'hello'],
-      ['adiós', 'goodbye'],
+      ['Fotossíntese', 'Processo de conversão de luz em energia'],
+      ['Mitose', 'Divisão celular'],
     ]);
     const html = convertXLSXToHTML(buffer, 'deck.html');
-    expect(html).not.toContain('<summary>Term</summary>');
+    expect(html).toContain('<summary>Fotossíntese</summary>');
+    expect(html).toContain('<summary>Mitose</summary>');
+  });
+
+  it('keeps an unrecognized header row as a visible card', () => {
+    const buffer = buildXlsxBuffer([
+      ['Vocabulary', 'Meaning'],
+      ['hola', 'hello'],
+    ]);
+    const html = convertXLSXToHTML(buffer, 'deck.html');
+    expect(html).toContain('<summary>Vocabulary</summary>');
     expect(html).toContain('<summary>hola</summary>');
-    expect(html).toContain('<summary>adiós</summary>');
   });
 
   it('keeps row 0 when it contains a numeric cell', () => {
@@ -73,16 +64,31 @@ describe('convertXLSXToHTML header detection', () => {
     expect(html).toContain('<summary>question 2</summary>');
   });
 
-  it('keeps row 0 when a cell is too long to be a label', () => {
-    const longBack =
-      'A really long answer that runs well past the heuristic length cap used to spot label-shaped rows';
+  it.each([
+    ['German', 'Frage', 'Antwort'],
+    ['German', 'Vorderseite', 'Rückseite'],
+    ['Spanish', 'Pregunta', 'Respuesta'],
+    ['Spanish', 'Anverso', 'Reverso'],
+    ['Portuguese', 'Frente', 'Verso'],
+    ['Portuguese', 'Pergunta', 'Resposta'],
+  ])('drops a %s %s/%s header row', (_locale, front, back) => {
     const buffer = buildXlsxBuffer([
-      ['hola', longBack],
-      ['adiós', 'goodbye'],
+      [front, back],
+      ['hola', 'hello'],
     ]);
     const html = convertXLSXToHTML(buffer, 'deck.html');
+    expect(html).not.toContain(`<summary>${front}</summary>`);
     expect(html).toContain('<summary>hola</summary>');
-    expect(html).toContain('<summary>adiós</summary>');
+  });
+
+  it('maps columns by name for a reversed localized header', () => {
+    const buffer = buildXlsxBuffer([
+      ['Antwort', 'Frage'],
+      ['Hallo', 'Was heißt hello?'],
+    ]);
+    const html = convertXLSXToHTML(buffer, 'Vokabeln');
+    expect(html).toContain('<summary>Was heißt hello?</summary>');
+    expect(html).toContain('<p>Hallo</p>');
   });
 });
 
@@ -144,7 +150,7 @@ describe('convertXLSXToHTML header-name mapping', () => {
     expect(html).not.toContain('<summary>term</summary>');
   });
 
-  it('falls back to positional mapping and drops a generic header row', () => {
+  it('drops a capitalized Term/Definition header via the named match', () => {
     const buffer = buildXlsxBuffer([
       ['Term', 'Definition'],
       ['Dog', 'Animal'],

--- a/src/infrastracture/adapters/fileConversion/convertXLSXToHTML.ts
+++ b/src/infrastracture/adapters/fileConversion/convertXLSXToHTML.ts
@@ -3,7 +3,6 @@ import {
   TabularRow,
   cellText,
   detectFieldColumns,
-  looksLikeHeaderRow,
   rowsFromBuffer,
 } from './tabularRows';
 
@@ -25,9 +24,9 @@ function resolveColumns(rows: TabularRow[]): FrontBackColumns {
       backIndex: named.backIndex,
     };
   }
-  if (looksLikeHeaderRow(rows[0])) {
-    return { rows: rows.slice(1), frontIndex: 0, backIndex: 1 };
-  }
+  // No fuzzy header guess: a short-text data row is indistinguishable from a
+  // header, and silently dropping a real first card is worse than shipping a
+  // visible, deletable header card (#3945).
   return { rows, frontIndex: 0, backIndex: 1 };
 }
 

--- a/src/infrastracture/adapters/fileConversion/tabularRows.ts
+++ b/src/infrastracture/adapters/fileConversion/tabularRows.ts
@@ -2,36 +2,28 @@ import * as XLSX from 'xlsx';
 
 export type TabularRow = unknown[];
 
-const HEADER_CELL_MAX_LENGTH = 40;
-
+// Closed set (trio decision, #3945): English plus the three locales with real
+// upload traffic — de, es, pt. A pair only drops row 0 when BOTH words match
+// exactly, so every addition slightly widens the false-drop surface; extend on
+// traffic evidence, not preemptively.
 const FIELD_HEADER_PAIRS: ReadonlyArray<readonly [string, string]> = [
   ['front', 'back'],
   ['question', 'answer'],
   ['term', 'definition'],
+  ['vorderseite', 'rückseite'],
+  ['frage', 'antwort'],
+  ['begriff', 'definition'],
+  ['anverso', 'reverso'],
+  ['pregunta', 'respuesta'],
+  ['término', 'definición'],
+  ['frente', 'verso'],
+  ['pergunta', 'resposta'],
+  ['termo', 'definição'],
 ];
 
 export interface FieldColumns {
   frontIndex: number;
   backIndex: number;
-}
-
-function cellLooksLikeHeader(cell: unknown): boolean {
-  if (cell == null) return true;
-  if (typeof cell === 'string') {
-    const trimmed = cell.trim();
-    if (trimmed.length === 0) return true;
-    if (trimmed.length > HEADER_CELL_MAX_LENGTH) return false;
-    return Number.isNaN(Number(trimmed));
-  }
-  return false;
-}
-
-export function looksLikeHeaderRow(row: TabularRow): boolean {
-  const cells = row.filter(
-    (cell) => cell != null && String(cell).trim() !== ''
-  );
-  if (cells.length === 0) return false;
-  return cells.every(cellLooksLikeHeader);
 }
 
 export function cellText(cell: unknown): string {

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-02-xlsx-first-row.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-02-xlsx-first-row.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-02-xlsx-first-row",
+  "date": "2026-08-02",
+  "type": "fix",
+  "title": "Headerless spreadsheets keep their first row — and header rows in German, Spanish, and Portuguese are recognized"
+}


### PR DESCRIPTION
## What

Fixes #3945: a headerless spreadsheet whose rows are short text — the exact shape of a vocabulary sheet — silently lost its first row to the `looksLikeHeaderRow` guess. Reported as a missing card by a rating-1 widget response (Portuguese, spreadsheet upload).

Row 0 is now dropped only on a deterministic named-header match (`detectFieldColumns`), and the named vocabulary gains German, Spanish, and Portuguese pairs. The fuzzy heuristic (`looksLikeHeaderRow`, `cellLooksLikeHeader`) is deleted — this also brings the XLSX path in line with the CSV path, which never guessed.

## Decisions made overnight (please review)

- **Fix shape: option 1 from the issue (delete the guess), no notice.** All three trio agents converged independently: a silently missing card is invisible and unrecoverable; an unrecognized header word now produces one visible, deletable junk card instead. The notice (option 2) guards an event that no longer happens and would cost a 10-locale string — deliberately not built.
- **Locale scope: de/es/pt only** (real upload traffic: ~4.5%/~0.8%/~1.5%), not all 10 locales. Engineer proposed all 10; PM and designer argued each pair slightly widens the false-drop surface (a data row that literally equals a header pair gets dropped) with no traffic evidence for the rest. Resolved to traffic-based. If that's wrong, extend `FIELD_HEADER_PAIRS` in `tabularRows.ts`.
- **Pairs shipped per locale: the three core translations only** (front/back, question/answer, term/definition). The designer also proposed word/meaning pairs (`Wort/Bedeutung`, `Palavra/Significado`, `Palabra/Significado`); excluded as the least header-like and most likely to appear as real vocab data. Assumption: exact-match on accented forms (`término/definición`) is enough; no accent folding.
- **Blast radius accepted: the CSV path** (`FallbackParser.parseCSVFile`) shares `detectFieldColumns`, so CSVs also gain localized header recognition. Intended, consistent — both paths drop only named headers now.

## Tradeoff (deliberate)

A sheet with an unrecognized header word ("Vocabulary/Meaning", any other locale) now keeps that row as a junk first card. Visible and deletable beats invisible and unrecoverable. If junk-header reports climb, the fix is adding the missing pair, not reinstating the guess.

## Tests

- New: headerless short-text sheet keeps every row (the reported bug — failed before the fix); unrecognized header kept as a visible card; 6 localized header pairs dropped; reversed localized header maps columns by name.
- Updated: `looksLikeHeaderRow` unit tests removed with the symbol.
- Full server suite + tsc + `pnpm format:check`: results in the checks below.
- Sonar: local scanner not run (no SONAR_TOKEN in env; see #3934); PR decoration will report.

Closes #3945.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Checks run

- New/updated XLSX tests: 17/17. FallbackParser (shared `detectFieldColumns` consumer): 33/33.
- Full server suite: 6229 passed / 2 failed — both the documented environmental `getPageCount` pdfinfo failures.
- `tsc -p . --noEmit` clean; `pnpm format:check` clean tree-wide.
- Full web vitest: 2788 passed / 0 failed (changelog loader asserts the new entry).

## Browser check
Browser check: not applicable — the only web/src change is a changelog JSON entry
