### PR TITLE
fix: census zip entries when a conversion ships zero cards

### DIFF
--- a/src/infrastracture/adapters/fileConversion/documentStructureCensus.test.ts
+++ b/src/infrastracture/adapters/fileConversion/documentStructureCensus.test.ts
@@ -88,8 +88,9 @@ describe('censusUploadedFile', () => {
       buffer: docx,
     });
     expect(census).not.toBeNull();
-    expect(census!.paragraphs).toBeGreaterThanOrEqual(1);
-    expect(census!.chars).toBeGreaterThan(0);
+    const doc = census as { paragraphs: number; chars: number };
+    expect(doc.paragraphs).toBeGreaterThanOrEqual(1);
+    expect(doc.chars).toBeGreaterThan(0);
   });
 
   it('returns null for an unreadable or binary non-docx file', async () => {
@@ -98,5 +99,77 @@ describe('censusUploadedFile', () => {
       buffer: Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00]),
     });
     expect(census).toBeNull();
+  });
+});
+
+describe('censusUploadedFile — zip archives (#4029)', () => {
+  const { zipSync, strToU8 } = require('fflate');
+
+  function buildZip(entries: Record<string, Uint8Array>): Buffer {
+    return Buffer.from(zipSync(entries));
+  }
+
+  it('returns an entry manifest with supported verdicts and nested-zip count', async () => {
+    const inner = zipSync({ 'Inner Page abc.html': strToU8('<html></html>') });
+    const zip = buildZip({
+      'Private & Shared/Bony Page abc123.html': strToU8('<html></html>'),
+      'Private & Shared/notes.pdf': strToU8('%PDF-1.4'),
+      'ExportBlock-abc-Part-1.zip': inner,
+      'assets/photo.png': strToU8('png-bytes'),
+    });
+
+    const census = await censusUploadedFile({
+      originalname: 'workspace-export.zip',
+      buffer: zip,
+    });
+
+    expect(census).toMatchObject({
+      kind: 'zip',
+      entryCount: 4,
+      nestedZipCount: 1,
+      supportedCount: 2,
+      unsupportedCount: 1,
+      truncated: false,
+    });
+    const entries = (
+      census as { entries: { name: string; supported: boolean }[] }
+    ).entries;
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'Private & Shared/Bony Page abc123.html',
+          supported: true,
+        }),
+        expect.objectContaining({
+          name: 'assets/photo.png',
+          supported: false,
+        }),
+      ])
+    );
+  });
+
+  it('marks an unreadable zip instead of throwing', async () => {
+    const census = await censusUploadedFile({
+      originalname: 'corrupt.zip',
+      buffer: Buffer.from('PK\x03\x04 not really a zip'),
+    });
+    expect(census).toMatchObject({ kind: 'zip', unreadable: true });
+  });
+
+  it('caps the manifest at 50 entries and flags truncation', async () => {
+    const many: Record<string, Uint8Array> = {};
+    for (let i = 0; i < 60; i++) {
+      many[`page-${i}.html`] = strToU8('<html></html>');
+    }
+    const census = await censusUploadedFile({
+      originalname: 'big.zip',
+      buffer: buildZip(many),
+    });
+    expect(census).toMatchObject({
+      kind: 'zip',
+      entryCount: 60,
+      truncated: true,
+    });
+    expect((census as { entries: unknown[] }).entries.length).toBe(50);
   });
 });

--- a/src/infrastracture/adapters/fileConversion/documentStructureCensus.ts
+++ b/src/infrastracture/adapters/fileConversion/documentStructureCensus.ts
@@ -1,6 +1,8 @@
 import * as cheerio from 'cheerio';
+import { unzipSync } from 'fflate';
 
 import { convertDocxToHTML } from './convertDocxToHTML';
