### PR TITLE
fix: stop showing users raw library error text when a job fails

### DIFF
--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -295,11 +295,7 @@ function walkMediaFiles(dir: string): string[] {
   return results;
 }
 
-function resolveAsyncFailureReason(
-  err: unknown,
-  message: string,
-  jobId: string
-): string {
+function resolveAsyncFailureReason(err: unknown, jobId: string): string {
   if (err instanceof MonthlyLimitError) {
     return JSON.stringify({
       code: 'monthly_limit',
@@ -317,13 +313,11 @@ function resolveAsyncFailureReason(
       reset_on: err.reset_on,
     });
   }
-  const isParserCrash =
-    err instanceof Error &&
-    (err as Error & { code?: string }).code === 'PARSER_CRASH';
-  if (err instanceof EmptyDeckError || isParserCrash || message.trim() === '') {
-    return jobFailureReasonFromError(err, jobId);
-  }
-  return message;
+  // Everything else goes through the allowlist, which decides what a user is
+  // allowed to read. Returning `message` here instead meant any library or
+  // driver text reached the downloads page verbatim — a user was once shown an
+  // Anthropic SDK error complete with a link to its GitHub repo.
+  return jobFailureReasonFromError(err, jobId);
 }
 
 function logNoPackageDiagnostics(uploadedFiles: UploadedFile[]) {
@@ -603,7 +597,7 @@ class UploadService {
         job.object_id,
         owner,
         'failed',
-        resolveAsyncFailureReason(err, err.message, job.object_id)
+        resolveAsyncFailureReason(err, job.object_id)
       );
     });
 
@@ -1057,7 +1051,7 @@ class UploadService {
             err,
           });
         }
-        const reason = resolveAsyncFailureReason(err, message, ws.id);
+        const reason = resolveAsyncFailureReason(err, ws.id);
         await this.jobRepository.updateJobStatus(
           ws.id,
           owner,

--- a/src/usecases/jobs/jobFailureReason.test.ts
+++ b/src/usecases/jobs/jobFailureReason.test.ts
@@ -4,6 +4,7 @@ import {
   ClaudeLargeSectionError,
   LARGE_SECTION_USER_MESSAGE,
 } from '../../lib/claude/ClaudeService';
+import { CONVERSION_TRUNCATED_MESSAGE } from '../../infrastracture/adapters/fileConversion/claudeFileConversion';
 import { EmptyDeckError } from './EmptyDeckError';
 import {
   COLUMNS_AMBIGUOUS_PREFIX,
@@ -350,5 +351,60 @@ describe('jobFailureReasonCode', () => {
     expect(jobFailureReasonCode(new Error('mystery'))).toBe('unknown');
     expect(jobFailureReasonCode('string error')).toBe('unknown');
     expect(jobFailureReasonCode(undefined)).toBe('unknown');
+  });
+});
+
+describe('jobFailureReasonFromError on worker-flattened errors', () => {
+  // The upload worker serialises errors to { message, name } and
+  // GeneratePackagesUseCase rebuilds a plain Error, so every instanceof and
+  // code check below sees a bare Error. These assert the reason still resolves
+  // from the name that survived the boundary.
+  function flatten(name: string, message: string): Error {
+    const e = new Error(message);
+    e.name = name;
+    return e;
+  }
+
+  it('keeps the large-section message when the class was flattened', () => {
+    expect(
+      jobFailureReasonFromError(
+        flatten('ClaudeLargeSectionError', LARGE_SECTION_USER_MESSAGE)
+      )
+    ).toBe(LARGE_SECTION_USER_MESSAGE);
+  });
+
+  it('keeps the python exit message when the class was flattened', () => {
+    expect(
+      jobFailureReasonFromError(flatten('PythonExitError', 'genanki blew up'))
+    ).toBe('genanki blew up');
+  });
+
+  it('keeps the truncation message when the class was flattened', () => {
+    expect(
+      jobFailureReasonFromError(
+        flatten('FileConversionError', CONVERSION_TRUNCATED_MESSAGE)
+      )
+    ).toBe(CONVERSION_TRUNCATED_MESSAGE);
+  });
+
+  it('does not leak an arbitrary FileConversionError message', () => {
+    const reason = jobFailureReasonFromError(
+      flatten(
+        'FileConversionError',
+        'Streaming is required for operations that may take longer than 10 minutes. See https://github.com/anthropics/anthropic-sdk-typescript#long-requests'
+      ),
+      'job-1'
+    );
+    expect(reason).not.toMatch(/anthropic-sdk-typescript/);
+    expect(reason).toMatch(/Something went wrong on our end/);
+  });
+
+  it('does not leak a raw library error message', () => {
+    const reason = jobFailureReasonFromError(
+      new Error('ECONNRESET at TLSSocket._onTimeout (node:net:1234)'),
+      'job-2'
+    );
+    expect(reason).not.toMatch(/TLSSocket/);
+    expect(reason).toMatch(/Job ID job-2/);
   });
 });

--- a/src/usecases/jobs/jobFailureReason.ts
+++ b/src/usecases/jobs/jobFailureReason.ts
@@ -62,6 +62,15 @@ function hasCode(error: unknown, code: string): boolean {
   );
 }
 
