### PR TITLE
fix: describe the real flow on pages that export out of Anki

### DIFF
--- a/web/src/pages/ConvertLandingPage/convertLandingConfig.ts
+++ b/web/src/pages/ConvertLandingPage/convertLandingConfig.ts
@@ -219,6 +219,25 @@ const apkgToCsv: LandingCopy = {
   h1: 'Anki deck to CSV — export cards to a spreadsheet',
   subhead:
     'Drop an .apkg file and download a CSV. Every card front, back, and tag in one spreadsheet you can edit.',
+  // This page runs the opposite direction to the rest of the site: a deck goes
+  // in and a spreadsheet comes out. The shared steps and format list describe
+  // building a deck, so without these overrides the page tells visitors to drop
+  // a Notion export and open an .apkg it never makes.
+  steps: [
+    {
+      title: 'Choose your .apkg',
+      body: 'Any Anki deck file — your own, or one you downloaded.',
+    },
+    {
+      title: '2anki reads every card',
+      body: 'Fronts, backs, and tags, including cloze markup.',
+    },
+    {
+      title: 'Open the CSV',
+      body: 'Excel, Google Sheets, or any spreadsheet app.',
+    },
+  ],
+  formats: ['.apkg in', 'CSV out'],
   faqs: [
     {
       q: 'Why would I export to CSV?',

--- a/web/src/pages/LandingPage/LandingPage.tsx
+++ b/web/src/pages/LandingPage/LandingPage.tsx
@@ -188,21 +188,29 @@ function LandingPage({
             {t('sections.howItWorks', { defaultValue: 'How it works' })}
           </p>
           <div className={styles.stepsGrid}>
-            {STEP_KEYS.map((key, idx) => (
-              <div key={key} className={styles.step}>
-                <span className={styles.stepNumber}>{idx + 1}</span>
-                <p className={styles.stepTitle}>
-                  {t(`steps.${key}.title`, {
-                    defaultValue: STEP_FALLBACK[key].title,
-                  })}
-                </p>
-                <p className={styles.stepBody}>
-                  {t(`steps.${key}.body`, {
-                    defaultValue: STEP_FALLBACK[key].body,
-                  })}
-                </p>
-              </div>
-            ))}
+            {copy.steps != null
+              ? copy.steps.map((step, idx) => (
+                  <div key={step.title} className={styles.step}>
+                    <span className={styles.stepNumber}>{idx + 1}</span>
+                    <p className={styles.stepTitle}>{step.title}</p>
+                    <p className={styles.stepBody}>{step.body}</p>
+                  </div>
+                ))
+              : STEP_KEYS.map((key, idx) => (
+                  <div key={key} className={styles.step}>
+                    <span className={styles.stepNumber}>{idx + 1}</span>
+                    <p className={styles.stepTitle}>
+                      {t(`steps.${key}.title`, {
+                        defaultValue: STEP_FALLBACK[key].title,
+                      })}
+                    </p>
+                    <p className={styles.stepBody}>
+                      {t(`steps.${key}.body`, {
+                        defaultValue: STEP_FALLBACK[key].body,
+                      })}
+                    </p>
+                  </div>
+                ))}
           </div>
         </div>
       </section>
@@ -214,7 +222,7 @@ function LandingPage({
           })}
         </p>
         <ul className={styles.formatsList}>
-          {FORMATS.map((format) => (
+          {(copy.formats ?? FORMATS).map((format) => (
             <li key={format} className={styles.formatTag}>
               {format}
             </li>

--- a/web/src/pages/LandingPage/copy/ankiToNotion.ts
+++ b/web/src/pages/LandingPage/copy/ankiToNotion.ts
@@ -19,6 +19,23 @@ const ankiToNotionCopy: LandingCopy = {
     'Upload an .apkg file. Get every card as a toggle in a Notion page you can study, search, and edit.',
   ctaLabel: 'Start free import',
   ctaHref: '/register?source=/anki-to-notion',
+  // Deck in, Notion page out — the opposite of the shared steps, which end with
+  // "open the .apkg in Anki". This page never produces one.
+  steps: [
+    {
+      title: 'Upload your .apkg',
+      body: 'Any Anki deck file, yours or a shared one.',
+    },
+    {
+      title: 'Pick a Notion page',
+      body: 'Connect Notion and choose where the cards land.',
+    },
+    {
+      title: 'Study it in Notion',
+      body: 'Every card becomes a toggle you can search and edit.',
+    },
+  ],
+  formats: ['.apkg in', 'Notion toggles out'],
   whatComesAcross: [
     {
       title: 'Card fronts and backs',

--- a/web/src/pages/LandingPage/types.ts
+++ b/web/src/pages/LandingPage/types.ts
@@ -13,6 +13,11 @@ export interface RelatedLink {
   href: string;
 }
 
+export interface LandingStep {
+  title: string;
+  body: string;
+}
+
 export interface LandingCopy {
   pathname: string;
   title: string;
@@ -25,4 +30,9 @@ export interface LandingCopy {
   whatComesAcross?: WhatComesAcrossItem[];
   relatedLinks?: ReadonlyArray<RelatedLink>;
   galleryBadge?: boolean;
+  // The default steps and format list describe building a deck from a document.
+  // A page that runs the other direction — a deck in, something else out — has
+  // to say so, or it tells the visitor to open an .apkg that it never produces.
+  steps?: ReadonlyArray<LandingStep>;
+  formats?: ReadonlyArray<string>;
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-05-export-page-steps.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-05-export-page-steps.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-05-export-page-steps",
+  "date": "2026-08-05",
+  "type": "fix",
+  "title": "The CSV and Notion export pages describe what they actually do"
+}


### PR DESCRIPTION
## What

Two landing pages that export *out* of Anki now describe their own flow instead of inheriting the deck-building steps.

## Why

`STEP_KEYS`, `STEP_FALLBACK`, and `FORMATS` were module-level constants in `LandingPage.tsx`, rendered identically on **every** landing page. They describe one direction: drop a document → 2anki builds a deck → open the `.apkg` in Anki.

Two pages run the opposite direction and inherited that copy verbatim, so each instructed visitors to do something the page cannot do.

**`/convert/apkg-to-csv`** takes a deck and returns a spreadsheet. It was telling visitors to:

| Step | What it said | Reality on this page |
| --- | --- | --- |
| 1 | "Drop your file — Notion export, PDF, Word, Markdown, or a Quizlet export." | accepts exactly one format: `.apkg` |
| 2 | "2anki builds your deck" | it reads a deck, it doesn't build one |
| 3 | "Open it in Anki. Double-click the .apkg file." | **never produces an .apkg** — the output is a CSV |

"Supported formats" listed `Notion, PDF, Markdown, HTML, CSV, Word, Quizlet` — the deck builder's seven inputs, none of which this page takes.

This is the fastest-growing entry point on the site (+278 clicks month-over-month in July), so the wrong instructions were reaching more new visitors than any other page's.

**`/anki-to-notion`** has the same shape — deck in, Notion page out — and carried the same build-a-deck steps.

## How

`LandingCopy` gains optional `steps` and `formats`. A page that sets neither keeps today's shared defaults, so the other 16 landing pages are untouched.

| Page | New steps | New formats |
| --- | --- | --- |
| `/convert/apkg-to-csv` | Choose your .apkg → 2anki reads every card → Open the CSV | `.apkg in` / `CSV out` |
| `/anki-to-notion` | Upload your .apkg → Pick a Notion page → Study it in Notion | `.apkg in` / `Notion toggles out` |

## Verification

- Full web suite: **358 files, 2804 tests pass.**
- `tsc --noEmit` clean; tree-wide `pnpm format:check` clean.

## Note on how this was found

I flagged this myself earlier while reviewing the same page ("the How it works panel describes Notion/PDF/Word inputs on a page whose job is `.apkg → CSV`"), then scoped it out when the work narrowed to the anonymous-export gate, and did not carry it forward. It took a third report to fix. Recording it here because the failure was dropping a known finding, not missing one.

## Browser check

- [x] Golden path on localhost:3000
- [x] No console errors at 375px

Notes: `pnpm --filter 2anki-web test:golden-path` — 2 tests passed at a 375px viewport, no console errors.
