### PR TITLE
fix: cap apkg decompression before it can OOM the main process

### DIFF
--- a/src/controllers/ApkgController.test.ts
+++ b/src/controllers/ApkgController.test.ts
@@ -527,6 +527,23 @@ describe('ApkgController.exportCsv', () => {
     expect(executeMock).toHaveBeenCalledWith(expect.any(Buffer), 100);
   });
 
+  it('returns 413 when the apkg exceeds the decompression caps', async () => {
+    const { ApkgTooLargeError } = jest.requireActual(
+      '../services/ApkgPreviewService/extractApkg'
+    );
+    executeMock.mockRejectedValueOnce(new ApkgTooLargeError());
+    const controller = makeController();
+    const req = makeReq() as Request;
+    const res = makeCsvRes({ patreon: true });
+
+    await controller.exportCsv(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(413);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'This Anki package is too large to process.',
+    });
+  });
+
   it('returns 400 when the deck has no notes', async () => {
     executeMock.mockRejectedValueOnce(new CsvEmptyDeckError());
     const controller = makeController();

--- a/src/controllers/ApkgController.ts
+++ b/src/controllers/ApkgController.ts
@@ -26,6 +26,7 @@ import PackEditedApkgUseCase from '../usecases/apkg/PackEditedApkgUseCase';
 import ResolveImportParentPageUseCase from '../usecases/apkg/ResolveImportParentPageUseCase';
 import NoNotionPagesError from '../usecases/apkg/NoNotionPagesError';
 import { CardEdit } from '../services/ApkgPreviewService/applyEditsToCards';
+import { ApkgTooLargeError } from '../services/ApkgPreviewService/extractApkg';
 import { NotionService } from '../services/NotionService/NotionService';
 import JobRepository from '../data_layer/JobRepository';
 import sendErrorResponse from '../lib/sendErrorResponse';
@@ -158,6 +159,7 @@ class ApkgController {
       if (!parsed) return;
       res.json(this.previewService.getMeta(parsed));
     } catch (error) {
+      if (sendApkgTooLarge(res, error)) return;
       if (this.downloadService.isMissingDownloadError(error)) {
         res.status(404).json({ message: 'Upload is no longer available.' });
         return;
@@ -188,6 +190,7 @@ class ApkgController {
         )
       );
     } catch (error) {
+      if (sendApkgTooLarge(res, error)) return;
       if (this.downloadService.isMissingDownloadError(error)) {
         res.status(404).json({ message: 'Upload is no longer available.' });
         return;
@@ -216,6 +219,7 @@ class ApkgController {
       res.setHeader('Cache-Control', 'private, max-age=300');
       res.send(buffer);
     } catch (error) {
+      if (sendApkgTooLarge(res, error)) return;
       if (this.downloadService.isMissingDownloadError(error)) {
         res.status(404).send();
         return;
@@ -284,6 +288,7 @@ class ApkgController {
       );
       res.send(result.pdf);
     } catch (error) {
+      if (sendApkgTooLarge(res, error)) return;
       if (error instanceof CardLimitExceededError) {
         res.status(400).json({ message: error.message });
         return;
@@ -414,6 +419,7 @@ class ApkgController {
 
       res.status(202).json({ job_id: jobId, status: 'queued' });
     } catch (error) {
+      if (sendApkgTooLarge(res, error)) return;
       if (error instanceof Error && error.message === 'unauthorized') {
         res.status(400).json({ message: 'Notion is not connected.' });
         return;
@@ -473,6 +479,7 @@ class ApkgController {
       );
       res.send(result.buffer);
     } catch (error) {
+      if (sendApkgTooLarge(res, error)) return;
       if (this.downloadService.isMissingDownloadError(error)) {
         res.status(404).json({ message: 'Upload is no longer available.' });
         return;
@@ -593,11 +600,20 @@ function csvNoteLimitFor(owner: unknown, paying: boolean): number | null {
   return owner == null ? CSV_ANONYMOUS_NOTE_LIMIT : CSV_FREE_NOTE_LIMIT;
 }
 
+function sendApkgTooLarge(res: Response, error: unknown): boolean {
+  if (error instanceof ApkgTooLargeError) {
+    res.status(413).json({ message: error.message });
+    return true;
+  }
+  return false;
+}
+
 function sendCsvExportError(
   res: Response,
   error: unknown,
   noteLimit: number | null
 ): void {
+  if (sendApkgTooLarge(res, error)) return;
   if (error instanceof CsvEmptyDeckError) {
     res.status(400).json({
       message: 'No notes found in this .apkg file. Pick another deck.',

--- a/src/controllers/ApkgController.ts
+++ b/src/controllers/ApkgController.ts
@@ -288,21 +288,7 @@ class ApkgController {
       );
       res.send(result.pdf);
     } catch (error) {
-      if (sendApkgTooLarge(res, error)) return;
-      if (error instanceof CardLimitExceededError) {
-        res.status(400).json({ message: error.message });
-        return;
-      }
-      if (
-        error instanceof Error &&
-        (error.message.includes('No Anki collection') ||
-          error.message.includes('open failed'))
-      ) {
-        res.status(400).json({ message: 'Invalid .apkg file' });
-        return;
-      }
-      console.error(error);
-      res.status(500).json({ message: 'PDF generation failed.' });
+      sendPdfExportError(res, error);
     }
   }
 
@@ -584,6 +570,24 @@ function csvNoteLimitFor(owner: unknown, paying: boolean): number | null {
     return null;
   }
   return owner == null ? CSV_ANONYMOUS_NOTE_LIMIT : CSV_FREE_NOTE_LIMIT;
+}
+
+function sendPdfExportError(res: Response, error: unknown): void {
+  if (sendApkgTooLarge(res, error)) return;
+  if (error instanceof CardLimitExceededError) {
+    res.status(400).json({ message: error.message });
+    return;
+  }
+  if (
+    error instanceof Error &&
+    (error.message.includes('No Anki collection') ||
+      error.message.includes('open failed'))
+  ) {
+    res.status(400).json({ message: 'Invalid .apkg file' });
+    return;
+  }
+  console.error(error);
+  res.status(500).json({ message: 'PDF generation failed.' });
 }
 
 function sendImportStartError(res: Response, error: unknown): void {

--- a/src/controllers/ApkgController.ts
+++ b/src/controllers/ApkgController.ts
@@ -419,21 +419,7 @@ class ApkgController {
 
       res.status(202).json({ job_id: jobId, status: 'queued' });
     } catch (error) {
-      if (sendApkgTooLarge(res, error)) return;
-      if (error instanceof Error && error.message === 'unauthorized') {
-        res.status(400).json({ message: 'Notion is not connected.' });
-        return;
-      }
-      if (error instanceof NoNotionPagesError) {
-        res.status(400).json({ message: error.message });
-        return;
-      }
-      if (error instanceof APIResponseError) {
-        sendErrorResponse(error, res);
-        return;
-      }
-      console.error(error);
-      res.status(500).json({ message: 'Import failed to start.' });
+      sendImportStartError(res, error);
     }
   }
 
@@ -598,6 +584,24 @@ function csvNoteLimitFor(owner: unknown, paying: boolean): number | null {
     return null;
   }
   return owner == null ? CSV_ANONYMOUS_NOTE_LIMIT : CSV_FREE_NOTE_LIMIT;
+}
+
+function sendImportStartError(res: Response, error: unknown): void {
+  if (sendApkgTooLarge(res, error)) return;
+  if (error instanceof Error && error.message === 'unauthorized') {
+    res.status(400).json({ message: 'Notion is not connected.' });
+    return;
+  }
+  if (error instanceof NoNotionPagesError) {
+    res.status(400).json({ message: error.message });
+    return;
+  }
+  if (error instanceof APIResponseError) {
+    sendErrorResponse(error, res);
+    return;
+  }
+  console.error(error);
+  res.status(500).json({ message: 'Import failed to start.' });
 }
 
 function sendApkgTooLarge(res: Response, error: unknown): boolean {

--- a/src/services/ApkgPreviewService/extractApkg.test.ts
+++ b/src/services/ApkgPreviewService/extractApkg.test.ts
@@ -113,3 +113,59 @@ describe('extractApkg + parseCollection composition', () => {
     expect(collection.notes.get(10)?.fields).toEqual(['hello', 'world']);
   });
 });
+
+describe('extractApkg decompression caps', () => {
+  const { ApkgTooLargeError } = require('./extractApkg');
+
+  it('rejects on declared sizes before inflating when the total cap is exceeded', async () => {
+    const zip = new JSZip();
+    zip.file('collection.anki2', Buffer.alloc(64 * 1024, 0));
+    zip.file('media', '{}');
+    const apkg = await zip.generateAsync({ type: 'nodebuffer' });
+
+    await expect(
+      extractApkg(apkg, { maxTotalDecompressedBytes: 16 * 1024 })
+    ).rejects.toBeInstanceOf(ApkgTooLargeError);
+  });
+
+  it('rejects when the archive holds more entries than the cap', async () => {
+    const zip = new JSZip();
+    zip.file('collection.anki2', buildLegacyCollectionBuffer());
+    zip.file('media', '{}');
+    for (let i = 0; i < 5; i++) {
+      zip.file(String(i), Buffer.from('x'));
+    }
+    const apkg = await zip.generateAsync({ type: 'nodebuffer' });
+
+    await expect(extractApkg(apkg, { maxEntries: 4 })).rejects.toBeInstanceOf(
+      ApkgTooLargeError
+    );
+  });
+
+  it('rejects when the zstd collection expands past the collection cap', async () => {
+    const zlib = await import('zlib');
+    const { promisify } = await import('util');
+    const zstdCompress = promisify(zlib.zstdCompress);
+    const compressed = await zstdCompress(Buffer.alloc(4 * 1024 * 1024, 0));
+    const apkg = await buildApkgZip('collection.anki21b', compressed as Buffer);
+
+    await expect(
+      extractApkg(apkg, {
+        maxTotalDecompressedBytes: 64 * 1024 * 1024,
+        maxCollectionDecompressedBytes: 1024 * 1024,
+      })
+    ).rejects.toBeInstanceOf(ApkgTooLargeError);
+  });
+
+  it('carries a user-safe message with no archive internals', async () => {
+    const zip = new JSZip();
+    zip.file('collection.anki2', Buffer.alloc(64 * 1024, 0));
+    const apkg = await zip.generateAsync({ type: 'nodebuffer' });
+
+    const err = await extractApkg(apkg, {
+      maxTotalDecompressedBytes: 1024,
+    }).catch((e) => e);
+    expect(err.name).toBe('ApkgTooLargeError');
+    expect(err.message).toBe('This Anki package is too large to process.');
+  });
+});

--- a/src/services/ApkgPreviewService/extractApkg.ts
+++ b/src/services/ApkgPreviewService/extractApkg.ts
@@ -1,4 +1,4 @@
-import { decompress as zstdDecompress } from 'fzstd';
+import { Decompress, decompress as zstdDecompress } from 'fzstd';
 import yauzl from 'yauzl';
 
 import { readRepeatedSubmessages, readString } from './protobuf';
@@ -10,6 +10,27 @@ export interface ApkgArchive {
   mediaEntries: Map<string, Buffer>;
 }
 
+// This runs in the main Express process (single pm2 instance), so a zip bomb
+// here takes down every in-flight conversion, not one worker. Caps sized for
+// the 100MB multer limit on the apkg routes: honest media is stored ~1:1 and
+// a large collection sqlite decompresses well under these.
+const MAX_TOTAL_DECOMPRESSED_BYTES = 1024 * 1024 * 1024;
+const MAX_COLLECTION_DECOMPRESSED_BYTES = 512 * 1024 * 1024;
+const MAX_ENTRIES = 65536;
+
+export interface ExtractApkgLimits {
+  maxTotalDecompressedBytes?: number;
+  maxCollectionDecompressedBytes?: number;
+  maxEntries?: number;
+}
+
+export class ApkgTooLargeError extends Error {
+  constructor() {
+    super('This Anki package is too large to process.');
+    this.name = 'ApkgTooLargeError';
+  }
+}
+
 const COLLECTION_CANDIDATES = [
   'collection.anki21b',
   'collection.anki21',
@@ -18,20 +39,61 @@ const COLLECTION_CANDIDATES = [
 
 function readEntry(
   zipfile: yauzl.ZipFile,
-  entry: yauzl.Entry
+  entry: yauzl.Entry,
+  remainingBudget: number
 ): Promise<Buffer> {
   return new Promise((resolve, reject) => {
     zipfile.openReadStream(entry, (err, stream) => {
       if (err || !stream) return reject(err ?? new Error('no stream'));
       const chunks: Buffer[] = [];
-      stream.on('data', (chunk) => chunks.push(chunk));
+      let received = 0;
+      stream.on('data', (chunk: Buffer) => {
+        received += chunk.length;
+        if (received > remainingBudget) {
+          stream.destroy();
+          reject(new ApkgTooLargeError());
+          return;
+        }
+        chunks.push(chunk);
+      });
       stream.on('end', () => resolve(Buffer.concat(chunks)));
       stream.on('error', reject);
     });
   });
 }
 
-export async function extractApkg(bytes: Buffer): Promise<ApkgArchive> {
+function decompressCollectionCapped(
+  compressed: Buffer,
+  maxBytes: number
+): Buffer {
+  const chunks: Uint8Array[] = [];
+  let produced = 0;
+  let overflow = false;
+  const stream = new Decompress((chunk) => {
+    produced += chunk.length;
+    if (produced > maxBytes) {
+      overflow = true;
+      return;
+    }
+    chunks.push(chunk);
+  });
+  stream.push(new Uint8Array(compressed), true);
+  if (overflow) {
+    throw new ApkgTooLargeError();
+  }
+  return Buffer.concat(chunks);
+}
+
+export async function extractApkg(
+  bytes: Buffer,
+  limits: ExtractApkgLimits = {}
+): Promise<ApkgArchive> {
+  const maxTotal =
+    limits.maxTotalDecompressedBytes ?? MAX_TOTAL_DECOMPRESSED_BYTES;
+  const maxCollection =
+    limits.maxCollectionDecompressedBytes ?? MAX_COLLECTION_DECOMPRESSED_BYTES;
+  const maxEntries = limits.maxEntries ?? MAX_ENTRIES;
+
   return new Promise((resolve, reject) => {
     yauzl.fromBuffer(bytes, { lazyEntries: true }, (err, zipfile) => {
       if (err || !zipfile) return reject(err ?? new Error('open failed'));
@@ -39,14 +101,40 @@ export async function extractApkg(bytes: Buffer): Promise<ApkgArchive> {
       const collections: Map<string, Buffer> = new Map();
       const mediaEntries: Map<string, Buffer> = new Map();
       let mediaManifestRaw: Buffer | null = null;
+      let declaredTotal = 0;
+      let inflatedTotal = 0;
+      let entryCount = 0;
+      let settled = false;
+
+      const fail = (error: Error) => {
+        if (settled) return;
+        settled = true;
+        reject(error);
+      };
 
       zipfile.on('entry', (entry: yauzl.Entry) => {
+        if (settled) return;
         if (/\/$/.test(entry.fileName)) {
           zipfile.readEntry();
           return;
         }
-        readEntry(zipfile, entry)
+        entryCount += 1;
+        if (entryCount > maxEntries) {
+          fail(new ApkgTooLargeError());
+          return;
+        }
+        // Central-directory declared size: refuse before inflating a single
+        // byte of an entry that would push the archive past the cap. The
+        // running count during inflation below catches lying headers.
+        declaredTotal += entry.uncompressedSize;
+        if (declaredTotal > maxTotal) {
+          fail(new ApkgTooLargeError());
+          return;
+        }
+        readEntry(zipfile, entry, maxTotal - inflatedTotal)
           .then((buf) => {
+            if (settled) return;
+            inflatedTotal += buf.length;
             if (COLLECTION_CANDIDATES.includes(entry.fileName)) {
               collections.set(entry.fileName, buf);
             } else if (entry.fileName === 'media') {
@@ -56,23 +144,31 @@ export async function extractApkg(bytes: Buffer): Promise<ApkgArchive> {
             }
             zipfile.readEntry();
           })
-          .catch(reject);
+          .catch(fail);
       });
 
       zipfile.on('end', () => {
+        if (settled) return;
         const name = COLLECTION_CANDIDATES.find((candidate) =>
           collections.has(candidate)
         );
         if (!name) {
-          reject(new Error('No Anki collection file found in archive'));
+          fail(new Error('No Anki collection file found in archive'));
           return;
         }
         let collectionBuffer = collections.get(name) as Buffer;
         if (name === 'collection.anki21b') {
-          collectionBuffer = Buffer.from(
-            zstdDecompress(new Uint8Array(collectionBuffer))
-          );
+          try {
+            collectionBuffer = decompressCollectionCapped(
+              collectionBuffer,
+              maxCollection
+            );
+          } catch (decompressError) {
+            fail(decompressError as Error);
+            return;
+          }
         }
+        settled = true;
         resolve({
           collectionBuffer,
           collectionName: name,
@@ -81,7 +177,7 @@ export async function extractApkg(bytes: Buffer): Promise<ApkgArchive> {
         });
       });
 
-      zipfile.on('error', reject);
+      zipfile.on('error', fail);
       zipfile.readEntry();
     });
   });

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-06-apkg-size-guardrails.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-06-apkg-size-guardrails.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-06-apkg-size-guardrails",
+  "date": "2026-08-06",
+  "type": "fix",
+  "title": "Oversized Anki packages get a clear \"too large\" message instead of failing midway"
+}


### PR DESCRIPTION
## Why

`extractApkg` inflated every zip entry and the zstd collection with no declared-size census, no total cap, no entry cap, and no in-memory bound — inline in the main Express process (single pm2 instance). DEFLATE tops out near 1032:1, so a crafted 100MB `.apkg` could target ~100GB and the zstd hop compounds it; a handful of concurrent requests forces a pm2 recycle that kills every in-flight conversion site-wide. The sibling zip path (`src/lib/zip/zip.tsx`) was hardened for exactly this in #3717; this path never got the lesson.

Fixes #4007.

## What

- **Census before inflating**: each entry's central-directory `uncompressedSize` counts against a 1GB total; the archive is refused before a byte of an over-cap entry inflates.
- **Running actual-bytes budget** during inflation catches lying headers; the stream is destroyed the moment it exceeds the remaining budget.
- **Entry-count cap** (65536) guards the media `Map` against many-tiny-entry abuse.
- **zstd collection cap**: `collection.anki21b` now streams through fzstd's `Decompress` with a 512MB output cap instead of one-shot decompression.
- **Designed 413**: all consumers (`/api/apkg/csv`, `/api/apkg/pdf`, meta/cards/media previews, edited-download, Notion import) map the new `ApkgTooLargeError` to `413 {"message": "This Anki package is too large to process."}` instead of an OOM or opaque 500. Caps sized against the routes' 100MB multer limit — honest media is stored ~1:1, so legitimate decks fit comfortably.

Deliberately NOT done (documented in the issue as the larger change): moving the parse into the conversion worker pool. The caps are the cheap 80% that removes the amplification; worker isolation can follow independently. No rate limiter — it would paper over the amplification.

## Tests

TDD: 4 new extractApkg tests (declared-size census abort, entry-count cap, zstd expansion cap, stable user-safe error identity) written failing first; 1 new controller test for the 413 mapping. Full server suite: 6298 passed, only the documented `getPageCount` pdfinfo environmental failure. tsc + format:check clean.

## Notes

Browser check: not applicable — changelog JSON is the only web/src change.
Sonar not run locally (overnight run); PR decoration + the zero-findings check cover it before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFM6MBEU4Gg2mVNtGsaxvP
