### PR TITLE
fix: paint warning badge text with the tuned warning-text token

### DIFF
--- a/web/src/pages/WhatsNewPage/changelog/2026-08-07-warning-badge-contrast.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-07-warning-badge-contrast.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-07-warning-badge-contrast",
+  "date": "2026-08-07",
+  "type": "fix",
+  "title": "Warning badges are readable in every theme, not just dark mode"
+}

--- a/web/src/styles/shared.module.css
+++ b/web/src/styles/shared.module.css
@@ -235,7 +235,7 @@
 
 .badgeWarning {
   composes: badge;
-  color: var(--color-warning);
+  color: var(--color-warning-text);
   background: var(--color-warning-light);
 }
 

--- a/web/src/styles/warningBadgeContrast.test.ts
+++ b/web/src/styles/warningBadgeContrast.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const baseCss = readFileSync(join(__dirname, 'base.css'), 'utf8');
+const sharedCss = readFileSync(join(__dirname, 'shared.module.css'), 'utf8');
+
+function themeBlocks(css: string): Record<string, string> {
+  const blocks: Record<string, string> = {};
+  const pattern = /(:root|\[data-theme='[^']+'\])[^{]*\{([^}]*)\}/g;
+  for (const match of css.matchAll(pattern)) {
+    const name = match[1] === ':root' ? 'light' : match[1];
+    blocks[name] = (blocks[name] ?? '') + match[2];
+  }
+  return blocks;
+}
+
+function readVar(block: string, name: string): string | null {
+  const match = new RegExp(`${name}:\\s*(#[0-9a-fA-F]{6})`).exec(block);
+  return match ? match[1] : null;
+}
+
+function luminance(hex: string): number {
+  const channel = (value: number) => {
+    const c = value / 255;
+    return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  };
+  const r = channel(parseInt(hex.slice(1, 3), 16));
+  const g = channel(parseInt(hex.slice(3, 5), 16));
+  const b = channel(parseInt(hex.slice(5, 7), 16));
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrastRatio(fg: string, bg: string): number {
+  const [hi, lo] = [luminance(fg), luminance(bg)].sort((a, b) => b - a);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+describe('warning badge contrast (issue #4011)', () => {
+  it('badgeWarning paints text with the tuned warning-text token, not the raw accent', () => {
+    const badge = /\.badgeWarning\s*\{[^}]*\}/.exec(sharedCss)?.[0] ?? '';
+    expect(badge).toContain('color: var(--color-warning-text)');
+    expect(badge).not.toContain('color: var(--color-warning)');
+  });
+
+  it('warning-text on warning-light clears WCAG AA (4.5:1) in every theme', () => {
+    const blocks = themeBlocks(baseCss);
+    const themed = Object.entries(blocks).filter(
+      ([, block]) =>
+        readVar(block, '--color-warning-text') &&
+        readVar(block, '--color-warning-light')
+    );
+    expect(themed.length).toBeGreaterThanOrEqual(5);
+    for (const [name, block] of themed) {
+      const text = readVar(block, '--color-warning-text') as string;
+      const bg = readVar(block, '--color-warning-light') as string;
+      const ratio = contrastRatio(text, bg);
+      expect(
+        ratio,
+        `${name}: ${text} on ${bg} = ${ratio.toFixed(2)}:1`
+      ).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+});


### PR DESCRIPTION
## Why

`sharedStyles.badgeWarning` painted `--color-warning` on `--color-warning-light`: ~2.1:1 in light/purple/hotpink and ~3.1:1 in gold at 12px medium text, where WCAG AA requires 4.5:1. Only dark passed. The badge exists to make silent failures visible; four of five themes rendered it near-invisible to anyone needing contrast.

Fixes #4011.

## What

One-line fix: the badge now uses `--color-warning-text` — the tuned-for-this-background token **every theme already defines** (`#92400e` on `#fffbeb` = 6.84:1 in light/gold/purple/hotpink; `#fcd34d` on `#3b2f08` = 9.12:1 in dark). All `badgeWarning` consumers (Downloads image-skipped badge, the #4010 unshared/skipped-blocks chips, Ankify sync conflicts, UploadPage — which aliases the shared module) inherit it from the single rule.

A new regression test (`web/src/styles/warningBadgeContrast.test.ts`) parses `base.css`, computes the WCAG ratio for the pair in every theme block, asserts ≥4.5:1 across all five, and asserts `badgeWarning` uses the text token — so neither a token drift nor a class regression can silently reintroduce this.

## Decisions made overnight (please review)

- Token strategy: reused the existing `--color-warning-text` semantic token (the issue's option 2) instead of darkening `--color-warning` globally (option 1). The design system already made this call — the `-text` variant exists in all five themes precisely for text-on-`-light` surfaces; no new token, no visual change to any other `--color-warning` consumer (borders, icons, meters). Assumption: the `-text` values are the intended pairing; if you'd rather re-tint, change base.css tokens — the test will hold the 4.5:1 floor.
- Scope: deliberately did NOT audit the other 14 `color: var(--color-warning)` sites on neutral backgrounds — different pairs, different question, and the issue scoped to the badge. Worth a follow-up a11y-reviewer pass if you want the sweep.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: `pnpm --filter 2anki-web test:golden-path` — 2 passed (machine-backed attestation per .claude/docs/browser-attestation.md).

## Tests

TDD: test written first, failed on the raw-token assertion, one-line fix turned it green. Full web suite 2815 passed (359 files); typecheck + lint clean (2 pre-existing warnings untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFM6MBEU4Gg2mVNtGsaxvP
