### PR TITLE
fix: stream Claude file conversions so PDFs and images convert

### DIFF
--- a/src/infrastracture/adapters/fileConversion/claudeFileConversion.test.ts
+++ b/src/infrastracture/adapters/fileConversion/claudeFileConversion.test.ts
@@ -1,22 +1,38 @@
 import type Anthropic from '@anthropic-ai/sdk';
 import { convertWithClaude, FileConversionError } from './claudeFileConversion';
 
-const makeAnthropicMock = (responseText: string, stopReason = 'end_turn') => ({
-  messages: {
-    create: jest.fn().mockResolvedValue({
-      content: [{ type: 'text', text: responseText }],
-      stop_reason: stopReason,
-    }),
-  },
-  beta: {
-    messages: {
-      create: jest.fn().mockResolvedValue({
-        content: [{ type: 'text', text: responseText }],
-        stop_reason: stopReason,
-      }),
+// The SDK rejects a non-streaming request whose max_tokens implies more than
+// ten minutes of work: 60min * max_tokens / 128000 > 10min. Anything above this
+// must stream, so the tests assert the streaming surface is the one used.
+const SDK_NON_STREAMING_CEILING = Math.floor(128000 / 6);
+
+const makeStream = (response: unknown) =>
+  jest.fn().mockReturnValue({
+    finalMessage: jest.fn().mockResolvedValue(response),
+  });
+
+const makeAnthropicMock = (responseText: string, stopReason = 'end_turn') => {
+  const response = {
+    content: [{ type: 'text', text: responseText }],
+    stop_reason: stopReason,
+  };
+  return {
+    messages: { stream: makeStream(response), create: jest.fn() },
+    beta: {
+      messages: { stream: makeStream(response), create: jest.fn() },
     },
-  },
-});
+  };
+};
+
+const makeFailingMock = (message: string) => {
+  const stream = jest.fn().mockReturnValue({
+    finalMessage: jest.fn().mockRejectedValue(new Error(message)),
+  });
+  return {
+    messages: { stream, create: jest.fn() },
+    beta: { messages: { stream, create: jest.fn() } },
+  };
+};
 
 describe('convertWithClaude', () => {
   it('returns the text content from the API response', async () => {
@@ -30,16 +46,7 @@ describe('convertWithClaude', () => {
   });
 
   it('throws FileConversionError when the API call fails', async () => {
-    const mock = {
-      messages: {
-        create: jest.fn().mockRejectedValue(new Error('API unavailable')),
-      },
-      beta: {
-        messages: {
-          create: jest.fn().mockRejectedValue(new Error('API unavailable')),
-        },
-      },
-    };
+    const mock = makeFailingMock('API unavailable');
     await expect(
       convertWithClaude(mock as unknown as Anthropic, 'system prompt', [
         { type: 'text', text: 'user text' },
@@ -48,16 +55,7 @@ describe('convertWithClaude', () => {
   });
 
   it('throws FileConversionError with upstream message when API fails', async () => {
-    const mock = {
-      messages: {
-        create: jest.fn().mockRejectedValue(new Error('rate limit exceeded')),
-      },
-      beta: {
-        messages: {
-          create: jest.fn().mockRejectedValue(new Error('rate limit exceeded')),
-        },
-      },
-    };
+    const mock = makeFailingMock('rate limit exceeded');
     await expect(
       convertWithClaude(mock as unknown as Anthropic, 'system prompt', [
         { type: 'text', text: 'user text' },
@@ -71,7 +69,7 @@ describe('convertWithClaude', () => {
       { type: 'text', text: 'user text' },
     ]);
 
-    const callArg = (mock.messages.create as jest.Mock).mock.calls[0][0];
+    const callArg = (mock.messages.stream as jest.Mock).mock.calls[0][0];
     expect(callArg.system).toEqual([
       {
         type: 'text',
@@ -81,7 +79,7 @@ describe('convertWithClaude', () => {
     ]);
   });
 
-  it('uses client.beta.messages.create with pdfs-2024-09-25 beta when pdf flag is set', async () => {
+  it('uses client.beta.messages.stream with pdfs-2024-09-25 beta when pdf flag is set', async () => {
     const mock = makeAnthropicMock('<p>result</p>');
     await convertWithClaude(
       mock as unknown as Anthropic,
@@ -90,29 +88,46 @@ describe('convertWithClaude', () => {
       { pdf: true }
     );
 
-    expect(mock.messages.create).not.toHaveBeenCalled();
-    const callArg = (mock.beta.messages.create as jest.Mock).mock.calls[0][0];
+    expect(mock.messages.stream).not.toHaveBeenCalled();
+    const callArg = (mock.beta.messages.stream as jest.Mock).mock.calls[0][0];
     expect(callArg.betas).toContain('pdfs-2024-09-25');
   });
 
-  it('uses client.messages.create (not beta) when pdf flag is not set', async () => {
+  it('uses client.messages.stream (not beta) when pdf flag is not set', async () => {
     const mock = makeAnthropicMock('<p>result</p>');
     await convertWithClaude(mock as unknown as Anthropic, 'system prompt', [
       { type: 'text', text: 'user text' },
     ]);
 
-    expect(mock.messages.create).toHaveBeenCalled();
+    expect(mock.messages.stream).toHaveBeenCalled();
+    expect(mock.beta.messages.stream).not.toHaveBeenCalled();
+  });
+
+  it('never uses the non-streaming API, which would throw at this max_tokens', async () => {
+    const mock = makeAnthropicMock('<p>result</p>');
+    await convertWithClaude(mock as unknown as Anthropic, 'system prompt', [
+      { type: 'text', text: 'user text' },
+    ]);
+    await convertWithClaude(
+      mock as unknown as Anthropic,
+      'system prompt',
+      [{ type: 'text', text: 'user text' }],
+      { pdf: true }
+    );
+
+    expect(mock.messages.create).not.toHaveBeenCalled();
     expect(mock.beta.messages.create).not.toHaveBeenCalled();
   });
 
-  it('uses 32768 max_tokens', async () => {
+  it('uses 32768 max_tokens, above the SDK non-streaming ceiling', async () => {
     const mock = makeAnthropicMock('<p>result</p>');
     await convertWithClaude(mock as unknown as Anthropic, 'system prompt', [
       { type: 'text', text: 'user text' },
     ]);
 
-    const callArg = (mock.messages.create as jest.Mock).mock.calls[0][0];
+    const callArg = (mock.messages.stream as jest.Mock).mock.calls[0][0];
     expect(callArg.max_tokens).toBe(32768);
+    expect(callArg.max_tokens).toBeGreaterThan(SDK_NON_STREAMING_CEILING);
   });
 
   it('throws instead of returning a silently truncated document', async () => {
@@ -140,12 +155,14 @@ describe('convertWithClaude', () => {
 
   it('joins every text block instead of reading only the first', async () => {
     const mock = makeAnthropicMock('');
-    (mock.messages.create as jest.Mock).mockResolvedValue({
-      content: [
-        { type: 'text', text: '<p>part one</p>' },
-        { type: 'text', text: '<p>part two</p>' },
-      ],
-      stop_reason: 'end_turn',
+    (mock.messages.stream as jest.Mock).mockReturnValue({
+      finalMessage: jest.fn().mockResolvedValue({
+        content: [
+          { type: 'text', text: '<p>part one</p>' },
+          { type: 'text', text: '<p>part two</p>' },
+        ],
+        stop_reason: 'end_turn',
+      }),
     });
 
     const result = await convertWithClaude(
@@ -163,7 +180,7 @@ describe('convertWithClaude', () => {
       { type: 'text', text: 'user text' },
     ]);
 
-    const callArg = (mock.messages.create as jest.Mock).mock.calls[0][0];
+    const callArg = (mock.messages.stream as jest.Mock).mock.calls[0][0];
     expect(callArg.model).toBe('claude-sonnet-4-6');
   });
 
@@ -175,7 +192,7 @@ describe('convertWithClaude', () => {
     ]);
     delete process.env.CLAUDE_FILE_CONVERSION_MODEL;
 
-    const callArg = (mock.messages.create as jest.Mock).mock.calls[0][0];
+    const callArg = (mock.messages.stream as jest.Mock).mock.calls[0][0];
     expect(callArg.model).toBe('claude-opus-4-5');
   });
 });

--- a/src/infrastracture/adapters/fileConversion/claudeFileConversion.ts
+++ b/src/infrastracture/adapters/fileConversion/claudeFileConversion.ts
@@ -11,6 +11,14 @@ const DEFAULT_MODEL = 'claude-sonnet-4-6';
 // were the whole thing.
 const MAX_TOKENS = 32768;
 
+// The SDK refuses a non-streaming request whose worst-case duration exceeds ten
+// minutes, and it decides that from max_tokens alone: 60min * max_tokens /
+// 128000 > 10min, so anything above 21 333 throws client-side before a request
+// is ever sent. Raising the cap to 32 768 therefore killed every conversion
+// through here until these calls became streaming ones. Lowering the cap would
+// bring back the silent truncation the cap exists to prevent, so the calls
+// stream instead.
+
 export const CONVERSION_TRUNCATED_MESSAGE =
   'This document is too large to convert in one pass. Split it into smaller parts and convert each one.';
 
@@ -63,26 +71,30 @@ export async function convertWithClaude(
 
   try {
     if (options.pdf) {
-      const response = await client.beta.messages.create({
-        model: getModel(),
-        max_tokens: MAX_TOKENS,
-        system: [systemBlock],
-        messages: [
-          { role: 'user', content: userContent as BetaContentBlockParam[] },
-        ],
-        betas: ['pdfs-2024-09-25'],
-      });
+      const response = await client.beta.messages
+        .stream({
+          model: getModel(),
+          max_tokens: MAX_TOKENS,
+          system: [systemBlock],
+          messages: [
+            { role: 'user', content: userContent as BetaContentBlockParam[] },
+          ],
+          betas: ['pdfs-2024-09-25'],
+        })
+        .finalMessage();
       logClaudeUsage('claudeFileConversion', response.usage);
       assertNotTruncated(response.stop_reason);
       return joinTextBlocks(response.content);
     }
 
-    const response = await client.messages.create({
-      model: getModel(),
-      max_tokens: MAX_TOKENS,
-      system: [systemBlock],
-      messages: [{ role: 'user', content: userContent }],
-    });
+    const response = await client.messages
+      .stream({
+        model: getModel(),
+        max_tokens: MAX_TOKENS,
+        system: [systemBlock],
+        messages: [{ role: 'user', content: userContent }],
+      })
+      .finalMessage();
     logClaudeUsage('claudeFileConversion', response.usage);
     assertNotTruncated(response.stop_reason);
     return joinTextBlocks(response.content);

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-05-ai-pdf-image-conversion.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-05-ai-pdf-image-conversion.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-05-ai-pdf-image-conversion",
+  "date": "2026-08-05",
+  "type": "fix",
+  "title": "Uploads with a PDF or image convert again when AI flashcards are on"
+}


### PR DESCRIPTION
Closes #3994

## What

`convertWithClaude` now streams instead of using the non-streaming API. Uploads containing a PDF or an image convert again.

## Why

The adapter sent `max_tokens: 32768` on `client.messages.create` / `client.beta.messages.create`. The Anthropic SDK refuses any non-streaming request whose worst-case duration exceeds ten minutes and derives that from `max_tokens` alone:

```
expectedTime = 60min * max_tokens / 128000 > 10min   →   anything above 21,333 throws
```

It throws **client-side, before a request is ever sent**. So every upload reaching this adapter has failed since 31e0edb084e2 (#3905, 2026-07-28) raised the cap 8,192 → 32,768 — three days after the SDK carrying that guard landed in #3836.

Reproduces with no server involved:

```bash
node -e "const A=require('@anthropic-ai/sdk');new A({apiKey:'x'}).messages.create({model:'claude-sonnet-4-6',max_tokens:32768,messages:[{role:'user',content:'hi'}]}).catch(e=>console.log(e.message))"
```

Lowering the cap back under the ceiling would restore the silent truncation the cap exists to prevent, so the calls stream instead. This is the SDK's own prescribed answer for long requests, and the pattern already used by `ClaudeService.ts:749-773` and `ChatUseCase.ts:653`.

## Scope

`convertWithClaude` is reached from two branches of `PrepareDeck.convertFile`:

| Branch | Gate |
| --- | --- |
| images in the upload | `settings.imageQuizHtmlToAnki` |
| PDFs in the upload | `settings.vertexAIPDFQuestions` |

Both are independent of `claudeAIFlashcards`, so this affected the **synchronous** upload path as well as the async AI job. Plain HTML never reached it — that goes to `ClaudeService.generateDeckInfo`, which already streams.

## Why CI missed it

`claudeFileConversion.test.ts` hand-rolled the client and cast it `mock as unknown as Anthropic`, so real SDK code — including the guard — never executed. The suite passed at 32,768 while production threw 100% of the time.

The tests now drive the streaming surface, assert the non-streaming one is never touched, and tie `max_tokens` to the ceiling constant so the bug cannot be "fixed" by quietly lowering the cap.

## Verification

Real SDK, same payload, invalid key:

```
non-streaming -> Streaming is required for operations that may take longer than 10 minu
streaming     -> 401 {"type":"error","error":{"type":"authentication_error",...
```

Non-streaming throws the guard; streaming reaches the network. That is the fix, confirmed at the SDK boundary rather than against a mock.

- Full server suite: 669 suites passed, 6267 tests passed. One pre-existing environmental failure (`src/lib/pdf/getPageCount.test.ts`, needs a `pdfinfo` binary not present on this box) — unrelated to this change.
- `pnpm format:check` (tree-wide) clean, `oxlint` clean, `tsc -p . --noEmit` clean with no `as any` needed.
- Reproduced on prod before the fix, by uploading a zip containing images with `image-quiz-html-to-anki` on: job failed in under a minute with the SDK message.

**Not yet verified end to end against the live API.** The guard is cleared and the response shape is unchanged (`finalMessage()` returns the same `Message` with `.content`, `.stop_reason`, `.usage`), but the first real post-deploy conversion of a PDF/image upload is the confirming signal. Per `.claude/rules/first-time-fix.md`, no "fixed" reply goes to the reporter until that lands.

## Funnel impact

Restores AI conversion for any upload containing a PDF or image. Signal to watch: occurrences of the SDK guard message in prod logs should go to zero.

Browser check: not applicable — server-side conversion adapter; the only `web/src` file in the diff is a changelog entry.
