### PR TITLE
test: fail when a table holds user rows account deletion would miss

### DIFF
--- a/src/data_layer/userDeletionSchemaParity.test.ts
+++ b/src/data_layer/userDeletionSchemaParity.test.ts
@@ -1,0 +1,121 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * #3974 found eleven tables holding user rows with no link to `users`. Those
+ * rows survived account deletion for as long as the tables existed, and nothing
+ * checked for it. This test is the check.
+ *
+ * A table with a user-identifying column is only safe if one of two things is
+ * true: the database cascades the delete for us, or `deleteUser` removes the
+ * rows by hand. Kanel types the column as `UsersId` exactly when a foreign key
+ * to `users` exists, so the generated types tell us which tables are covered by
+ * the database. Everything else has to be in the explicit list, or a user's rows
+ * outlive their account.
+ *
+ * Reads generated source as text rather than importing it, the same shape as
+ * `src/lib/sonarConfigParity.test.ts`, so no database connection is needed and
+ * the guard runs in CI.
+ *
+ * What this does NOT cover: the delete *rule*. Kanel types a column as
+ * `UsersId` for any foreign key to `users`, whether it cascades or is the
+ * default `NO ACTION`. #3974 hit both failure modes — a missing key leaks rows,
+ * and a `NO ACTION` key made every user who had answered a re-engagement email
+ * undeletable with a 23503. Only the first is checkable from the generated
+ * types; confirming `confdeltype` needs a live connection, so a `NO ACTION` key
+ * still has to be caught in migration review.
+ */
+
+const GENERATED_DIR = path.join(__dirname, 'public');
+const USERS_REPOSITORY = path.join(__dirname, 'UsersRepository.ts');
+
+// Columns that identify a user. A new name here is a new way to hold user data,
+// so extend this list when one appears rather than letting it go unchecked.
+const USER_COLUMNS = [
+  'owner',
+  'user_id',
+  'claimed_by_user_id',
+  'resolved_by',
+  'updated_by',
+];
+
+// Tables keyed on an email address rather than a user id. `deleteUser` clears
+// them through emailTables, and they carry no `users` foreign key by design.
+const EMAIL_KEYED_TABLES = new Set([
+  'feedback',
+  'emoji_feedback',
+  'abandoned_checkout_recovery_emails',
+]);
+
+function toSnakeCase(fileName: string): string {
+  return fileName
+    .replace(/\.ts$/, '')
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .toLowerCase();
+}
+
+interface UnlinkedColumn {
+  table: string;
+  column: string;
+  type: string;
+}
+
+function readUnlinkedUserColumns(): UnlinkedColumn[] {
+  const found: UnlinkedColumn[] = [];
+  const files = fs
+    .readdirSync(GENERATED_DIR)
+    .filter((f) => f.endsWith('.ts') && !f.endsWith('.d.ts'));
+
+  for (const file of files) {
+    const source = fs.readFileSync(path.join(GENERATED_DIR, file), 'utf8');
+    const body = /export default interface \w+ \{(.*?)\n\}/s.exec(source);
+    if (!body) continue;
+
+    for (const column of USER_COLUMNS) {
+      const declaration = new RegExp(`\\n  ${column}\\??: ([^;]+);`).exec(
+        body[1]
+      );
+      if (!declaration) continue;
+      const type = declaration[1].trim();
+      // `UsersId` is kanel's branded type for a real foreign key to users.
+      if (!type.includes('UsersId')) {
+        found.push({ table: toSnakeCase(file), column, type });
+      }
+    }
+  }
+  return found;
+}
+
+function readExplicitlyDeletedTables(): Set<string> {
+  const source = fs.readFileSync(USERS_REPOSITORY, 'utf8');
+  const block = /const ownerTables = \[(.*?)\];/s.exec(source);
+  if (!block) {
+    throw new Error(
+      'Could not find the ownerTables list in UsersRepository.deleteUser — if it was renamed, update this test to match.'
+    );
+  }
+  const names = [...block[1].matchAll(/'([a-z_]+)'/g)].map((m) => m[1]);
+  return new Set(names);
+}
+
+describe('account deletion covers every table holding user rows', () => {
+  it('deletes or cascades every user-identifying column', () => {
+    const unlinked = readUnlinkedUserColumns();
+    const deleted = readExplicitlyDeletedTables();
+
+    const uncovered = unlinked.filter(
+      (c) => !deleted.has(c.table) && !EMAIL_KEYED_TABLES.has(c.table)
+    );
+
+    expect(uncovered.map((c) => `${c.table}.${c.column} (${c.type})`)).toEqual(
+      []
+    );
+  });
+
+  it('finds the lists it depends on', () => {
+    // If a rename silently empties either side, both assertions above pass
+    // vacuously. This fails loudly instead.
+    expect(readExplicitlyDeletedTables().size).toBeGreaterThan(0);
+    expect(readUnlinkedUserColumns().length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Closes #3976

## What

A test that fails when a table holds user rows account deletion would miss.

## Why

#3974 fixed eleven tables holding user rows with no link to `users`. Those rows had survived account deletion for as long as the tables existed — a GDPR leak that went unnoticed because nothing checked for it. The twelfth table would leak the same way, silently, and surface only in another manual schema audit.

## How it works

A table with a user-identifying column is safe when one of two things is true: the database cascades the delete, or `deleteUser` removes the rows by hand.

Kanel types a column as `UsersId` **exactly when** a foreign key to `users` exists — a bare column stays `number` or `string`. So the generated types tell us which tables the database covers, and everything else must appear in the explicit `ownerTables` list in `UsersRepository.deleteUser`.

The test reads both sides as text — the same shape as `src/lib/sonarConfigParity.test.ts` — so it needs **no database connection** and runs in CI alongside every other suite.

```
Blocks.owner:      string      → no FK, must be hand-deleted
Mindmaps.user_id:  UsersId     → FK exists, database handles it
```

## Current state

Ten tables rely on hand deletion — `access_tokens`, `blocks`, `cancellation_feedback`, `dropbox_uploads`, `google_drive_uploads`, `jobs`, `notion_tokens`, `settings`, `templates`, `uploads` — and all ten are in `ownerTables`. The suite passes today; **no live leak was found.**

Three email-keyed tables (`feedback`, `emoji_feedback`, `abandoned_checkout_recovery_emails`) are excluded with a stated reason: they key on the raw address, not a user id, and `deleteUser` clears them through `emailTables`.

## Verified as a real guard, not a vacuous one

Planted a generated type with a bare `owner` column and confirmed the test fails with:

```
+   "fake_leak.owner (number)"
```

There is also a third assertion that fails loudly if either list is ever renamed to empty, so the primary check cannot start passing for the wrong reason.

## Scope — what this does NOT catch

Stated plainly because it is easy to assume otherwise: this catches a **missing** foreign key, not a **wrong delete rule**.

Kanel types a column as `UsersId` whether the key cascades or is the default `NO ACTION`. #3974 hit that second failure mode too — `re_engagement_feedback` had a `NO ACTION` key, which leaked nothing but made every user who had answered a re-engagement email **undeletable**, raising 23503 and rolling back the whole delete transaction.

Reading `confdeltype` requires a live connection, which would make this test unrunnable in CI and defeat the purpose. So a `NO ACTION` key still has to be caught in migration review. The limitation is documented in the test's header comment rather than left for the next reader to discover.

I checked the one table this ambiguity touches today: `favorites` has a `UsersId` column *and* sits in `ownerTables`. Its constraint is `confdeltype = 'c'` (CASCADE), so the hand-delete is redundant rather than load-bearing — harmless, and left alone since removing it is a behaviour change unrelated to this guard.

## Verification

- `pnpm test src/data_layer/` — 71 suites, 410 tests pass.
- `tsc -p . --noEmit` clean, `pnpm format:check` clean tree-wide.

## Expected impact

Internal — no user-facing change, no funnel metric. The effect is that the next table shipping with a bare `owner` column turns CI red instead of quietly outliving deleted accounts.

Browser check: not applicable — test-only change, no `web/src` files in the diff.
