### PR TITLE
fix: honour the requested deck name for CSV and text uploads

### DIFF
--- a/src/lib/parser/experimental/FallbackParser.test.ts
+++ b/src/lib/parser/experimental/FallbackParser.test.ts
@@ -253,3 +253,42 @@ describe('FallbackParser unstructured text (no tabs, no bullets)', () => {
     expect(decks).toHaveLength(0);
   });
 });
+
+describe('FallbackParser deck naming', () => {
+  const csv = 'front,back\nBonjour,Hello';
+
+  it('strips the extension from a CSV deck name, like its sibling branches', () => {
+    const parser = new FallbackParser([
+      { name: 'JLPT N5.csv', contents: Buffer.from(csv) },
+    ]);
+    const decks = parser.run({} as any);
+    expect(decks[0].name).toBe('JLPT N5');
+  });
+
+  it('uses an explicit deckName over the filename for CSV', () => {
+    const parser = new FallbackParser([
+      { name: 'JLPT N5.csv', contents: Buffer.from(csv) },
+    ]);
+    const decks = parser.run({ deckName: 'Japanese vocab' } as any);
+    expect(decks[0].name).toBe('Japanese vocab');
+  });
+
+  it('uses an explicit deckName over the filename for plain text', () => {
+    const parser = new FallbackParser([
+      {
+        name: 'notes.txt',
+        contents: Buffer.from('Bonjour\tHello\nMerci\tThanks'),
+      },
+    ]);
+    const decks = parser.run({ deckName: 'Japanese vocab' } as any);
+    expect(decks[0].name).toBe('Japanese vocab');
+  });
+
+  it('falls back to the filename when no deckName is given', () => {
+    const parser = new FallbackParser([
+      { name: 'vocab.csv', contents: Buffer.from(csv) },
+    ]);
+    const decks = parser.run({ deckName: '' } as any);
+    expect(decks[0].name).toBe('vocab');
+  });
+});

--- a/src/lib/parser/experimental/FallbackParser.ts
+++ b/src/lib/parser/experimental/FallbackParser.ts
@@ -252,7 +252,7 @@ class FallbackParser {
 
     return {
       cards,
-      deckName: fileName ?? 'Default',
+      deckName: fileName?.replace(/\.[^/.]+$/, '') ?? 'Default',
       clean: false,
     };
   }
@@ -283,9 +283,16 @@ class FallbackParser {
 
       const clean = result.clean !== false;
 
+      // An explicit deck name wins over the filename, matching DeckParser and
+      // making the `applied.deckName` the API reports back actually true.
+      const deckName =
+        settings.deckName != null && settings.deckName.trim() !== ''
+          ? settings.deckName
+          : result.deckName;
+
       decks.push(
         new Deck(
-          result.deckName,
+          deckName,
           clean ? Deck.CleanCards(result.cards) : result.cards,
           '',
           '',

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-05-csv-deck-name.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-05-csv-deck-name.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-05-csv-deck-name",
+  "date": "2026-08-05",
+  "type": "fix",
+  "title": "CSV decks use the name you asked for, without the .csv on the end"
+}


### PR DESCRIPTION
Closes #3978

## What

CSV and text uploads now use the deck name the caller asked for, and a CSV deck no longer carries `.csv` in its name.

## Why

Two defects, both in `FallbackParser`.

**1. The CSV branch was the only one keeping the extension.**

| Branch | Deck name |
| --- | --- |
| markdown | `fileName.replace(/\.[^/.]+$/, '')` |
| plain text | `fileName.replace(/\.[^/.]+$/, '')` |
| **CSV** | `fileName ?? 'Default'` — extension kept |

A CSV landed in Anki as `JLPT N5.csv`. Its two siblings strip the extension, so this reads as an oversight rather than a decision; the CSV branch now matches them.

**2. `options.deckName` never reached the deck.**

The filename always won, while `buildAppliedOptions` still reported the requested name back in `applied`:

```
convert_to_deck({ filename: "JLPT N5.csv", options: { deckName: "JLPT N5" } })
→ decks:   [{ name: "JLPT N5.csv" }]
  applied: { deckName: "JLPT N5" }
```

Reporting an option as applied when it was silently dropped is the worse half — a caller has no way to detect the substitution.

## The decision this required

The issue asked for one of two fixes, explicitly "not both": make `settings.deckName` win, or make `applied` stop claiming it.

**Took the first.** `DeckParser.ts:300` already resolves `this.settings.deckName ?? getTitleFromMarkdown(...) ?? name` for the main conversion path, so honouring an explicit deck name is established behaviour in this codebase — `FallbackParser` was the outlier. This aligns it rather than inventing a rule, and it makes `applied` true instead of making it quieter.

An empty or whitespace-only `deckName` still falls back to the filename, so callers sending an empty string keep the old result.

## Tests

Four new tests in `FallbackParser.test.ts`, all failing before the change:

- a CSV deck name has its extension stripped
- an explicit `deckName` wins over the filename for CSV
- an explicit `deckName` wins over the filename for plain text
- an empty `deckName` falls back to the filename

## Verification

- Full server suite: **669 suites, 6271 tests pass**, only the known `src/lib/pdf/getPageCount.test.ts` environmental failure (needs a `pdfinfo` binary). Ran in full rather than scoped, since `FallbackParser` is multi-consumer parser code.
- `tsc -p . --noEmit` clean. `pnpm format:check` clean tree-wide.

## Expected impact

Funnel: none directly measurable. This is deck-quality — a user who asks for a deck name and gets `name.csv` has to rename it in Anki, and an API caller cannot trust `applied`.

Browser check: not applicable — server-side parser change; the only `web/src` file in the diff is a changelog entry.