+// The upload worker serialises errors across a thread boundary as
+// { message, name }, and GeneratePackagesUseCase rebuilds a plain Error from
+// that. Every instanceof below therefore fails on the async upload path, so the
+// classes whose message is meant to reach the user are matched by the name that
+// survived instead.
+function hasName(error: unknown, name: string): boolean {
+  return error instanceof Error && error.name === name;
+}
+
 export type JobFailureReasonCode =
   | 'empty_deck'
   | 'markdown_likely_lossy'
@@ -147,17 +156,21 @@ export function jobFailureReasonFromError(
     }
     return EMPTY_DECK_FAILURE_REASON;
   }
-  if (error instanceof ClaudeLargeSectionError) {
-    return error.message;
+  if (
+    error instanceof ClaudeLargeSectionError ||
+    hasName(error, 'ClaudeLargeSectionError')
+  ) {
+    return (error as Error).message;
   }
   if (
-    error instanceof FileConversionError &&
-    error.message === CONVERSION_TRUNCATED_MESSAGE
+    (error instanceof FileConversionError ||
+      hasName(error, 'FileConversionError')) &&
+    (error as Error).message === CONVERSION_TRUNCATED_MESSAGE
   ) {
-    return error.message;
+    return (error as Error).message;
   }
-  if (error instanceof PythonExitError) {
-    return error.message;
+  if (error instanceof PythonExitError || hasName(error, 'PythonExitError')) {
+    return (error as Error).message;
   }
   if (isColumnsAmbiguousError(error)) {
     return buildColumnsAmbiguousReason(error.columns);

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-05-failed-conversion-messages.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-05-failed-conversion-messages.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-05-failed-conversion-messages",
+  "date": "2026-08-05",
+  "type": "fix",
+  "title": "Failed conversions explain what happened instead of showing internal error text"
+}


### PR DESCRIPTION
Closes #3995

## What

Failed conversions now show a message written for the user. Raw library text no longer reaches the downloads page.

## Why

`resolveAsyncFailureReason` returned `err.message` for anything that was not an `EmptyDeckError`, a parser crash, or empty:

```ts
if (err instanceof EmptyDeckError || isParserCrash || message.trim() === '') {
  return jobFailureReasonFromError(err, jobId);
}
return message;   // <- raw library text reached the user here
```

Raw passthrough was the **default**, and the curated allowlist in `jobFailureReasonFromError` only governed the collapse. A user was shown this on their downloads page:

```
Streaming is required for operations that may take longer than 10 minutes.
See https://github.com/anthropics/anthropic-sdk-typescript#long-requests for more details
```

An SDK error with a link to the SDK's own GitHub repo. Any library, driver, or filesystem message reached them the same way — this was not specific to that one error.

Now every async failure routes through the allowlist, and anything it does not recognise becomes the generic reason with the job ID.

## The part that made this more than a one-line change

Routing alone would have made things **worse**. The upload worker serialises errors across a thread boundary as `{ message, name }` (`worker.ts:258-264`) and `GeneratePackagesUseCase.buildWorkerError` rebuilds a plain `Error` from that. So every `instanceof` in the allowlist already failed on the async upload path.

Three classes exist precisely so their message reaches the user, and all three would have collapsed to generic text:

| Class | Message |
| --- | --- |
| `ClaudeLargeSectionError` | the large-section guidance |
| `PythonExitError` | the packaging failure detail |
| `FileConversionError` | only when it equals `CONVERSION_TRUNCATED_MESSAGE` |

They are now matched by the surviving `name` as well as by class. The narrow `FileConversionError` condition is preserved — a `FileConversionError` carrying anything *other* than the truncation message still collapses, which is what kept the SDK text out.

`code` does not survive the worker boundary either, so the `hasCode` branches remain dead on that path. Left alone deliberately: fixing it means changing the worker's serialisation shape, which is a wider change than this issue, and those errors already resolve to sensible generic text rather than leaking.

## Tests

Five new tests in `jobFailureReason.test.ts`, driving errors through the flattening the worker actually performs:

- the three passthrough classes still return their message when the class was flattened to a plain `Error`
- a `FileConversionError` carrying the SDK text does **not** leak it — asserts the output contains no `anthropic-sdk-typescript`
- a raw socket error does not leak — asserts no `TLSSocket`, and that the job ID is present

The first three failed before the fix, which is what proved the routing change needed the name matching.

## Verification

- Full server suite: **669 suites, 6272 tests pass**, only the known `src/lib/pdf/getPageCount.test.ts` environmental failure (needs a `pdfinfo` binary).
- `tsc -p . --noEmit` clean. `pnpm format:check` clean tree-wide.
- `oxlint` on the touched files: 17 warnings before the change, 17 after — none introduced.

## Expected impact

Funnel: none directly. This is a trust surface — a learner who sees an SDK GitHub link on a failed job concludes the product is broken. The signal to watch is support volume mentioning error text on the downloads page.

Browser check: not applicable — server-side failure-reason routing; the only `web/src` file in the diff is a changelog entry.
