### PR TITLE
fix: offer zip and DOCX images to AI conversions outside Notion layout

### DIFF
--- a/src/infrastracture/adapters/fileConversion/PrepareDeck.test.ts
+++ b/src/infrastracture/adapters/fileConversion/PrepareDeck.test.ts
@@ -46,6 +46,10 @@ jest.mock('./convertPDFToImages', () => ({
   convertPDFToImages: jest.fn().mockResolvedValue('<p>page image card</p>'),
 }));
 
+jest.mock('./convertDocxToHTML', () => ({
+  convertDocxToHTML: jest.fn(),
+}));
+
 const {
   convertPdfTextToHtml,
   convertPdfTextToHtmlAuto,
@@ -686,5 +690,73 @@ describe('PrepareDeck — extracted PDF figures reach the Claude media list', ()
       undefined,
       undefined
     );
+  });
+});
+
+describe('PrepareDeck — AI media matching (#3946)', () => {
+  const { convertDocxToHTML } = require('./convertDocxToHTML');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('offers unclaimed zip images to the AI conversion', async () => {
+    generateDeckInfo.mockResolvedValueOnce([]);
+
+    await PrepareDeck({
+      name: 'export.zip',
+      files: [
+        { name: 'Page.html', contents: '<p>Front</p>' },
+        { name: 'images/photo.png', contents: Buffer.from('png-bytes') },
+      ],
+      settings: makeSettings({ 'claude-ai-flashcards': 'true' }),
+      noLimits: true,
+      workspace: makeWorkspace(),
+    }).catch(() => {});
+
+    expect(generateDeckInfo).toHaveBeenCalledTimes(1);
+    const mediaArg = generateDeckInfo.mock.calls[0][1];
+    expect(mediaArg).toContain('images/photo.png');
+  });
+
+  it('does not offer the original source files as media', async () => {
+    generateDeckInfo.mockResolvedValueOnce([]);
+    convertDocxToHTML.mockResolvedValueOnce('<p>docx text</p>');
+
+    await PrepareDeck({
+      name: 'notes.docx',
+      files: [{ name: 'notes.docx', contents: Buffer.from('PK-docx') }],
+      settings: makeSettings({ 'claude-ai-flashcards': 'true' }),
+      noLimits: true,
+      workspace: makeWorkspace(),
+    }).catch(() => {});
+
+    const mediaArg = generateDeckInfo.mock.calls[0][1];
+    expect(mediaArg).not.toContain('notes.docx');
+  });
+
+  it('carries DOCX images written by the media sink into the AI conversion', async () => {
+    generateDeckInfo.mockResolvedValueOnce([]);
+    convertDocxToHTML.mockImplementationOnce(
+      async (
+        _contents: Buffer,
+        sink: { write: (bytes: Buffer, contentType: string) => string }
+      ) => {
+        const name = sink.write(Buffer.from('img-bytes'), 'image/png');
+        return `<p>docx text</p><img src="${name}" />`;
+      }
+    );
+
+    await PrepareDeck({
+      name: 'notes.docx',
+      files: [{ name: 'notes.docx', contents: Buffer.from('PK-docx') }],
+      settings: makeSettings({ 'claude-ai-flashcards': 'true' }),
+      noLimits: true,
+      workspace: makeWorkspace(),
+    }).catch(() => {});
+
+    expect(generateDeckInfo).toHaveBeenCalledTimes(1);
+    const mediaArg = generateDeckInfo.mock.calls[0][1] as string[];
+    expect(mediaArg.some((m: string) => m.endsWith('.png'))).toBe(true);
   });
 });

--- a/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
+++ b/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
@@ -38,6 +38,7 @@ import Workspace from '../../../lib/parser/WorkSpace';
 import path from 'path';
 import { writeWorkspaceFile } from './writeWorkspaceFile';
 import { writePdfImageFallbackMarker } from './pdfImageFallbackMarker';
+import { mediaFilesForHtmlFile } from './mediaFilesForHtmlFile';
 
 const HTML_GENERATION_CONCURRENCY = 3;
 
