### PR TITLE
feat: let anonymous visitors export a deck to CSV, capped at 21 notes

### DIFF
--- a/src/controllers/ApkgController.test.ts
+++ b/src/controllers/ApkgController.test.ts
@@ -24,6 +24,7 @@ jest.mock('../usecases/apkg/ExportApkgToCsvUseCase', () => {
     CardLimitExceededError: actual.CardLimitExceededError,
     EmptyDeckError: actual.EmptyDeckError,
     CSV_FREE_NOTE_LIMIT: actual.CSV_FREE_NOTE_LIMIT,
+    CSV_ANONYMOUS_NOTE_LIMIT: actual.CSV_ANONYMOUS_NOTE_LIMIT,
   };
 });
 jest.mock('../services/events/track', () => ({ track: jest.fn() }));
@@ -496,7 +497,7 @@ describe('ApkgController.exportCsv', () => {
 
     await controller.exportCsv(req, res);
 
-    expect(executeMock).toHaveBeenCalledWith(expect.any(Buffer), true);
+    expect(executeMock).toHaveBeenCalledWith(expect.any(Buffer), null);
     const setHeader = (res as unknown as { setHeader: jest.Mock }).setHeader;
     expect(setHeader).toHaveBeenCalledWith(
       'Content-Type',
@@ -523,7 +524,7 @@ describe('ApkgController.exportCsv', () => {
 
     await controller.exportCsv(req, res);
 
-    expect(executeMock).toHaveBeenCalledWith(expect.any(Buffer), false);
+    expect(executeMock).toHaveBeenCalledWith(expect.any(Buffer), 100);
   });
 
   it('returns 400 when the deck has no notes', async () => {
@@ -549,5 +550,49 @@ describe('ApkgController.exportCsv', () => {
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({ note_count: 250, note_limit: 100 })
     );
+  });
+
+  // makeRes defaults locals.owner to 'user-1', so an anonymous case only exists
+  // if owner is explicitly cleared. Without the override these read as
+  // signed-in and quietly assert the wrong tier.
+  it('caps an anonymous caller at the anonymous note limit', async () => {
+    const controller = makeController();
+    const req = makeReq() as Request;
+    const res = makeCsvRes({ owner: undefined });
+
+    await controller.exportCsv(req, res);
+
+    expect(executeMock).toHaveBeenCalledWith(expect.any(Buffer), 21);
+  });
+
+  it('tells an anonymous caller over the cap to make an account, not to pay', async () => {
+    executeMock.mockRejectedValueOnce(new CsvCardLimitExceededError(340, 21));
+    const controller = makeController();
+    const req = makeReq() as Request;
+    const res = makeCsvRes({ owner: undefined });
+
+    await controller.exportCsv(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(402);
+    const body = (res.json as jest.Mock).mock.calls[0][0];
+    expect(body).toMatchObject({
+      note_count: 340,
+      note_limit: 21,
+      requires_account: true,
+    });
+    expect(body.message).toContain('340');
+    expect(body.message).not.toMatch(/upgrade/i);
+  });
+
+  it('does not tell a signed-in caller over the cap that they need an account', async () => {
+    executeMock.mockRejectedValueOnce(new CsvCardLimitExceededError(250, 100));
+    const controller = makeController();
+    const req = makeReq() as Request;
+    const res = makeCsvRes({ patreon: false, subscriber: false });
+
+    await controller.exportCsv(req, res);
+
+    const body = (res.json as jest.Mock).mock.calls[0][0];
+    expect(body.requires_account).toBe(false);
   });
 });

--- a/src/controllers/ApkgController.ts
+++ b/src/controllers/ApkgController.ts
@@ -17,6 +17,8 @@ import ExportApkgToPdfUseCase, {
 } from '../usecases/apkg/ExportApkgToPdfUseCase';
 import ExportApkgToCsvUseCase, {
   CardLimitExceededError as CsvCardLimitExceededError,
+  CSV_ANONYMOUS_NOTE_LIMIT,
+  CSV_FREE_NOTE_LIMIT,
   EmptyDeckError as CsvEmptyDeckError,
 } from '../usecases/apkg/ExportApkgToCsvUseCase';
 import ImportApkgToNotionUseCase from '../usecases/apkg/ImportApkgToNotionUseCase';
@@ -317,12 +319,20 @@ class ApkgController {
     } finally {
       await tryUnlink(file.path);
     }
+    const owner = res.locals.owner;
+    const noteLimit = csvNoteLimitFor(owner, isPaying(res.locals));
     try {
       const useCase = new ExportApkgToCsvUseCase();
-      const result = await useCase.execute(fileBuffer, isPaying(res.locals));
+      const result = await useCase.execute(fileBuffer, noteLimit);
+      if (owner == null) {
+        track('apkg_csv_export_anonymous', {
+          userId: null,
+          props: { note_count: result.noteCount },
+        });
+      }
       sendCsvDownload(res, result.csv, file.originalname, result.noteCount);
     } catch (error) {
-      sendCsvExportError(res, error);
+      sendCsvExportError(res, error, noteLimit);
     }
   }
 
@@ -564,7 +574,19 @@ function isInvalidApkgError(error: unknown): boolean {
   );
 }
 
-function sendCsvExportError(res: Response, error: unknown): void {
+// Three tiers: no account, free account, paid. Null means unlimited.
+function csvNoteLimitFor(owner: unknown, paying: boolean): number | null {
+  if (paying) {
+    return null;
+  }
+  return owner == null ? CSV_ANONYMOUS_NOTE_LIMIT : CSV_FREE_NOTE_LIMIT;
+}
+
+function sendCsvExportError(
+  res: Response,
+  error: unknown,
+  noteLimit: number | null
+): void {
   if (error instanceof CsvEmptyDeckError) {
     res.status(400).json({
       message: 'No notes found in this .apkg file. Pick another deck.',
@@ -572,10 +594,17 @@ function sendCsvExportError(res: Response, error: unknown): void {
     return;
   }
   if (error instanceof CsvCardLimitExceededError) {
+    // The next step differs by tier: someone without an account should be told
+    // to sign in for a bigger allowance, not to pay. The client renders this as
+    // a neutral gate rather than an error, using the two numbers below.
     res.status(402).json({
-      message: `${error.noteCount} notes — over the free limit of ${error.noteLimit}. Upgrade for no monthly cap.`,
+      message:
+        noteLimit === CSV_ANONYMOUS_NOTE_LIMIT
+          ? `This deck has ${error.noteCount} notes. Without an account you can export ${error.noteLimit}.`
+          : `This deck has ${error.noteCount} notes. Your plan exports ${error.noteLimit} per file.`,
       note_count: error.noteCount,
       note_limit: error.noteLimit,
+      requires_account: noteLimit === CSV_ANONYMOUS_NOTE_LIMIT,
     });
     return;
   }

--- a/src/controllers/ApkgController.ts
+++ b/src/controllers/ApkgController.ts
@@ -316,6 +316,14 @@ class ApkgController {
     let fileBuffer: Buffer;
     try {
       fileBuffer = await fs.readFile(file.path);
+    } catch {
+      // Without this the rejection escapes the handler entirely — express does
+      // not await it — and the unhandled-rejection guard in server.ts exits the
+      // process. One anonymous request hitting a reaped temp file would take
+      // the whole site down.
+      await tryUnlink(file.path);
+      res.status(400).json({ message: "Couldn't read the uploaded file." });
+      return;
     } finally {
       await tryUnlink(file.path);
     }
@@ -324,7 +332,10 @@ class ApkgController {
     try {
       const useCase = new ExportApkgToCsvUseCase();
       const result = await useCase.execute(fileBuffer, noteLimit);
-      if (owner == null) {
+      // A paid day-pass sets `subscriber` without an `owner`, so an owner check
+      // alone would file paying customers under anonymous and skew the funnel
+      // number this event exists to produce.
+      if (owner == null && !isPaying(res.locals)) {
         track('apkg_csv_export_anonymous', {
           userId: null,
           props: { note_count: result.noteCount },

--- a/src/routes/ApkgRouter.ts
+++ b/src/routes/ApkgRouter.ts
@@ -257,10 +257,13 @@ const ApkgRouter = () => {
     limits: { fileSize: 100 * 1024 * 1024 },
   });
 
+  // No RequireAuthentication: anonymous visitors get a capped export. This is
+  // the landing page for "export anki deck to csv" search traffic, and a 401
+  // after the file picker spent their intent for nothing. RequireAllowedOrigin
+  // already populates res.locals, so the controller can still read the tier.
   router.post(
     '/api/apkg/csv',
     RequireAllowedOrigin,
-    RequireAuthentication,
     csvUpload.single('file'),
     (req, res) => controller.exportCsv(req, res)
   );

--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -65,6 +65,7 @@ export const KNOWN_EVENTS = new Set([
   'onboarding_skipped',
   'onboarding_completed',
   'apkg_csv_exported',
+  'apkg_csv_export_anonymous',
   'make_another_deck_clicked',
   'recent_page_reconvert_clicked',
   'native_app_page_viewed',

--- a/src/usecases/apkg/ExportApkgToCsvUseCase.test.ts
+++ b/src/usecases/apkg/ExportApkgToCsvUseCase.test.ts
@@ -2,6 +2,7 @@ import ExportApkgToCsvUseCase, {
   EmptyDeckError,
   CardLimitExceededError,
   CSV_FREE_NOTE_LIMIT,
+  CSV_ANONYMOUS_NOTE_LIMIT,
 } from './ExportApkgToCsvUseCase';
 import * as parseApkgNotesModule from '../../services/ApkgPreviewService/parseApkgNotes';
 import { ParsedNote } from '../../lib/ankify/transforms/types';
@@ -32,7 +33,7 @@ describe('ExportApkgToCsvUseCase', () => {
       sourceMedia: [],
     });
     const useCase = new ExportApkgToCsvUseCase();
-    const result = await useCase.execute(Buffer.from('fake-apkg'), true);
+    const result = await useCase.execute(Buffer.from('fake-apkg'), null);
     expect(result.deckName).toBe('Spanish 101');
     expect(result.noteCount).toBe(2);
     const csv = result.csv.toString('utf8').replace(/^﻿/, '');
@@ -50,7 +51,7 @@ describe('ExportApkgToCsvUseCase', () => {
     });
     const useCase = new ExportApkgToCsvUseCase();
     await expect(
-      useCase.execute(Buffer.from('fake-apkg'), false)
+      useCase.execute(Buffer.from('fake-apkg'), CSV_FREE_NOTE_LIMIT)
     ).rejects.toBeInstanceOf(EmptyDeckError);
   });
 
@@ -66,11 +67,11 @@ describe('ExportApkgToCsvUseCase', () => {
     });
     const useCase = new ExportApkgToCsvUseCase();
     await expect(
-      useCase.execute(Buffer.from('fake-apkg'), false)
+      useCase.execute(Buffer.from('fake-apkg'), CSV_FREE_NOTE_LIMIT)
     ).rejects.toBeInstanceOf(CardLimitExceededError);
   });
 
-  it('does not apply the cap when the user is on the paid plan', async () => {
+  it('does not apply the cap when the caller is unlimited', async () => {
     const many = Array.from({ length: CSV_FREE_NOTE_LIMIT + 100 }, (_, i) =>
       note([`Q${i}`, `A${i}`])
     );
@@ -81,7 +82,7 @@ describe('ExportApkgToCsvUseCase', () => {
       sourceMedia: [],
     });
     const useCase = new ExportApkgToCsvUseCase();
-    const result = await useCase.execute(Buffer.from('fake-apkg'), true);
+    const result = await useCase.execute(Buffer.from('fake-apkg'), null);
     expect(result.noteCount).toBe(CSV_FREE_NOTE_LIMIT + 100);
   });
 
@@ -93,10 +94,66 @@ describe('ExportApkgToCsvUseCase', () => {
       sourceMedia: [],
     });
     const useCase = new ExportApkgToCsvUseCase();
-    const result = await useCase.execute(Buffer.from('fake-apkg'), true);
+    const result = await useCase.execute(Buffer.from('fake-apkg'), null);
     expect(result.csv[0]).toBe(0xef);
     expect(result.csv[1]).toBe(0xbb);
     expect(result.csv[2]).toBe(0xbf);
     expect(result.csv.toString('utf8')).toContain('¿Cómo estás?');
+  });
+});
+
+describe('ExportApkgToCsvUseCase note limit tiers', () => {
+  const parseSpyFor = (count: number) =>
+    jest.spyOn(parseApkgNotesModule, 'parseApkgNotes').mockResolvedValue({
+      notes: Array.from({ length: count }, (_, i) => note([`Q${i}`, `A${i}`])),
+      unknownModelNames: [],
+      deckName: 'Deck',
+      sourceMedia: [],
+    });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    ['anonymous', CSV_ANONYMOUS_NOTE_LIMIT],
+    ['free account', CSV_FREE_NOTE_LIMIT],
+  ])('exports exactly the cap for %s', async (_tier, cap) => {
+    parseSpyFor(cap);
+    const result = await new ExportApkgToCsvUseCase().execute(
+      Buffer.from('fake-apkg'),
+      cap
+    );
+    expect(result.noteCount).toBe(cap);
+  });
+
+  it.each([
+    ['anonymous', CSV_ANONYMOUS_NOTE_LIMIT],
+    ['free account', CSV_FREE_NOTE_LIMIT],
+  ])('rejects one note over the cap for %s', async (_tier, cap) => {
+    parseSpyFor(cap + 1);
+    await expect(
+      new ExportApkgToCsvUseCase().execute(Buffer.from('fake-apkg'), cap)
+    ).rejects.toMatchObject({
+      name: 'CardLimitExceededError',
+      noteCount: cap + 1,
+      noteLimit: cap,
+    });
+  });
+
+  it('treats a cap of 0 as a cap, not as unlimited', async () => {
+    parseSpyFor(1);
+    await expect(
+      new ExportApkgToCsvUseCase().execute(Buffer.from('fake-apkg'), 0)
+    ).rejects.toBeInstanceOf(CardLimitExceededError);
+  });
+
+  it('exports a deck far over the free cap when the caller is unlimited', async () => {
+    parseSpyFor(CSV_FREE_NOTE_LIMIT * 5);
+    const result = await new ExportApkgToCsvUseCase().execute(
+      Buffer.from('fake-apkg'),
+      null
+    );
+    expect(result.noteCount).toBe(CSV_FREE_NOTE_LIMIT * 5);
   });
 });

--- a/src/usecases/apkg/ExportApkgToCsvUseCase.ts
+++ b/src/usecases/apkg/ExportApkgToCsvUseCase.ts
@@ -3,6 +3,12 @@ import { buildCsvFromApkgNotes } from '../../lib/csv/buildCsvFromApkgNotes';
 
 export const CSV_FREE_NOTE_LIMIT = 100;
 
+// Anonymous visitors get a smaller allowance than a free account, so signing in
+// still buys something on this page. Deliberately a separate constant from the
+// main converter's ANONYMOUS_CARD_CAP even though both are 21 — they are equal
+// by coincidence, not by rule, and coupling them would make one move the other.
+export const CSV_ANONYMOUS_NOTE_LIMIT = 21;
+
 const UTF8_BOM = Buffer.from([0xef, 0xbb, 0xbf]);
 
 export class EmptyDeckError extends Error {
@@ -17,9 +23,10 @@ export class CardLimitExceededError extends Error {
     public readonly noteCount: number,
     public readonly noteLimit: number
   ) {
-    super(
-      `${noteCount} notes — over the free limit of ${noteLimit}. Upgrade for no monthly cap.`
-    );
+    // The user-facing wording lives in the client, which knows whether to offer
+    // signing in or upgrading. This message is for logs; the numbers travel on
+    // the error so the client can name the real count and the applicable cap.
+    super(`${noteCount} notes exceeds the ${noteLimit} note limit.`);
     this.name = 'CardLimitExceededError';
   }
 }
@@ -31,19 +38,22 @@ export interface ExportApkgToCsvResult {
 }
 
 export default class ExportApkgToCsvUseCase {
+  /**
+   * @param noteLimit the caller's applicable cap, or null for unlimited. A
+   * number rather than a boolean because there are three tiers now: anonymous,
+   * free account, and paid.
+   */
   async execute(
     fileBuffer: Buffer,
-    unlimitedAccess: boolean
+    noteLimit: number | null
   ): Promise<ExportApkgToCsvResult> {
     const parsed = await parseApkgNotes(fileBuffer);
     if (parsed.notes.length === 0) {
       throw new EmptyDeckError();
     }
-    if (!unlimitedAccess && parsed.notes.length > CSV_FREE_NOTE_LIMIT) {
-      throw new CardLimitExceededError(
-        parsed.notes.length,
-        CSV_FREE_NOTE_LIMIT
-      );
+    // `!= null` rather than a truthy check, so a cap of 0 stays a cap.
+    if (noteLimit != null && parsed.notes.length > noteLimit) {
+      throw new CardLimitExceededError(parsed.notes.length, noteLimit);
     }
     const csvText = buildCsvFromApkgNotes(parsed.notes);
     const csv = Buffer.concat([UTF8_BOM, Buffer.from(csvText, 'utf8')]);

--- a/web/src/lib/analytics/events.ts
+++ b/web/src/lib/analytics/events.ts
@@ -49,6 +49,7 @@ export const KNOWN_EVENTS = new Set([
   'onboarding_skipped',
   'onboarding_completed',
   'apkg_csv_exported',
+  'apkg_csv_export_anonymous',
   'make_another_deck_clicked',
   'recent_page_reconvert_clicked',
   'native_app_page_viewed',

--- a/web/src/pages/ConvertLandingPage/ApkgCsvExportForm.module.css
+++ b/web/src/pages/ConvertLandingPage/ApkgCsvExportForm.module.css
@@ -121,3 +121,58 @@
   cursor: pointer;
   text-decoration: underline;
 }
+
+/* The note cap is a gate, not a failure — neutral surface, no danger colour.
+   Red stays for genuine errors so it keeps meaning something. */
+.capNotice {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.875rem 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-secondary);
+}
+
+.capHeadline {
+  margin: 0;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+}
+
+.capSubline {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.capActions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.capPrimary {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-md);
+  background: var(--color-primary);
+  color: #fff;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  text-decoration: none;
+}
+
+.capSecondary {
+  font-size: var(--text-sm);
+  color: var(--color-text-link);
+  text-decoration: none;
+}
+
+.capSecondary:hover {
+  text-decoration: underline;
+}

--- a/web/src/pages/ConvertLandingPage/ApkgCsvExportForm.test.tsx
+++ b/web/src/pages/ConvertLandingPage/ApkgCsvExportForm.test.tsx
@@ -121,9 +121,21 @@ describe('ApkgCsvExportForm', () => {
     });
   });
 
-  it('falls back to a sign-in prompt when the server returns 401 with no body', async () => {
+  // Replaces a test that asserted a 401 sign-in prompt. Anonymous visitors are
+  // no longer blocked at the route, so a 401 is not the shape this form sees;
+  // the real contract is the 402 note-cap gate below.
+  it('shows the note cap as a neutral gate, not an error alert', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(null, { status: 401 })
+      new Response(
+        JSON.stringify({
+          message:
+            'This deck has 340 notes. Without an account you can export 21.',
+          note_count: 340,
+          note_limit: 21,
+          requires_account: true,
+        }),
+        { status: 402, headers: { 'Content-Type': 'application/json' } }
+      )
     );
     render(<ApkgCsvExportForm />);
     const input = screen.getByLabelText(
@@ -131,8 +143,45 @@ describe('ApkgCsvExportForm', () => {
     ) as HTMLInputElement;
     fireEvent.change(input, { target: { files: [makeApkgFile()] } });
     fireEvent.submit(input.closest('form')!);
+
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent(/Sign in/i);
+      expect(screen.getByRole('status')).toHaveTextContent(/340 notes/);
     });
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(
+      screen.getByRole('link', { name: /Sign in to export/i })
+    ).toHaveAttribute('href', '/login?redirect=/convert/apkg-to-csv');
+  });
+
+  it('offers only the upgrade path when a signed-in caller hits their cap', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          message: 'This deck has 250 notes. Your plan exports 100 per file.',
+          note_count: 250,
+          note_limit: 100,
+          requires_account: false,
+        }),
+        { status: 402, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    render(<ApkgCsvExportForm />);
+    const input = screen.getByLabelText(
+      /Choose \.apkg file/i
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [makeApkgFile()] } });
+    fireEvent.submit(input.closest('form')!);
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent(/250 notes/);
+    });
+    expect(
+      screen.queryByRole('link', { name: /Sign in to export/i })
+    ).toBeNull();
+  });
+
+  it('tells anonymous visitors what they can export before they pick a file', () => {
+    render(<ApkgCsvExportForm />);
+    expect(screen.getByText(/Export up to 21 notes now/i)).toBeTruthy();
   });
 });

