### PR TITLE
fix: teach chat the correct ruby markup for furigana

### DIFF
--- a/src/usecases/chat/ChatUseCase.test.ts
+++ b/src/usecases/chat/ChatUseCase.test.ts
@@ -974,6 +974,17 @@ describe('ChatUseCase', () => {
       expect(callArg.system[0].text).toMatch(/correct_index/);
     });
 
+    it('teaches correct ruby markup in the system prompt (furigana prod failure)', async () => {
+      const { anthropic, useCase } = buildUseCase('reply');
+      await useCase.execute({
+        user: FREE_USER,
+        content: 'q',
+        conversationHistory: [],
+      });
+      const callArg = anthropic.messages.stream.mock.calls[0][0];
+      expect(callArg.system[0].text).toContain('<ruby>三<rt>さん</rt></ruby>');
+    });
+
     it('does not add MCQ instructions to the system prompt for free users', async () => {
       const { anthropic, useCase } = buildUseCase('reply');
       await useCase.execute({

--- a/src/usecases/chat/ChatUseCase.ts
+++ b/src/usecases/chat/ChatUseCase.ts
@@ -121,6 +121,8 @@ For fill-in-the-blank or cloze cards, put the answer inline using Anki cloze syn
 
 Use {{c1::...}}, {{c2::...}}, {{c3::...}} for separate blanks within the same card. Do not use bare ___ placeholders — the deck builder expects Anki cloze syntax for cloze cards.
 
+Card fields may contain inline HTML (b, i, u, sub, sup, ruby, br). For furigana or other reading annotations, use complete ruby markup with the base text INSIDE the tag and the reading in <rt>: \`<ruby>三<rt>さん</rt></ruby>\`. Never write the base text outside the tag or omit <rt> (\`三<ruby>さん</ruby>\` is wrong and renders as plain text).
+
 Never output raw JSON without the code fence. Always include the opening \`\`\`json and closing \`\`\` markers.
 
 On the line immediately before the JSON code block, write \`Deck: <name>\` — a short, descriptive deck name (max 60 characters) for the cards, e.g. \`Deck: Cell Biology — Mitosis\`. Don't mention the deck name in the prose; that line is metadata, not conversation.

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-06-chat-furigana-ruby.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-06-chat-furigana-ruby.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-06-chat-furigana-ruby",
+  "date": "2026-08-06",
+  "type": "fix",
+  "title": "Chat flashcards with furigana use correct ruby markup so readings display above the kanji"
+}


### PR DESCRIPTION
## Why

A real /chat session (2026-08-06) asked for Japanese number cards with furigana. The model emitted `三<ruby>さん</ruby>` — base kanji outside the tag, no `<rt>` — which browsers render as plain inline text ("三さん"), and a follow-up "fix that" produced the same broken shape. The system prompt had no HTML guidance at all, so the model invented its own ruby structure.

## What

The chat system prompt now names the allowed inline HTML tags and shows the one correct ruby form (`<ruby>三<rt>さん</rt></ruby>`), explicitly calling out the observed wrong shape. No pipeline change needed: `src/lib/markdown.ts` already allowlists `ruby|rt|rp|rb`, so correct markup survives to the deck and the chat preview.

## Tests

New assertion that the system prompt teaches the correct ruby example; chat suite 72 passed. tsc + format clean.

## Notes

Browser check: not applicable — changelog JSON is the only web/src change; the behavioral fix is a server-side prompt string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFM6MBEU4Gg2mVNtGsaxvP
