### PR TITLE
fix: turn apkg import user-state failures into designed 4xx replies

### DIFF
--- a/src/controllers/ApkgController.test.ts
+++ b/src/controllers/ApkgController.test.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express';
+import { APIErrorCode, APIResponseError } from '@notionhq/client';
 import ApkgController from './ApkgController';
 import DownloadService from '../services/DownloadService';
 import ApkgPreviewService from '../services/ApkgPreviewService/ApkgPreviewService';
@@ -64,6 +65,17 @@ function makeReq(overrides: Partial<Request> = {}): Partial<Request> {
     },
     ...overrides,
   };
+}
+
+function makeAPIResponseError(code: string, status: number): APIResponseError {
+  const err = Object.create(APIResponseError.prototype) as APIResponseError;
+  Object.assign(err, {
+    name: 'APIResponseError',
+    message: `notion internal detail for ${code}`,
+    code,
+    status,
+  });
+  return err;
 }
 
 function makeController() {
@@ -218,6 +230,72 @@ describe('ApkgController.importToNotion', () => {
     expect(res.status).toHaveBeenCalledWith(202);
     const executeCall = executeMock.mock.calls[0];
     expect(executeCall[5]).toMatchObject({ isPaying: true, maxNotes: 10000 });
+  });
+
+  it('returns 400 when the user has no accessible Notion pages', async () => {
+    const controller = makeController();
+    const notionService = controller[
+      'notionService'
+    ] as jest.Mocked<NotionService>;
+    (notionService.getNotionAPI as jest.Mock).mockResolvedValue({
+      searchTopLevelPages: jest.fn().mockResolvedValue({ results: [] }),
+      createPage: jest.fn(),
+    });
+    const req = makeReq({ body: {} }) as Request;
+    const res = makeRes({ patreon: false, subscriber: false }) as Response;
+
+    await controller.importToNotion(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message:
+        'No Notion pages available. Share at least one page with 2anki to use quick import.',
+    });
+  });
+
+  it('returns 401 notion_unauthorized when Notion rejects the search as Unauthorized', async () => {
+    const controller = makeController();
+    const notionService = controller[
+      'notionService'
+    ] as jest.Mocked<NotionService>;
+    (notionService.getNotionAPI as jest.Mock).mockResolvedValue({
+      searchTopLevelPages: jest
+        .fn()
+        .mockRejectedValue(
+          makeAPIResponseError(APIErrorCode.Unauthorized, 401)
+        ),
+      createPage: jest.fn(),
+    });
+    const req = makeReq({ body: {} }) as Request;
+    const res = makeRes({ patreon: false, subscriber: false }) as Response;
+    (res.json as jest.Mock).mockReturnThis();
+    (res as unknown as Record<string, jest.Mock>).send = jest.fn();
+
+    await controller.importToNotion(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'notion_unauthorized' })
+    );
+  });
+
+  it('returns 500 when an unexpected error occurs while starting the import', async () => {
+    const controller = makeController();
+    const notionService = controller[
+      'notionService'
+    ] as jest.Mocked<NotionService>;
+    (notionService.getNotionAPI as jest.Mock).mockRejectedValue(
+      new Error('boom')
+    );
+    const req = makeReq({ body: {} }) as Request;
+    const res = makeRes({ patreon: false, subscriber: false }) as Response;
+
+    await controller.importToNotion(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Import failed to start.',
+    });
   });
 });
 

--- a/src/controllers/ApkgController.ts
+++ b/src/controllers/ApkgController.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express';
+import { APIResponseError } from '@notionhq/client';
 import path from 'path';
 import { randomUUID } from 'crypto';
 import StorageHandler from '../lib/storage/StorageHandler';
