### PR TITLE
fix: tell assistants to copy MCP download links verbatim

### DIFF
--- a/src/services/mcp/McpServerFactory.test.ts
+++ b/src/services/mcp/McpServerFactory.test.ts
@@ -163,7 +163,10 @@ describe('create_deck handler', () => {
 
     expect(result.content[0].text).toContain('2 cards. Ready to download.');
     expect(result.content[0].text).toContain(
-      'Download: https://2anki.net/api/mcp/decks/abc/download'
+      'Download: [deck.apkg](https://2anki.net/api/mcp/decks/abc/download)'
+    );
+    expect(result.content[0].text).toContain(
+      'copy the link exactly as written'
     );
     expect(result.content[0].text).toContain('| # | Front | Back |');
     expect(result.content[0].text).toContain('| 1 | water | 水 |');

--- a/src/services/mcp/McpServerFactory.ts
+++ b/src/services/mcp/McpServerFactory.ts
@@ -110,20 +110,29 @@ function slimDeckText(
 
 const DECK_PREVIEW_TEASER_ROWS = 5;
 
+// Assistants retyping the URL into prose corrupt the UUID (a real ChatGPT
+// session added a hex char and the link 404ed) — so tell them to copy it.
+const VERBATIM_LINK_INSTRUCTION =
+  'When sharing this download link, copy the link exactly as written — never retype the URL.';
+
 function deckHeaderLines(result: Record<string, unknown>): string[] {
   const lines: string[] = [];
   if (typeof result.summary === 'string') {
     lines.push(`**${result.summary}**`);
   }
   if (typeof result.downloadUrl === 'string') {
-    lines.push(`Download: ${result.downloadUrl}`);
+    const label =
+      typeof result.filename === 'string' ? result.filename : 'deck';
+    lines.push(`Download: [${label}](${result.downloadUrl})`);
+    lines.push(VERBATIM_LINK_INSTRUCTION);
   } else if (result.kind === 'batch' && Array.isArray(result.decks)) {
     for (const deck of result.decks as {
       name: string;
       downloadUrl: string;
     }[]) {
-      lines.push(`- ${deck.name}: ${deck.downloadUrl}`);
+      lines.push(`- [${deck.name}](${deck.downloadUrl})`);
     }
+    lines.push(VERBATIM_LINK_INSTRUCTION);
   }
   return lines;
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-06-mcp-download-links-verbatim.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-06-mcp-download-links-verbatim.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-06-mcp-download-links-verbatim",
+  "date": "2026-08-06",
+  "type": "fix",
+  "title": "Deck download links shared by AI assistants stay clickable instead of breaking"
+}


### PR DESCRIPTION
## Why

A real ChatGPT session (2026-08-06) received the correct MCP `create_deck` download URL, then retyped it into its prose reply and hallucinated an extra hex character in the UUID — the shared link 404ed. The deck existed the whole time; only the transcription was wrong.

## What

`deckHeaderLines` in `McpServerFactory` now renders the download URL as a markdown link labeled with the filename (batch: deck name) and appends one instruction line telling the assistant to copy the link exactly and never retype the URL. Models copy markdown links far more reliably than bare URLs in prose.

## Tests

Updated the create_deck handler expectation to the new link format + instruction. MCP suite 172 passed; full server suite 6292 passed (only the documented `getPageCount` pdfinfo environmental failure). tsc + format:check clean.

## Notes

Browser check: not applicable — changelog JSON is the only web/src change, rendered by the existing What's New page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFM6MBEU4Gg2mVNtGsaxvP