+import { isZipContentFileSupported } from '../../../usecases/uploads/isZipContentFileSupported';
 
 export interface DocumentStructureCensus {
   chars: number;
@@ -14,6 +16,73 @@ export interface DocumentStructureCensus {
 }
 
 const TEXTUAL_EXTENSIONS = /\.(html?|md|markdown|txt|csv)$/i;
+
+export interface ZipEntryCensus {
+  name: string;
+  size: number;
+  supported: boolean;
+}
+
+export interface ZipStructureCensus {
+  kind: 'zip';
+  unreadable?: boolean;
+  entryCount: number;
+  nestedZipCount: number;
+  supportedCount: number;
+  unsupportedCount: number;
+  truncated: boolean;
+  entries: ZipEntryCensus[];
+}
+
+const ZIP_CENSUS_MAX_ENTRIES = 50;
+const ZIP_CENSUS_MAX_NAME = 120;
+
+// Central-directory walk only — the filter always returns false, so no entry
+// ever inflates and a zip bomb cannot hurt the diagnostics path.
+export function censusZipEntries(buffer: Buffer): ZipStructureCensus {
+  const all: { name: string; size: number }[] = [];
+  try {
+    unzipSync(new Uint8Array(buffer), {
+      filter: (file) => {
+        if (!file.name.endsWith('/')) {
+          all.push({ name: file.name, size: file.originalSize });
+        }
+        return false;
+      },
+    });
+  } catch {
+    return {
+      kind: 'zip',
+      unreadable: true,
+      entryCount: 0,
+      nestedZipCount: 0,
+      supportedCount: 0,
+      unsupportedCount: 0,
+      truncated: false,
+      entries: [],
+    };
+  }
+
+  const nested = all.filter((e) => /\.zip$/i.test(e.name));
+  const flat = all.filter((e) => !/\.zip$/i.test(e.name));
+  const entries = all.slice(0, ZIP_CENSUS_MAX_ENTRIES).map((e) => ({
+    name: e.name.slice(0, ZIP_CENSUS_MAX_NAME),
+    size: e.size,
+    supported: Boolean(isZipContentFileSupported(e.name)),
+  }));
+
+  return {
+    kind: 'zip',
+    entryCount: all.length,
+    nestedZipCount: nested.length,
+    supportedCount: flat.filter((e) => isZipContentFileSupported(e.name))
+      .length,
+    unsupportedCount: flat.filter((e) => !isZipContentFileSupported(e.name))
+      .length,
+    truncated: all.length > ZIP_CENSUS_MAX_ENTRIES,
+    entries,
+  };
+}
 
 export function censusFromHtml(html: string): DocumentStructureCensus {
   const $ = cheerio.load(html);
@@ -32,12 +101,15 @@ export function censusFromHtml(html: string): DocumentStructureCensus {
 export async function censusUploadedFile(file: {
   originalname: string;
   buffer: Buffer | undefined;
-}): Promise<DocumentStructureCensus | null> {
+}): Promise<DocumentStructureCensus | ZipStructureCensus | null> {
   const { originalname, buffer } = file;
   if (buffer == null) {
     return null;
   }
   try {
+    if (/\.zip$/i.test(originalname)) {
+      return censusZipEntries(buffer);
+    }
     if (/\.docx$/i.test(originalname)) {
       return censusFromHtml(await convertDocxToHTML(buffer));
     }

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -339,14 +339,20 @@ function logNoPackageDiagnostics(uploadedFiles: UploadedFile[]) {
         console.info('  no file contents available for diagnostics');
         continue;
       }
-      const head = contents.slice(0, 1000).toString('utf8');
-      const hasDisplayContents = head.includes('display:contents');
-      const hasToggleClass = head.includes('class="toggle"');
-      const hasDetails = head.includes('<details');
-      console.info(`  snippet=${JSON.stringify(head.slice(0, 300))}`);
-      console.info(
-        `  display:contents=${hasDisplayContents} .toggle=${hasToggleClass} <details=${hasDetails}`
-      );
+      if (/\.zip$/i.test(file.originalname)) {
+        // Raw zip bytes as a "snippet" are noise and the toggle heuristics
+        // always read false on binary — the zip census below is the signal.
+        console.info('  zip archive: entry census follows');
+      } else {
+        const head = contents.slice(0, 1000).toString('utf8');
+        const hasDisplayContents = head.includes('display:contents');
+        const hasToggleClass = head.includes('class="toggle"');
+        const hasDetails = head.includes('<details');
+        console.info(`  snippet=${JSON.stringify(head.slice(0, 300))}`);
+        console.info(
+          `  display:contents=${hasDisplayContents} .toggle=${hasToggleClass} <details=${hasDetails}`
+        );
+      }
       // Structural shape, not content — makes the zero-card class
       // reproducible from logs alone (#3966). Fire and forget: the census
       // may re-run a DOCX conversion and must never delay the response.


### PR DESCRIPTION
## Why

Diagnosing the zip zero-card regression (#4028) from prod logs dead-ended: `logNoPackageDiagnostics` prints the zip's raw binary head as the "snippet", the toggle heuristics always read false on binary, and `censusUploadedFile` (#3967) skips zips. Fixes #4029.

## What

- `censusZipEntries`: central-directory walk via fflate with a filter that always returns false — no entry ever inflates, so the diagnostics path is zip-bomb-safe by construction. Logs entry count, nested-zip count, supported/unsupported counts, and per-entry name (truncated), size, and `isZipContentFileSupported` verdict, capped at 50 entries with a truncation flag. Unreadable zips report `unreadable: true` instead of throwing.
- `censusUploadedFile` routes `.zip` uploads to it; the existing `census=` log line in `logNoPackageDiagnostics` picks it up with no extra wiring.
- The misleading binary snippet + toggle-heuristic lines are skipped for zips.

## Tests

TDD: 3 new cases written failing first (manifest with verdicts + nested count, corrupt zip, 50-entry cap). Suite 9/9; full server suite 6315 passed with only the documented `getPageCount` pdfinfo environmental failure. tsc, `pnpm arch` (no new violations), format:check clean.

No changelog entry — internal observability, no user-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFM6MBEU4Gg2mVNtGsaxvP