### PR TITLE
chore: ignore held sanitize-html and jsdom bumps in dependabot

### DIFF
--- a/.claude/rules/dependencies.md
+++ b/.claude/rules/dependencies.md
@@ -31,5 +31,7 @@
 ## Held bumps — do not retry without clearing the blocker
 
 - **markdown-it 15** (pinned at 14.3.0, ignored in `.github/dependabot.yml`): v15 removed `md.utils.assign`, which `markdown-it-multimd-table@4.2.3` calls at module load — the server dies at boot (the 2026-08-06 outage, reverted in #4015). Re-attempt only together with a multimd-table release that declares markdown-it 15 support, and remove the dependabot ignore in the same PR.
-- **jsdom 30** (held on 29.1.1, see #3988): regresses attribute-value matching on camelCase SVG attributes (`svg[viewBox="0 0 24 24"]` matches 0). Wait for a fixed release; do not weaken the HomePage icon test to get green.
-- **sanitize-html 2.17.6** (held on 2.17.5, see #4002): pulls ESM-only `htmlparser2@12`, which the CJS Jest suite cannot load, and tests exercise real sanitization so stubbing is not an option.
+- **jsdom 30** (held on 29.1.1, ignored `>=30.0.0` in dependabot.yml, see #3988): regresses attribute-value matching on camelCase SVG attributes (`svg[viewBox="0 0 24 24"]` matches 0). Wait for a fixed release; do not weaken the HomePage icon test to get green.
+- **sanitize-html 2.17.6** (held on 2.17.5, ignored `>=2.17.6` in dependabot.yml, see #4002 and #4025 — the grouped PR resurfaced it once already): pulls ESM-only `htmlparser2@12`, which the CJS Jest suite cannot load, and tests exercise real sanitization so stubbing is not an option.
+
+Every entry here MUST have a matching `ignore` in `.github/dependabot.yml` (and vice versa — remove both together when a hold clears). The ledger is the why; the ignore is the enforcement. A hold without an ignore resurfaces in the next grouped PR with the held bump buried among safe ones (#4025).

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,18 @@ updates:
       # markdown-it 15 support — see "Held bumps" in .claude/rules/dependencies.md.
       - dependency-name: 'markdown-it'
         update-types: ['version-update:semver-major']
+      # sanitize-html 2.17.6 moves htmlparser2 to ESM-only 12.0.0, which the
+      # CJS Jest suite cannot load (8 suites red — #4002, resurfaced in #4025).
+      # Tests exercise real sanitization so stubbing is not an option. Remove
+      # once the suite has an ESM strategy or sanitize-html restores CJS
+      # compatibility — see "Held bumps" in .claude/rules/dependencies.md.
+      - dependency-name: 'sanitize-html'
+        versions: ['>=2.17.6']
+      # jsdom 30 regresses attribute-value matching on camelCase SVG
+      # attributes (svg[viewBox="..."] matches nothing — #3988). Held on
+      # 29.1.1 until a fixed release; do not weaken the HomePage icon test.
+      - dependency-name: 'jsdom'
+        versions: ['>=30.0.0']
     groups:
       production-dependencies:
         dependency-type: 'production'


### PR DESCRIPTION
## Why

https://github.com/2anki/2anki.net/pull/4025 resurfaced the held sanitize-html 2.17.6 bump buried in a six-package group (ESM-only htmlparser2 12 → 8 Jest suites red, same as #4002). A Held-bumps ledger entry without a dependabot ignore just comes back every regeneration.

## What

Version-scoped `ignore` entries for `sanitize-html >=2.17.6` and `jsdom >=30.0.0`, matching the existing markdown-it one. Ledger updated with the invariant: every hold pairs with an ignore; both removed together when the hold clears.

After merge: comment `@dependabot recreate` on #4025 so the group regenerates without sanitize-html — the remaining five bumps should then go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFM6MBEU4Gg2mVNtGsaxvP