--- a/web/src/pages/ConvertLandingPage/ApkgCsvExportForm.tsx
+++ b/web/src/pages/ConvertLandingPage/ApkgCsvExportForm.tsx
@@ -12,12 +12,43 @@ type FormState =
       csvName: string;
       csvUrl: string;
     }
+  // `capped` is deliberately separate from `error`. Hitting the note limit is a
+  // gate, not a failure — it gets a neutral treatment and an obvious next step,
+  // while red stays reserved for things that actually went wrong.
+  | {
+      kind: 'capped';
+      noteCount: number;
+      noteLimit: number;
+      needsAccount: boolean;
+    }
   | { kind: 'error'; message: string };
 
 interface ServerError {
   message?: string;
   note_count?: number;
   note_limit?: number;
+  requires_account?: boolean;
+}
+
+async function readCapExceeded(response: Response): Promise<{
+  kind: 'capped';
+  noteCount: number;
+  noteLimit: number;
+  needsAccount: boolean;
+} | null> {
+  if (response.status !== 402) return null;
+  try {
+    const body = (await response.clone().json()) as ServerError;
+    if (body.note_count == null || body.note_limit == null) return null;
+    return {
+      kind: 'capped',
+      noteCount: body.note_count,
+      noteLimit: body.note_limit,
+      needsAccount: body.requires_account === true,
+    };
+  } catch {
+    return null;
+  }
 }
 
 async function readErrorMessage(response: Response): Promise<string> {
@@ -29,7 +60,6 @@ async function readErrorMessage(response: Response): Promise<string> {
   } catch {
     // not JSON
   }
-  if (response.status === 401) return 'Sign in to export your deck as a CSV.';
   if (response.status === 413)
     return 'This file is over the 100 MB upload limit.';
   return "Couldn't read this .apkg file. Pick another deck and try again.";
@@ -92,6 +122,11 @@ function ApkgCsvExportForm() {
         body: formData,
       });
       if (!response.ok) {
+        const capped = await readCapExceeded(response);
+        if (capped) {
+          setState(capped);
+          return;
+        }
         const message = await readErrorMessage(response);
         setState({ kind: 'error', message });
         return;
@@ -156,9 +191,37 @@ function ApkgCsvExportForm() {
         </div>
       )}
       <p className={styles.helper}>