@@ -21,6 +22,7 @@ import ExportApkgToCsvUseCase, {
 import ImportApkgToNotionUseCase from '../usecases/apkg/ImportApkgToNotionUseCase';
 import PackEditedApkgUseCase from '../usecases/apkg/PackEditedApkgUseCase';
 import ResolveImportParentPageUseCase from '../usecases/apkg/ResolveImportParentPageUseCase';
+import NoNotionPagesError from '../usecases/apkg/NoNotionPagesError';
 import { CardEdit } from '../services/ApkgPreviewService/applyEditsToCards';
 import { NotionService } from '../services/NotionService/NotionService';
 import JobRepository from '../data_layer/JobRepository';
@@ -393,6 +395,14 @@ class ApkgController {
     } catch (error) {
       if (error instanceof Error && error.message === 'unauthorized') {
         res.status(400).json({ message: 'Notion is not connected.' });
+        return;
+      }
+      if (error instanceof NoNotionPagesError) {
+        res.status(400).json({ message: error.message });
+        return;
+      }
+      if (error instanceof APIResponseError) {
+        sendErrorResponse(error, res);
         return;
       }
       console.error(error);

--- a/src/usecases/apkg/NoNotionPagesError.ts
+++ b/src/usecases/apkg/NoNotionPagesError.ts
@@ -1,0 +1,8 @@
+export default class NoNotionPagesError extends Error {
+  constructor(
+    message = 'No Notion pages available. Share at least one page with 2anki to use quick import.'
+  ) {
+    super(message);
+    this.name = 'NoNotionPagesError';
+  }
+}

--- a/src/usecases/apkg/ResolveImportParentPageUseCase.test.ts
+++ b/src/usecases/apkg/ResolveImportParentPageUseCase.test.ts
@@ -1,4 +1,5 @@
 import ResolveImportParentPageUseCase from './ResolveImportParentPageUseCase';
+import NoNotionPagesError from './NoNotionPagesError';
 import NotionAPIWrapper from '../../services/NotionService/NotionAPIWrapper';
 
 function makeNotionApi(
@@ -76,6 +77,9 @@ describe('ResolveImportParentPageUseCase', () => {
       searchTopLevelPages: jest.fn().mockResolvedValue({ results: [] }),
     });
 
+    await expect(useCase.execute(notionApi)).rejects.toBeInstanceOf(
+      NoNotionPagesError
+    );
     await expect(useCase.execute(notionApi)).rejects.toThrow(
       'No Notion pages available'
     );

--- a/src/usecases/apkg/ResolveImportParentPageUseCase.ts
+++ b/src/usecases/apkg/ResolveImportParentPageUseCase.ts
@@ -1,4 +1,5 @@
 import NotionAPIWrapper from '../../services/NotionService/NotionAPIWrapper';
+import NoNotionPagesError from './NoNotionPagesError';
 
 const IMPORT_PAGE_TITLE = '2anki Imports';
 
@@ -32,9 +33,7 @@ export default class ResolveImportParentPageUseCase {
     });
 
     if (topPages.results.length === 0) {
-      throw new Error(
-        'No Notion pages available. Share at least one page with 2anki to use quick import.'
-      );
+      throw new NoNotionPagesError();
     }
 
     const parentId = topPages.results[0].id;

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-02-apkg-import-errors.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-02-apkg-import-errors.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-02-apkg-import-errors",
+  "date": "2026-08-02",
+  "type": "fix",
+  "title": "Importing an Anki deck to Notion now explains what went wrong instead of failing silently"
+}


### PR DESCRIPTION
## What

`ApkgController.importToNotion` (POST `/api/apkg/import`) wrapped its entire request path in a catch-all that mapped every failure to a generic `500 "Import failed to start."` Two classes of ordinary user-state faults were dying there as opaque 500s:

1. A user with **zero accessible top-level Notion pages** — `ResolveImportParentPageUseCase` threw a generic `Error` with designed copy ("No Notion pages available. Share at least one page…"), but the catch-all flattened it to a 500 so the user never saw the guidance.
2. **Notion `APIResponseError`s** from the search/create calls — a revoked integration (Unauthorized), an unshared page (ObjectNotFound), or a rate limit (RateLimited) all hit the catch-all as 500s, even though the repo already has the mapping machinery (`sendErrorResponse` + `toNotionUploadError`) to turn them into actionable 401/404/429 replies.

This introduces a `NoNotionPagesError` class thrown by the resolver (same message string), and teaches the controller's catch to map both fault classes to designed 4xx replies. Everything unexpected still returns 500.

## Why

These were never server bugs — they are expected outcomes of the user's own Notion state (nothing shared, connection revoked, rate limited). Prod `request_logs` show ~20 unexplained 500s on this route since mid-June, the largest genuine 5xx pool (issue #3953). A generic 500 tells the user "we broke" when the real message is "share a page" or "reconnect Notion." Turning them into designed 4xx replies with copy the user can act on both drops the 5xx count and lets the import self-explain.

## How

New error class + three catch branches after the existing `'unauthorized'` check:

| Failure | Reply |
| --- | --- |
| No accessible Notion pages (`NoNotionPagesError`) | `400 { message }` (the designed copy) |
| Notion `Unauthorized` | `401 { code: notion_unauthorized }` |
| Notion `ObjectNotFound` | `404 { code: notion_object_not_found }` |
| Notion `RateLimited` | `429 { code: notion_rate_limit }` |
| Anything else | `500 "Import failed to start."` (unchanged) |

The 401/404/429 mapping reuses `sendErrorResponse(error, res)` — the same helper the upload path already uses — so the bodies match existing Notion-error copy.

## Measuring success

Prod `request_logs`: the count of `500` responses on `POST /api/apkg/import` should drop toward zero, replaced by `400`/`401`/`404`/`429` where the user's Notion state is the cause. Query the route's status-code distribution before/after deploy.

## Testing

- Unit tests added to `ApkgController.test.ts` (`describe('ApkgController.importToNotion')`): resolver-throws-NoNotionPagesError → 400 with the message; Notion search rejecting with an `Unauthorized` `APIResponseError` → 401 with `notion_unauthorized` body; unexpected generic error → still 500.
- `ResolveImportParentPageUseCase.test.ts`: the no-pages case now asserts `NoNotionPagesError` instance in addition to the message.
- Affected suites: `ApkgController.test.ts` + `ResolveImportParentPageUseCase.test.ts` — 27 passed.
- Full server suite: 6154 passed, 74 failed, 25 skipped, 7 todo (6260 total). All 74 failures are the documented worktree-environmental ones — `getPageCount` (missing `pdfinfo` binary) and the parser/golden/canary suites that spawn Python (no venv in worktrees, per `.claude/rules/local-dev.md`). None touch the files in this PR.
- `tsc -p . --noEmit` clean; `pnpm format:check` clean tree-wide.

Sonar: local scanner not run (no SONAR_TOKEN in env; see #3934); PR decoration will report.

Browser check: not applicable — changelog JSON only under web/src

## Changelog

`web/src/pages/WhatsNewPage/changelog/2026-08-02-apkg-import-errors.json` — "Importing an Anki deck to Notion now explains what went wrong instead of failing silently"

## Risks

Low. The change only reshapes error responses on failure paths; the 202 success path and the explicit-`parent_page_id` path are untouched. The 400/401/404/429 bodies reuse the existing `sendErrorResponse` machinery already proven on the upload path. Rollback is a straight revert.

## Goal alignment

Reliability/trust on a paid conversion surface — a broken import that self-explains is one the user can recover from instead of churning or emailing support. Metric: 5xx rate on `POST /api/apkg/import` in prod `request_logs`, read post-deploy.

Fixes #3953

🤖 Generated with [Claude Code](https://claude.com/claude-code)