@@ -140,16 +141,29 @@ async function convertFile(
     const mediaSink = createWorkspaceDocxImageMediaSink(
       input.workspace.location
     );
+    // Record what the sink writes: the flat hash-named images never match the
+    // <html-base>/ media convention, so without carrying them as extraFiles
+    // the AI branch converts DOCX text without its images (#3946).
+    const writtenImages: PdfHtmlImage[] = [];
+    const recordingSink: typeof mediaSink = {
+      write(bytes, contentType) {
+        const fileName = mediaSink.write(bytes, contentType);
+        writtenImages.push({ name: fileName, contents: bytes });
+        return fileName;
+      },
+    };
     const result = {
       name: `${file.name}.html`,
       contents: Buffer.from(
-        await convertDocxToHTML(file.contents as Buffer, mediaSink, {
+        await convertDocxToHTML(file.contents as Buffer, recordingSink, {
           bulletFanOut: input.settings.overlappingCloze === 'off',
         })
       ),
+      extraFiles: writtenImages.length > 0 ? writtenImages : undefined,
     };
     console.log('[PrepareDeck] convertFile docx', {
       file: file.name,
+      imageCount: writtenImages.length,
       durationMs: Date.now() - t0,
     });
     return result;
@@ -391,24 +405,6 @@ function deckPrefixFromFilePath(htmlFileName: string): string {
     .join('::');
 }
 
-function mediaFilesForHtmlFile(
-  htmlFileName: string,
-  allMediaFiles: string[]
-): string[] {
-  const normalized = htmlFileName.replaceAll('\\', '/');
-  const lastSlash = normalized.lastIndexOf('/');
-  const dir = lastSlash >= 0 ? normalized.substring(0, lastSlash) : '';
-  const base = normalized
-    .substring(lastSlash + 1)
-    .replace(/\.html$/i, '')
-    .replace(/ [a-f0-9]{32}$/i, '')
-    .trim();
-  const prefix = dir ? `${dir}/${base}/` : `${base}/`;
-  return allMediaFiles.filter((m) =>
-    m.replaceAll('\\', '/').startsWith(prefix)
-  );
-}
-
 export async function PrepareDeck(
   input: DeckParserInput
 ): Promise<PrepareDeckResult> {
@@ -455,8 +451,22 @@ export async function PrepareDeck(
       (f) => (isHTMLFile(f.name) || isMarkdownFile(f.name)) && f.contents
     );
 
+    // Figure images extracted per source file (PDF text-layer, DOCX) travel
+    // to their own HTML via pdfFigureNamesByHtml below; keeping them out of
+    // the shared pool stops the unclaimed-media fallback from offering one
+    // file's figures to every other file's prompt.
+    const perFileFigureNames = new Set(
+      convertedFiles.flatMap(
+        (f) => f.extraFiles?.map((image) => image.name) ?? []
+      )
+    );
     const mediaFiles = allFiles
-      .filter((f) => !isHTMLFile(f.name) && !isMarkdownFile(f.name))
+      .filter(
+        (f) =>
+          !isHTMLFile(f.name) &&
+          !isMarkdownFile(f.name) &&
+          !perFileFigureNames.has(f.name)
+      )
       .map((f) => f.name);
 
     const pdfFigureNamesByHtml = new Map(
@@ -507,7 +517,11 @@ export async function PrepareDeck(
         generateDeckInfo(
           f.contents!.toString(),
           [
-            ...mediaFilesForHtmlFile(f.name, mediaFiles),
+            ...mediaFilesForHtmlFile(
+              f.name,
+              mediaFiles,
+              htmlFiles.map((h) => h.name)
+            ),
             ...(pdfFigureNamesByHtml.get(f.name) ?? []),
           ],
           userInstructions,

--- a/src/infrastracture/adapters/fileConversion/mediaFilesForHtmlFile.test.ts
+++ b/src/infrastracture/adapters/fileConversion/mediaFilesForHtmlFile.test.ts
@@ -1,0 +1,55 @@
+import { mediaFilesForHtmlFile } from './mediaFilesForHtmlFile';
+
+describe('mediaFilesForHtmlFile', () => {
+  it('matches media under the Notion-style <base>/ folder', () => {
+    const media = [
+      'Export/Page abc123def456abc123def456abc12345/img.png',
+      'Export/Other page 999999999999999999999999999999zz/other.png',
+    ];
+    const result = mediaFilesForHtmlFile(
+      'Export/Page abc123def456abc123def456abc12345.html',
+      media,
+      [
+        'Export/Page abc123def456abc123def456abc12345.html',
+        'Export/Other page 999999999999999999999999999999zz.html',
+      ]
+    );
+    expect(result).toEqual([
+      'Export/Page abc123def456abc123def456abc12345/img.png',
+    ]);
+  });
+
+  it('offers root-level images that belong to no HTML file (#3946)', () => {
+    const media = ['images/photo.png', 'cover.jpg'];
+    const result = mediaFilesForHtmlFile('Page.html', media, ['Page.html']);
+    expect(result).toEqual(['images/photo.png', 'cover.jpg']);
+  });
+
+  it('offers unclaimed images to every HTML file, claimed ones to their own', () => {
+    const media = ['A/one.png', 'shared/logo.png'];
+    const htmlNames = ['A.html', 'B.html'];
+    expect(mediaFilesForHtmlFile('A.html', media, htmlNames)).toEqual([
+      'A/one.png',
+      'shared/logo.png',
+    ]);
+    expect(mediaFilesForHtmlFile('B.html', media, htmlNames)).toEqual([
+      'shared/logo.png',
+    ]);
+  });
+
+  it('does not offer non-image unclaimed files as media', () => {
+    const media = ['notes.docx', 'deck.pdf', 'images/fig.png'];
+    const result = mediaFilesForHtmlFile('notes.docx.html', media, [
+      'notes.docx.html',
+    ]);
+    expect(result).toEqual(['images/fig.png']);
+  });
+
+  it('normalizes backslash paths', () => {
+    const media = ['Export\\Page\\img.png'];
+    const result = mediaFilesForHtmlFile('Export\\Page.html', media, [
+      'Export\\Page.html',
+    ]);
+    expect(result).toEqual(['Export\\Page\\img.png']);
+  });
+});

--- a/src/infrastracture/adapters/fileConversion/mediaFilesForHtmlFile.ts
+++ b/src/infrastracture/adapters/fileConversion/mediaFilesForHtmlFile.ts
@@ -1,0 +1,36 @@
+import { isImageFile } from '../../../lib/storage/checks';
+
+function mediaPrefixForHtml(htmlFileName: string): string {
+  const normalized = htmlFileName.replaceAll('\\', '/');
+  const lastSlash = normalized.lastIndexOf('/');
+  const dir = lastSlash >= 0 ? normalized.substring(0, lastSlash) : '';
+  const base = normalized
+    .substring(lastSlash + 1)
+    .replace(/\.html$/i, '')
+    .replace(/ [a-f0-9]{32}$/i, '')
+    .trim();
+  return dir ? `${dir}/${base}/` : `${base}/`;
+}
+
+// Media matched by the Notion-export convention (<dir>/<html-base>/...) stays
+// scoped to its page. Images that sit under NO html file's folder — sibling
+// or root-level layouts from non-Notion zips — used to match nothing and
+// silently vanish from AI conversions (#3946); they are now offered to every
+// html file. Only images qualify for the fallback: the unclaimed pool also
+// holds the original .docx/.pdf sources, which are not card media.
+export function mediaFilesForHtmlFile(
+  htmlFileName: string,
+  allMediaFiles: string[],
+  allHtmlFileNames: string[]
+): string[] {
+  const ownPrefix = mediaPrefixForHtml(htmlFileName);
+  const allPrefixes = allHtmlFileNames.map(mediaPrefixForHtml);
+  return allMediaFiles.filter((m) => {
+    const normalized = m.replaceAll('\\', '/');
+    if (normalized.startsWith(ownPrefix)) return true;
+    return (
+      isImageFile(normalized) &&
+      !allPrefixes.some((prefix) => normalized.startsWith(prefix))
+    );
+  });
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-02-ai-zip-docx-images.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-02-ai-zip-docx-images.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-02-ai-zip-docx-images",
+  "date": "2026-08-02",
+  "type": "fix",
+  "title": "AI conversions keep the images from Word documents and from zips with images in their own folder"
+}


### PR DESCRIPTION
## What

Fixes the two AI-conversion image paths #3939/#3965 did not cover, matching the suspects named in #3946:

1. **Zips with images outside the Notion `<html-base>/` layout.** `mediaFilesForHtmlFile` matched media only under `<dir>/<html-base>/`; sibling- or root-folder images matched nothing and the AI cards silently shipped without them. Images that belong to no HTML file's folder are now offered to every HTML file (extracted to `mediaFilesForHtmlFile.ts` with tests). The fallback is image-only — the unclaimed pool also holds the original `.docx`/`.pdf` sources, which are not card media and stay excluded.
2. **DOCX images through the AI branch.** The DOCX media sink writes flat hash-named images that can never satisfy the prefix convention, and they were never added to the media list at all — DOCX text converted with zero images offered. The conversion now records what the sink writes and carries it as `extraFiles`, riding the exact mechanism the PDF figure path already uses (`pdfFigureNamesByHtml`).

Per-file figures (PDF + DOCX) are also excluded from the shared pool so one file's images are never offered to another file's prompt.

## Could not reproduce from the report

The 2026-07-30 rating-1 report is anonymous with no upload shape; it may also have been the scanned-PDF path #3939 already fixed. These two gaps are verified by reading the matching code, not by reproducing the reporter's upload — stated per the issue's own next-step framing. The issue stays open for post-deploy observation; this closes its two named suspects.

## Tests

- New `mediaFilesForHtmlFile.test.ts` (5): Notion-layout scoping preserved, root/sibling images offered, unclaimed images shared across HTML files while claimed stay scoped, non-image files never offered, backslash paths.
- New PrepareDeck wiring tests (3): unclaimed zip image reaches `generateDeckInfo`'s media list; original source file does not; DOCX sink-written image does. (Honest note: the module-level tests assert the new fallback behavior; the wiring tests were written alongside the wiring, not watched fail first — the interface change makes the old shape uncompilable.)
- Full server suite: 6231 passed / 2 failed — both the documented environmental `getPageCount` pdfinfo failures. `tsc -p . --noEmit` clean; `pnpm format:check` clean tree-wide.
- Sonar: local scanner not run (no SONAR_TOKEN in env; see #3934); PR decoration will report.

## Browser check
Browser check: not applicable — server-side conversion change; the only web/src file is a changelog entry

Contributes to #3946 (both named suspects fixed; issue stays open for post-deploy recurrence watch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