-        Sign in to export. Free accounts get 100 notes per file — upgrade for
-        unlimited.
+        Export up to 21 notes now, no account needed. A free account raises that
+        to 100 per file — unlimited with a paid plan.
       </p>
+      {state.kind === 'capped' && (
+        <div className={styles.capNotice} role="status" aria-live="polite">
+          <p className={styles.capHeadline}>
+            This deck has {state.noteCount} notes.{' '}
+            {state.needsAccount
+              ? `Without an account you can export ${state.noteLimit}.`
+              : `Your plan exports ${state.noteLimit} per file.`}
+          </p>
+          {state.needsAccount && (
+            <p className={styles.capSubline}>
+              Sign in free to export up to 100 per file.
+            </p>
+          )}
+          <div className={styles.capActions}>
+            {state.needsAccount && (
+              <a
+                className={styles.capPrimary}
+                href="/login?redirect=/convert/apkg-to-csv"
+              >
+                Sign in to export
+              </a>
+            )}
+            <a className={styles.capSecondary} href="/pricing">
+              Upgrade for unlimited
+            </a>
+          </div>
+        </div>
+      )}
       {state.kind === 'error' && (
         <p className={styles.error} role="alert">
           {state.message}

--- a/web/src/pages/LandingPage/LandingPage.module.css
+++ b/web/src/pages/LandingPage/LandingPage.module.css
@@ -247,3 +247,15 @@ details[open] > .faqSummary::before {
     padding: 2rem 1rem;
   }
 }
+
+/* When the hero carries a live tool rather than a marketing CTA, the tool is
+   the conversion moment and should not need a scroll. Tighten the padding so
+   the title, one-line subhead, and the picker row share the first viewport. */
+.heroWithTool {
+  padding-top: 2.5rem;
+  padding-bottom: 2rem;
+}
+
+.heroWithTool .heroSubhead {
+  margin-bottom: 1.25rem;
+}

--- a/web/src/pages/LandingPage/LandingPage.tsx
+++ b/web/src/pages/LandingPage/LandingPage.tsx
@@ -138,7 +138,14 @@ function LandingPage({
         <script type="application/ld+json">{faqJsonLd}</script>
       </Helmet>
 
-      <section id="upload" className={styles.hero}>
+      <section
+        id="upload"
+        className={
+          heroSlot == null
+            ? styles.hero
+            : `${styles.hero} ${styles.heroWithTool}`
+        }
+      >
         <div className={styles.heroInner}>
           <h1 className={styles.heroTitle}>
             {t(`pages.${pageKey}.h1`, { defaultValue: copy.h1 })}

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-05-anonymous-csv-export.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-05-anonymous-csv-export.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-05-anonymous-csv-export",
+  "date": "2026-08-05",
+  "type": "feature",
+  "title": "Export an Anki deck to CSV without an account — up to 21 notes"
+}


### PR DESCRIPTION
## What

Anonymous visitors can now export an Anki deck to CSV, capped at 21 notes. The ladder is **21 anonymous → 100 free account → unlimited paid**.

## Why

`/convert/apkg-to-csv` gained **+278 clicks month-over-month in July** — more than any other page on the site (site total: 2.55K clicks, 33.1K impressions). An anonymous visitor arriving from that search could not use it. `RequireAuthentication` sat on `POST /api/apkg/csv`, so they picked a file, clicked Export, and got a red **"Authentication required"**.

The wall fired *after* the effort. That spends the intent that brought them and returns nothing.

**It was an outlier, not a policy.** The primary converter has no auth middleware at all:

| Route | Auth | Anonymous |
| --- | --- | --- |
| `POST /api/upload/file` (main converter) | `acceptKeyOr(RequireAllowedOrigin)` | allowed, capped |
| `POST /api/image-occlusion` | none | allowed |
| `POST /api/apkg/csv` (this page) | `RequireAuthentication` | **hard 401** |

Anonymous-with-a-cap is the established pattern. This route reads like it was written with auth by default.

## Why 21 and not 100

This is the load-bearing choice. At 100, anonymous would equal the signed-in free tier and creating an account would buy nothing on this page — the signup rung collapses and only *paying* helps. At 21 a chapter-sized deck exports friction-free, while any real study deck still meets the account wall, now placed *after* the tool has demonstrated it works.

Over the cap the export is **blocked, not truncated**. A CSV missing most of a deck is a broken artifact someone may import believing it is complete.

## Mechanics

- `execute()` takes `noteLimit: number | null` instead of `unlimitedAccess: boolean` — a boolean cannot express three tiers, and `CardLimitExceededError` already carried a slot for the applicable limit. Mirrors the mindmap tiering pattern.
- The cap check uses an explicit `!= null` rather than a truthy test, so a cap of `0` stays a cap rather than reading as unlimited.
- **No new middleware.** `RequireAllowedOrigin` already calls `configureUserLocal` (`RequireAllowedOrigin.ts:36`), so `res.locals` is populated for anonymous callers and `isPaying({})` correctly returns `false`. Verified directly rather than assumed.
- Over-cap copy is **tier-aware**: telling someone without an account to "upgrade" was wrong. They're told to sign in for 100, with upgrade as a secondary link. That wording now lives in the controller, which knows the tier — removing the duplicate message that previously existed in both the use case and the response builder.

## Abuse surface

Unchanged in kind. `parseApkgNotes` runs before the cap check, so a 100MB anonymous parse is possible — but that exact capability already ships on `POST /api/upload/file`, which is anonymous-allowed today with the same multer `fileSize: 100MB` limit. This adds no new capability, so no new rate limiter. If anonymous-parse DoS becomes real it belongs in front of *all* anonymous parse routes, not bolted onto this one.

## Design

- The ladder is stated **above the button** ("Export up to 21 notes now, no account needed…") so expectations are set before the click rather than as a red error after it.
- The cap renders as a **neutral gate** with `role="status"` / `aria-live="polite"`, not the red `role="alert"` error slot. Red stays reserved for genuine failures, and the gate reaches screen readers rather than being signalled by colour alone (WCAG).
- Actions are ranked: `Sign in to export` (primary, redirects back to this page) and `Upgrade for unlimited` (tertiary link). A signed-in caller over their cap sees only the upgrade path.
- Landing heroes carrying a live tool lose some padding so the picker shares the first viewport — the tool is the conversion moment on those pages, not the headline.

## Tests

Server (Jest): use-case tier coverage via `it.each` for 21/100 at and over the cap, a cap of `0`, and unlimited; controller coverage for anonymous vs free vs paid and both over-cap message shapes.

Web (Vitest): the 402 gate renders as `status` not `alert`, the sign-in link carries the redirect, a signed-in caller sees no sign-in link, and the ladder copy is present before any file is picked.

**Replaced rather than deleted:** a test asserting a 401 sign-in prompt. Anonymous callers are no longer blocked at the route, so a 401 is not a shape this form sees; the real contract (the 402 cap gate) is covered instead.

## Verification

- Full server suite: **669 suites, 6286 tests pass** — only the known `getPageCount` environmental failure (needs `pdfinfo`).
- Full web suite: **358 files, 2804 tests pass.**
- `tsc -p . --noEmit`, `oxlint`, and tree-wide `pnpm format:check` all clean.

The typed `KNOWN_EVENTS` allowlist caught the analytics gap at first typecheck — `track('apkg_csv_export_anonymous')` would not compile until the string existed server-side. Added to both allowlists.

## Expected impact

Anonymous export success rate goes from ~0 (every attempt blocked) to most attempts. The metric to watch is **signups attributed to `/convert/apkg-to-csv`**, read at `/api/ops/metrics`, day-7 check, guardrail "must not fall". If anonymous export cannibalises signups it shows there, and the revert is a single middleware line.

## Not in this PR

- `/print` and `/photo-to-deck` have the identical "reject after file selection" ordering. Their gates **stay** — both have real per-use economics (print quota, Claude vision) — but the pre-picker copy rule should be applied to them in a follow-up.
- The form still hardcodes English, as it did before this change. A 10-locale migration is its own PR.
- The shared ToolCard extraction the designer proposed is a fast-follow, not a blocker for the acquisition fix.

## Browser check

- [x] Golden path on localhost:3000
- [x] No console errors at 375px

Notes: backed by a real run of `pnpm --filter 2anki-web test:golden-path` — 2 tests passed at a 375px viewport with no console errors. Playwright's browsers needed reinstalling first: today's 1.60 to 1.62 bump (#3981) invalidated the cached Chromium, so anyone else running this spec locally will hit the same prompt and needs `pnpm exec playwright install chromium`.
