### PR TITLE
ci: run the server test suite on dependabot PRs

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -40,7 +40,6 @@ jobs:
 
   test:
     name: test (22.20.0)
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## What

Removes one line from `.github/workflows/server.yml` so the server test suite runs on Dependabot PRs.

```diff
   test:
     name: test (22.20.0)
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
```

## Why

The `test` job was gated on `github.actor != 'dependabot[bot]'`, so `pnpm test` never ran on a dependency bump. The check still appeared in the rollup as `SKIPPED`, and the PR still summarised as green — so a Dependabot PR looked verified when the one gate that catches transitive breakage had not run at all.

Dependency bumps are the change class where transitive breakage is most likely and where reading the diff is least informative. They were the only changes exempt from the test gate. `dependabot-auto-merge.yml` acts on that green.

This is not theoretical. Three bumps open today were green under the old gate, and each breaks the suite:

| PR | Bump | Effect |
| --- | --- | --- |
| #3998 | sanitize-html 2.17.5 → 2.17.6 | pulls ESM-only `htmlparser2@12`; **11 suites fail to load** across the upload/preview path |
| #3987 | markdown-it 14 → 15 | removes `md.utils.assign`; `markdown-it-multimd-table` throws on import, **26 suites** die |
| #3988 | jsdom 29 → 30 | regresses SVG attribute-value selectors |

#3998 and #3987 would have broken the conversion path in production. All three were found only by running the suite locally.

## Security

No new trust boundary. The `static` job (typecheck, lint, format, arch) already runs on Dependabot PRs from the same `actions/checkout` and the same `pnpm install`, so the branch's code and its build scripts already execute in CI either way. This change runs more of the already-checked-out code, not code that was previously untrusted.

The workflow triggers on `push` and interpolates no event data into any `run:` step, so there is no injection surface.

## Secrets

Dependabot runs do not receive regular repo secrets, so `NOTION_KEY` is empty for them. That is fine: the Notion tests construct `MockNotionAPI` and never call the network. Verified locally with `NOTION_KEY` unset — **669 suites pass**, with only the known `src/lib/pdf/getPageCount.test.ts` environmental failure (needs a `pdfinfo` binary).

## What this deliberately does not change

`playwright.yml:34` keeps its `if: ${{ github.actor != 'dependabot[bot]' }}`. It is a browser e2e that would add runtime and flake to every bump, and it would not have caught any of the three breakages above. Per `.claude/rules/browser-attestation.md`, a flaky e2e blocking merges is worse than the gap it closes.

## Expected impact

Internal — no user-facing change, no funnel metric. The effect is that a Dependabot PR that breaks the server suite now shows red instead of green.

Browser check: not applicable — CI workflow change, no `web/src` files in the diff.
