### PR TITLE
feat: monitor paying users who got zero value from their window

### DIFF
--- a/src/controllers/OpsController.ts
+++ b/src/controllers/OpsController.ts
@@ -24,6 +24,7 @@ import { ReconcileOrphanedSubscriptionsUseCase } from '../usecases/ops/Reconcile
 import { GetLandingPageYieldUseCase } from '../usecases/ops/GetLandingPageYieldUseCase';
 import { GetCustomerSignalsUseCase } from '../usecases/ops/GetCustomerSignalsUseCase';
 import { GetPassUnlockMonitorUseCase } from '../usecases/ops/GetPassUnlockMonitorUseCase';
+import { GetPaidValueMonitorUseCase } from '../usecases/ops/GetPaidValueMonitorUseCase';
 import GrantDeveloperAccessUseCase, {
   InvalidEmailError,
 } from '../usecases/developer/GrantDeveloperAccessUseCase';
@@ -51,7 +52,8 @@ class OpsController {
     private readonly getPassUnlockMonitorUseCase?: GetPassUnlockMonitorUseCase,
     private readonly sendPassWinbackUseCase?: SendPassWinbackUseCase,
     private readonly grantDeveloperAccessUseCase?: GrantDeveloperAccessUseCase,
-    private readonly getCancelFunnelUseCase?: GetCancelFunnelUseCase
+    private readonly getCancelFunnelUseCase?: GetCancelFunnelUseCase,
+    private readonly getPaidValueMonitorUseCase?: GetPaidValueMonitorUseCase
   ) {}
 
   async grantDeveloperAccess(req: express.Request, res: express.Response) {
@@ -433,6 +435,22 @@ class OpsController {
     } catch (error) {
       console.error('[ops] getPassUnlockMonitor failed', error);
       res.status(500).json({ message: 'Failed to load pass unlock monitor' });
+    }
+  }
+
+  async getPaidValueMonitor(req: express.Request, res: express.Response) {
+    if (this.getPaidValueMonitorUseCase == null) {
+      res.status(503).json({ message: 'Paid value monitor not configured' });
+      return;
+    }
+    try {
+      const window =
+        typeof req.query.window === 'string' ? req.query.window : undefined;
+      const result = await this.getPaidValueMonitorUseCase.execute(window);
+      res.status(200).json(result);
+    } catch (error) {
+      console.error('[ops] getPaidValueMonitor failed', error);
+      res.status(500).json({ message: 'Failed to load paid value monitor' });
     }
   }
 

--- a/src/data_layer/AnonymousPassRepository.ts
+++ b/src/data_layer/AnonymousPassRepository.ts
@@ -11,6 +11,14 @@ export interface AnonymousPass {
   buyer_email_hash: string | null;
 }
 
+export interface AnonymousPassWindowRow {
+  id: number;
+  kind: string;
+  createdAt: Date;
+  expiresAt: Date;
+  claimedByUserId: number | null;
+}
+
 export interface IAnonymousPassRepository {
   findBySessionId(stripeSessionId: string): Promise<AnonymousPass | null>;
   findActive(stripeSessionId: string, now: Date): Promise<AnonymousPass | null>;
@@ -118,6 +126,30 @@ export class AnonymousPassRepository implements IAnonymousPassRepository {
       }
       throw err;
     }
+  }
+
+  async listActiveInWindow(
+    since: Date,
+    until: Date
+  ): Promise<AnonymousPassWindowRow[]> {
+    const rows = await this.database(this.table)
+      .select('id', 'kind', 'created_at', 'expires_at', 'claimed_by_user_id')
+      .where('expires_at', '>=', since)
+      .where('created_at', '<=', until);
+    return rows.map((row) => ({
+      id: Number(row.id),
+      kind: String(row.kind),
+      createdAt:
+        row.created_at instanceof Date
+          ? row.created_at
+          : new Date(row.created_at),
+      expiresAt:
+        row.expires_at instanceof Date
+          ? row.expires_at
+          : new Date(row.expires_at),
+      claimedByUserId:
+        row.claimed_by_user_id == null ? null : Number(row.claimed_by_user_id),
+    }));
   }
 
   async findUnclaimedByBuyerEmailHash(

--- a/src/data_layer/EventsMetricsRepository.ts
+++ b/src/data_layer/EventsMetricsRepository.ts
@@ -14,6 +14,18 @@ export interface IPassSalesRepository {
   passSalesSince(since: Date): Promise<PassSalesCounts>;
 }
 
+export const PAID_VALUE_EVENT_NAMES = [
+  'conversion_succeeded',
+  'deck_downloaded',
+  'conversion_failed',
+] as const;
+
+export interface PaidValueEventRow {
+  userId: number;
+  name: string;
+  createdAt: Date;
+}
+
 export interface MedianMinutesRow {
   median_minutes: number | string | null;
 }
@@ -121,6 +133,32 @@ export class EventsMetricsRepository
       | UploadToDownloadRateRow
       | undefined;
     return mapUploadToDownloadRateRow(row);
+  }
+
+  async listPaidValueEvents(
+    userIds: number[],
+    since: Date
+  ): Promise<PaidValueEventRow[]> {
+    if (userIds.length === 0) {
+      return [];
+    }
+    const rows = (await this.database('events')
+      .select('user_id', 'name', 'created_at')
+      .whereIn('user_id', userIds)
+      .whereIn('name', [...PAID_VALUE_EVENT_NAMES])
+      .where('created_at', '>=', since)) as Array<{
+      user_id: number;
+      name: string;
+      created_at: Date | string;
+    }>;
+    return rows.map((row) => ({
+      userId: Number(row.user_id),
+      name: String(row.name),
+      createdAt:
+        row.created_at instanceof Date
+          ? row.created_at
+          : new Date(row.created_at),
+    }));
   }
 }
 

--- a/src/data_layer/PaidValueSubscriptionsRepository.sql.test.ts
+++ b/src/data_layer/PaidValueSubscriptionsRepository.sql.test.ts
@@ -1,0 +1,30 @@
+import knex from 'knex';
+
+import { buildNewSubscriptionsQuery } from './PaidValueSubscriptionsRepository';
+
+const since = new Date('2026-07-07T12:00:00.000Z');
+const until = new Date('2026-07-14T12:00:00.000Z');
+
+describe('PaidValueSubscriptionsRepository generated SQL', () => {
+  const pg = knex({ client: 'pg' });
+
+  afterAll(async () => {
+    await pg.destroy();
+  });
+
+  it('joins subscriptions to users by normalized email and filters by created_at window', () => {
+    const { sql, bindings } = buildNewSubscriptionsQuery(
+      pg,
+      since,
+      until
+    ).toSQL();
+
+    expect(sql).toBe(
+      'select "users"."id" as "user_id", ' +
+        '"subscriptions"."created_at" as "created_at" from "subscriptions" ' +
+        'join users on lower(trim(users.email)) = lower(trim(subscriptions.email)) ' +
+        'where "subscriptions"."created_at" >= ? and "subscriptions"."created_at" <= ?'
+    );
+    expect(bindings).toEqual([since, until]);
+  });
+});

--- a/src/data_layer/PaidValueSubscriptionsRepository.ts
+++ b/src/data_layer/PaidValueSubscriptionsRepository.ts
@@ -1,0 +1,51 @@
+import type { Knex } from 'knex';
+
+export interface NewSubscriptionWithUserRow {
+  userId: number;
+  createdAt: Date;
+}
+
+export interface INewSubscriptionsRepository {
+  listNewWithUserId(
+    since: Date,
+    until: Date
+  ): Promise<NewSubscriptionWithUserRow[]>;
+}
+
+export function buildNewSubscriptionsQuery(
+  database: Knex,
+  since: Date,
+  until: Date
+): Knex.QueryBuilder {
+  return database('subscriptions')
+    .joinRaw(
+      'join users on lower(trim(users.email)) = lower(trim(subscriptions.email))'
+    )
+    .where('subscriptions.created_at', '>=', since)
+    .where('subscriptions.created_at', '<=', until)
+    .select('users.id as user_id', 'subscriptions.created_at as created_at');
+}
+
+export class PaidValueSubscriptionsRepository implements INewSubscriptionsRepository {
+  constructor(private readonly database: Knex) {}
+
+  async listNewWithUserId(
+    since: Date,
+    until: Date
+  ): Promise<NewSubscriptionWithUserRow[]> {
+    const rows = (await buildNewSubscriptionsQuery(
+      this.database,
+      since,
+      until
+    )) as Array<{ user_id: number; created_at: Date | string }>;
+    return rows.map((row) => ({
+      userId: Number(row.user_id),
+      createdAt:
+        row.created_at instanceof Date
+          ? row.created_at
+          : new Date(row.created_at),
+    }));
+  }
+}
+
+export default PaidValueSubscriptionsRepository;

--- a/src/data_layer/UserPassRepository.ts
+++ b/src/data_layer/UserPassRepository.ts
@@ -15,6 +15,13 @@ export interface PaidPassCounts {
   weekPasses: number;
 }
 
+export interface UserPassWindowRow {
+  id: number;
+  userId: number;
+  kind: string;
+  expiresAt: Date;
+}
+
 export interface IUserPassRepository {
   findActive(userId: number, now: Date): Promise<UserPass | null>;
   countPaidPassesSince(userId: number, since: Date): Promise<PaidPassCounts>;
@@ -73,6 +80,25 @@ export class UserPassRepository implements IUserPassRepository {
       .where('stripe_payment_intent_id', paymentIntentId)
       .first();
     return row != null;
+  }
+
+  async listActiveInWindow(
+    since: Date,
+    until: Date
+  ): Promise<UserPassWindowRow[]> {
+    const rows = await this.database<UserPassRow>(this.table)
+      .select('id', 'user_id', 'kind', 'expires_at')
+      .where('expires_at', '>=', since)
+      .where('expires_at', '<=', until);
+    return rows.map((row) => ({
+      id: row.id,
+      userId: row.user_id,
+      kind: row.kind,
+      expiresAt:
+        row.expires_at instanceof Date
+          ? row.expires_at
+          : new Date(row.expires_at),
+    }));
   }
 
   countPaidPassesQuery(userId: number, since: Date) {

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -61,6 +61,9 @@ import { CustomerSignalsService } from '../services/ops/CustomerSignalsService';
 import { BehavioralDropoffRepository } from '../data_layer/BehavioralDropoffRepository';
 import { GetPassUnlockMonitorUseCase } from '../usecases/ops/GetPassUnlockMonitorUseCase';
 import { PassUnlockMonitorService } from '../services/ops/PassUnlockMonitorService';
+import { GetPaidValueMonitorUseCase } from '../usecases/ops/GetPaidValueMonitorUseCase';
+import { PaidValueMonitorService } from '../services/ops/PaidValueMonitorService';
+import PaidValueSubscriptionsRepository from '../data_layer/PaidValueSubscriptionsRepository';
 import UserPassRepository from '../data_layer/UserPassRepository';
 import AnonymousPassRepository from '../data_layer/AnonymousPassRepository';
 import { updateStripeSubscriptions } from '../lib/storage/jobs/helpers/updateStripeSubscriptions';
@@ -197,6 +200,14 @@ const OpsRouter = () => {
     new GrantDeveloperAccessUseCase(new UsersRepository(database)),
     new GetCancelFunnelUseCase(
       new CancelFunnelService({ eventsRepo: new EventsRepository(database) })
+    ),
+    new GetPaidValueMonitorUseCase(
+      new PaidValueMonitorService({
+        userPasses: new UserPassRepository(database),
+        anonymousPasses: new AnonymousPassRepository(database),
+        subscriptions: new PaidValueSubscriptionsRepository(database),
+        events: new EventsMetricsRepository(database),
+      })
     )
   );
 
@@ -711,6 +722,40 @@ const OpsRouter = () => {
    */
   router.get('/api/ops/passes/unlock-monitor', RequireOpsAccess, (req, res) =>
     controller.getPassUnlockMonitor(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ops/value-monitor:
+   *   get:
+   *     summary: Paying users who produced zero successful conversions in their paid window
+   *     description: |
+   *       For each Day/Week pass, claimed anonymous pass, and new subscription in
+   *       a rolling window, counts the conversion successes, downloads, and
+   *       failures inside that unit's own paid window. Splits each group into
+   *       with-value, zero-value-tried (failures but no success/download — the
+   *       urgent case), and zero-value-never-tried. Rows list only the zero-value
+   *       units by numeric user id; no emails are returned. Unclaimed anonymous
+   *       passes cannot be linked to a user, so they are reported as an honest
+   *       count only. Defaults to the last 7 days; pass ?window=1d|7d|14d|30d.
+   *       Internal endpoint locked to the ops owner — returns 404 for everyone
+   *       else.
+   *     tags: [Ops]
+   *     parameters:
+   *       - in: query
+   *         name: window
+   *         schema:
+   *           type: string
+   *           enum: ['1d', '7d', '14d', '30d']
+   *         description: Lookback window. Defaults to 7d.
+   *     responses:
+   *       200:
+   *         description: Paid value monitor payload
+   *       404:
+   *         description: Not the ops owner
+   */
+  router.get('/api/ops/value-monitor', RequireOpsAccess, (req, res) =>
+    controller.getPaidValueMonitor(req, res)
   );
 
   /**

--- a/src/services/ops/PaidValueMonitorService.test.ts
+++ b/src/services/ops/PaidValueMonitorService.test.ts
@@ -1,0 +1,268 @@
+import type { UserPassWindowRow } from '../../data_layer/UserPassRepository';
+import type { AnonymousPassWindowRow } from '../../data_layer/AnonymousPassRepository';
+import type { PaidValueEventRow } from '../../data_layer/EventsMetricsRepository';
+import type { NewSubscriptionWithUserRow } from '../../data_layer/PaidValueSubscriptionsRepository';
+import { PaidValueMonitorService } from './PaidValueMonitorService';
+
+const NOW = new Date('2026-07-14T12:00:00.000Z');
+const SINCE = new Date('2026-07-07T12:00:00.000Z');
+
+interface Fixture {
+  userPasses?: UserPassWindowRow[];
+  anonymousPasses?: AnonymousPassWindowRow[];
+  subscriptions?: NewSubscriptionWithUserRow[];
+  events?: PaidValueEventRow[];
+}
+
+const buildService = (fixture: Fixture) => {
+  const eventsCapture = {
+    userIds: [] as number[],
+    since: null as Date | null,
+  };
+  const service = new PaidValueMonitorService({
+    userPasses: {
+      listActiveInWindow: async () => fixture.userPasses ?? [],
+    },
+    anonymousPasses: {
+      listActiveInWindow: async () => fixture.anonymousPasses ?? [],
+    },
+    subscriptions: {
+      listNewWithUserId: async () => fixture.subscriptions ?? [],
+    },
+    events: {
+      listPaidValueEvents: async (userIds, since) => {
+        eventsCapture.userIds = userIds;
+        eventsCapture.since = since;
+        return (fixture.events ?? []).filter((event) =>
+          userIds.includes(event.userId)
+        );
+      },
+    },
+  });
+  return { service, eventsCapture };
+};
+
+describe('PaidValueMonitorService', () => {
+  it('counts a pass with a successful conversion as value delivered', async () => {
+    const { service, eventsCapture } = buildService({
+      userPasses: [
+        {
+          id: 1,
+          userId: 100,
+          kind: '7d',
+          expiresAt: new Date('2026-07-13T12:00:00.000Z'),
+        },
+      ],
+      events: [
+        {
+          userId: 100,
+          name: 'conversion_succeeded',
+          createdAt: new Date('2026-07-10T12:00:00.000Z'),
+        },
+      ],
+    });
+
+    const result = await service.getStatus(SINCE, NOW);
+
+    expect(result.passes).toEqual({
+      checked: 1,
+      withValue: 1,
+      zeroValueTried: 0,
+      zeroValueNeverTried: 0,
+      rows: [],
+    });
+    expect(eventsCapture.since).toEqual(new Date('2026-07-06T12:00:00.000Z'));
+  });
+
+  it('classifies a pass with only failures as zero-value tried', async () => {
+    const { service } = buildService({
+      userPasses: [
+        {
+          id: 2,
+          userId: 200,
+          kind: '24h',
+          expiresAt: new Date('2026-07-13T12:00:00.000Z'),
+        },
+      ],
+      events: [
+        {
+          userId: 200,
+          name: 'conversion_failed',
+          createdAt: new Date('2026-07-12T18:00:00.000Z'),
+        },
+      ],
+    });
+
+    const result = await service.getStatus(SINCE, NOW);
+
+    expect(result.passes.zeroValueTried).toBe(1);
+    expect(result.passes.withValue).toBe(0);
+    expect(result.passes.rows).toEqual([
+      {
+        userId: 200,
+        kind: '24h',
+        expiresAt: '2026-07-13T12:00:00.000Z',
+        successes: 0,
+        downloads: 0,
+        failures: 1,
+        classification: 'tried',
+      },
+    ]);
+  });
+
+  it('classifies a pass with no events at all as zero-value never tried', async () => {
+    const { service } = buildService({
+      userPasses: [
+        {
+          id: 3,
+          userId: 300,
+          kind: '24h',
+          expiresAt: new Date('2026-07-13T12:00:00.000Z'),
+        },
+      ],
+    });
+
+    const result = await service.getStatus(SINCE, NOW);
+
+    expect(result.passes.zeroValueNeverTried).toBe(1);
+    expect(result.passes.rows[0]).toMatchObject({
+      userId: 300,
+      classification: 'never',
+      successes: 0,
+      downloads: 0,
+      failures: 0,
+    });
+  });
+
+  it('ignores events that fall outside the pass active window', async () => {
+    const { service } = buildService({
+      userPasses: [
+        {
+          id: 4,
+          userId: 400,
+          kind: '24h',
+          expiresAt: new Date('2026-07-13T12:00:00.000Z'),
+        },
+      ],
+      events: [
+        {
+          userId: 400,
+          name: 'conversion_succeeded',
+          createdAt: new Date('2026-07-08T12:00:00.000Z'),
+        },
+      ],
+    });
+
+    const result = await service.getStatus(SINCE, NOW);
+
+    expect(result.passes.withValue).toBe(0);
+    expect(result.passes.zeroValueNeverTried).toBe(1);
+    expect(result.passes.rows[0]).toMatchObject({
+      classification: 'never',
+      successes: 0,
+    });
+  });
+
+  it('counts a new subscriber who converted inside their first paid week', async () => {
+    const { service } = buildService({
+      subscriptions: [
+        { userId: 500, createdAt: new Date('2026-07-13T12:00:00.000Z') },
+      ],
+      events: [
+        {
+          userId: 500,
+          name: 'conversion_succeeded',
+          createdAt: new Date('2026-07-14T00:00:00.000Z'),
+        },
+      ],
+    });
+
+    const result = await service.getStatus(SINCE, NOW);
+
+    expect(result.newSubscriptions).toEqual({
+      checked: 1,
+      withValue: 1,
+      zeroValueTried: 0,
+      zeroValueNeverTried: 0,
+      rows: [],
+    });
+  });
+
+  it('defaults an unknown pass kind to a 24h window and warns', async () => {
+    const warn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    const { service } = buildService({
+      userPasses: [
+        {
+          id: 6,
+          userId: 600,
+          kind: 'lifetime-typo',
+          expiresAt: new Date('2026-07-13T12:00:00.000Z'),
+        },
+      ],
+      events: [
+        {
+          userId: 600,
+          name: 'conversion_succeeded',
+          createdAt: new Date('2026-07-10T12:00:00.000Z'),
+        },
+      ],
+    });
+
+    const result = await service.getStatus(SINCE, NOW);
+
+    expect(result.passes.zeroValueNeverTried).toBe(1);
+    expect(result.passes.rows[0]).toMatchObject({
+      classification: 'never',
+      successes: 0,
+    });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('lifetime-typo'));
+    warn.mockRestore();
+  });
+
+  it('counts unclaimed anonymous passes without attributing events, and attributes claimed ones', async () => {
+    const { service } = buildService({
+      anonymousPasses: [
+        {
+          id: 1,
+          kind: '24h',
+          createdAt: new Date('2026-07-13T00:00:00.000Z'),
+          expiresAt: new Date('2026-07-14T00:00:00.000Z'),
+          claimedByUserId: null,
+        },
+        {
+          id: 2,
+          kind: '24h',
+          createdAt: new Date('2026-07-13T00:00:00.000Z'),
+          expiresAt: new Date('2026-07-14T00:00:00.000Z'),
+          claimedByUserId: 700,
+        },
+      ],
+      events: [
+        {
+          userId: 700,
+          name: 'conversion_failed',
+          createdAt: new Date('2026-07-13T12:00:00.000Z'),
+        },
+      ],
+    });
+
+    const result = await service.getStatus(SINCE, NOW);
+
+    expect(result.unclaimedAnonymousPasses).toBe(1);
+    expect(result.claimedAnonymousPasses.checked).toBe(1);
+    expect(result.claimedAnonymousPasses.zeroValueTried).toBe(1);
+    expect(result.claimedAnonymousPasses.rows).toEqual([
+      {
+        userId: 700,
+        kind: '24h',
+        expiresAt: '2026-07-14T00:00:00.000Z',
+        successes: 0,
+        downloads: 0,
+        failures: 1,
+        classification: 'tried',
+      },
+    ]);
+  });
+});

--- a/src/services/ops/PaidValueMonitorService.ts
+++ b/src/services/ops/PaidValueMonitorService.ts
@@ -1,0 +1,386 @@
+import type { UserPassWindowRow } from '../../data_layer/UserPassRepository';
+import type { AnonymousPassWindowRow } from '../../data_layer/AnonymousPassRepository';
+import type { PaidValueEventRow } from '../../data_layer/EventsMetricsRepository';
+import type { NewSubscriptionWithUserRow } from '../../data_layer/PaidValueSubscriptionsRepository';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const WEEK_MS = 7 * DAY_MS;
+
+const KIND_DURATION_MS: Record<string, number> = {
+  '24h': DAY_MS,
+  '7d': WEEK_MS,
+};
+const DEFAULT_KIND_DURATION_MS = DAY_MS;
+const LARGEST_KIND_DURATION_MS = WEEK_MS;
+const SUBSCRIPTION_VALUE_WINDOW_MS = WEEK_MS;
+
+export type PaidValueClassification = 'tried' | 'never';
+
+export interface PassValueRow {
+  userId: number;
+  kind: string;
+  expiresAt: string;
+  successes: number;
+  downloads: number;
+  failures: number;
+  classification: PaidValueClassification;
+}
+
+export interface SubscriptionValueRow {
+  userId: number;
+  subscribedAt: string;
+  successes: number;
+  downloads: number;
+  failures: number;
+  classification: PaidValueClassification;
+}
+
+export interface PassValueGroup {
+  checked: number;
+  withValue: number;
+  zeroValueTried: number;
+  zeroValueNeverTried: number;
+  rows: PassValueRow[];
+}
+
+export interface SubscriptionValueGroup {
+  checked: number;
+  withValue: number;
+  zeroValueTried: number;
+  zeroValueNeverTried: number;
+  rows: SubscriptionValueRow[];
+}
+
+export interface PaidValueMonitorResponse {
+  window_since: string;
+  as_of: string;
+  passes: PassValueGroup;
+  claimedAnonymousPasses: PassValueGroup;
+  unclaimedAnonymousPasses: number;
+  newSubscriptions: SubscriptionValueGroup;
+}
+
+export interface UserPassWindowSource {
+  listActiveInWindow(since: Date, until: Date): Promise<UserPassWindowRow[]>;
+}
+
+export interface AnonymousPassWindowSource {
+  listActiveInWindow(
+    since: Date,
+    until: Date
+  ): Promise<AnonymousPassWindowRow[]>;
+}
+
+export interface NewSubscriptionsSource {
+  listNewWithUserId(
+    since: Date,
+    until: Date
+  ): Promise<NewSubscriptionWithUserRow[]>;
+}
+
+export interface PaidValueEventsSource {
+  listPaidValueEvents(
+    userIds: number[],
+    since: Date
+  ): Promise<PaidValueEventRow[]>;
+}
+
+interface PaidValueMonitorServiceDeps {
+  userPasses: UserPassWindowSource;
+  anonymousPasses: AnonymousPassWindowSource;
+  subscriptions: NewSubscriptionsSource;
+  events: PaidValueEventsSource;
+}
+
+interface PassLikeUnit {
+  userId: number;
+  kind: string;
+  expiresAt: Date;
+  windowStart: Date;
+  windowEnd: Date;
+}
+
+interface SubscriptionUnit {
+  userId: number;
+  subscribedAt: Date;
+  windowStart: Date;
+  windowEnd: Date;
+}
+
+interface EventCounts {
+  successes: number;
+  downloads: number;
+  failures: number;
+}
+
+function kindDurationMs(kind: string): number {
+  const known = KIND_DURATION_MS[kind];
+  if (known != null) {
+    return known;
+  }
+  console.warn(
+    `[paid-value-monitor] unknown pass kind "${kind}" — defaulting to 24h window`
+  );
+  return DEFAULT_KIND_DURATION_MS;
+}
+
+function windowsIntersect(
+  startMs: number,
+  endMs: number,
+  sinceMs: number,
+  nowMs: number
+): boolean {
+  return startMs <= nowMs && endMs >= sinceMs;
+}
+
+function toPassUnit(row: UserPassWindowRow): PassLikeUnit {
+  const duration = kindDurationMs(row.kind);
+  return {
+    userId: row.userId,
+    kind: row.kind,
+    expiresAt: row.expiresAt,
+    windowStart: new Date(row.expiresAt.getTime() - duration),
+    windowEnd: row.expiresAt,
+  };
+}
+
+function toSubscriptionUnit(
+  row: NewSubscriptionWithUserRow,
+  now: Date
+): SubscriptionUnit {
+  const windowEndMs = Math.min(
+    row.createdAt.getTime() + SUBSCRIPTION_VALUE_WINDOW_MS,
+    now.getTime()
+  );
+  return {
+    userId: row.userId,
+    subscribedAt: row.createdAt,
+    windowStart: row.createdAt,
+    windowEnd: new Date(windowEndMs),
+  };
+}
+
+function groupEventsByUser(
+  events: PaidValueEventRow[]
+): Map<number, PaidValueEventRow[]> {
+  const byUser = new Map<number, PaidValueEventRow[]>();
+  for (const event of events) {
+    const existing = byUser.get(event.userId);
+    if (existing == null) {
+      byUser.set(event.userId, [event]);
+    } else {
+      existing.push(event);
+    }
+  }
+  return byUser;
+}
+
+function countInWindow(
+  events: PaidValueEventRow[] | undefined,
+  windowStart: Date,
+  windowEnd: Date
+): EventCounts {
+  const startMs = windowStart.getTime();
+  const endMs = windowEnd.getTime();
+  const counts: EventCounts = { successes: 0, downloads: 0, failures: 0 };
+  for (const event of events ?? []) {
+    const at = event.createdAt.getTime();
+    if (at < startMs || at > endMs) {
+      continue;
+    }
+    if (event.name === 'conversion_succeeded') {
+      counts.successes += 1;
+    } else if (event.name === 'deck_downloaded') {
+      counts.downloads += 1;
+    } else if (event.name === 'conversion_failed') {
+      counts.failures += 1;
+    }
+  }
+  return counts;
+}
+
+function classify(counts: EventCounts): 'withValue' | PaidValueClassification {
+  if (counts.successes > 0 || counts.downloads > 0) {
+    return 'withValue';
+  }
+  if (counts.failures > 0) {
+    return 'tried';
+  }
+  return 'never';
+}
+
+interface ValueGroupCounts {
+  checked: number;
+  withValue: number;
+  zeroValueTried: number;
+  zeroValueNeverTried: number;
+}
+
+function accumulateUnit<TRow>(
+  group: ValueGroupCounts & { rows: TRow[] },
+  classification: 'withValue' | PaidValueClassification,
+  buildRow: (classification: PaidValueClassification) => TRow
+): void {
+  group.checked += 1;
+  if (classification === 'withValue') {
+    group.withValue += 1;
+    return;
+  }
+  if (classification === 'tried') {
+    group.zeroValueTried += 1;
+  } else {
+    group.zeroValueNeverTried += 1;
+  }
+  group.rows.push(buildRow(classification));
+}
+
+function buildPassGroup(
+  units: PassLikeUnit[],
+  eventsByUser: Map<number, PaidValueEventRow[]>
+): PassValueGroup {
+  const group: PassValueGroup = {
+    checked: 0,
+    withValue: 0,
+    zeroValueTried: 0,
+    zeroValueNeverTried: 0,
+    rows: [],
+  };
+  for (const unit of units) {
+    const counts = countInWindow(
+      eventsByUser.get(unit.userId),
+      unit.windowStart,
+      unit.windowEnd
+    );
+    accumulateUnit(group, classify(counts), (classification) => ({
+      userId: unit.userId,
+      kind: unit.kind,
+      expiresAt: unit.expiresAt.toISOString(),
+      successes: counts.successes,
+      downloads: counts.downloads,
+      failures: counts.failures,
+      classification,
+    }));
+  }
+  return group;
+}
+
+function buildSubscriptionGroup(
+  units: SubscriptionUnit[],
+  eventsByUser: Map<number, PaidValueEventRow[]>
+): SubscriptionValueGroup {
+  const group: SubscriptionValueGroup = {
+    checked: 0,
+    withValue: 0,
+    zeroValueTried: 0,
+    zeroValueNeverTried: 0,
+    rows: [],
+  };
+  for (const unit of units) {
+    const counts = countInWindow(
+      eventsByUser.get(unit.userId),
+      unit.windowStart,
+      unit.windowEnd
+    );
+    accumulateUnit(group, classify(counts), (classification) => ({
+      userId: unit.userId,
+      subscribedAt: unit.subscribedAt.toISOString(),
+      successes: counts.successes,
+      downloads: counts.downloads,
+      failures: counts.failures,
+      classification,
+    }));
+  }
+  return group;
+}
+
+export class PaidValueMonitorService {
+  private readonly userPasses: UserPassWindowSource;
+  private readonly anonymousPasses: AnonymousPassWindowSource;
+  private readonly subscriptions: NewSubscriptionsSource;
+  private readonly events: PaidValueEventsSource;
+
+  constructor(deps: PaidValueMonitorServiceDeps) {
+    this.userPasses = deps.userPasses;
+    this.anonymousPasses = deps.anonymousPasses;
+    this.subscriptions = deps.subscriptions;
+    this.events = deps.events;
+  }
+
+  async getStatus(since: Date, now: Date): Promise<PaidValueMonitorResponse> {
+    const sinceMs = since.getTime();
+    const nowMs = now.getTime();
+    const passUntil = new Date(nowMs + LARGEST_KIND_DURATION_MS);
+
+    const [userPassRows, anonPassRows, subscriptionRows] = await Promise.all([
+      this.userPasses.listActiveInWindow(since, passUntil),
+      this.anonymousPasses.listActiveInWindow(since, now),
+      this.subscriptions.listNewWithUserId(since, now),
+    ]);
+
+    const passUnits = userPassRows
+      .map(toPassUnit)
+      .filter((unit) =>
+        windowsIntersect(
+          unit.windowStart.getTime(),
+          unit.windowEnd.getTime(),
+          sinceMs,
+          nowMs
+        )
+      );
+
+    const claimedAnonUnits: PassLikeUnit[] = [];
+    let unclaimedAnonymousPasses = 0;
+    for (const row of anonPassRows) {
+      const intersects = windowsIntersect(
+        row.createdAt.getTime(),
+        row.expiresAt.getTime(),
+        sinceMs,
+        nowMs
+      );
+      if (!intersects) {
+        continue;
+      }
+      if (row.claimedByUserId == null) {
+        unclaimedAnonymousPasses += 1;
+        continue;
+      }
+      claimedAnonUnits.push({
+        userId: row.claimedByUserId,
+        kind: row.kind,
+        expiresAt: row.expiresAt,
+        windowStart: row.createdAt,
+        windowEnd: row.expiresAt,
+      });
+    }
+
+    const subscriptionUnits = subscriptionRows.map((row) =>
+      toSubscriptionUnit(row, now)
+    );
+
+    const userIds = new Set<number>();
+    let earliestStartMs = nowMs;
+    for (const unit of [
+      ...passUnits,
+      ...claimedAnonUnits,
+      ...subscriptionUnits,
+    ]) {
+      userIds.add(unit.userId);
+      earliestStartMs = Math.min(earliestStartMs, unit.windowStart.getTime());
+    }
+
+    const events = await this.events.listPaidValueEvents(
+      [...userIds],
+      new Date(earliestStartMs)
+    );
+    const eventsByUser = groupEventsByUser(events);
+
+    return {
+      window_since: since.toISOString(),
+      as_of: now.toISOString(),
+      passes: buildPassGroup(passUnits, eventsByUser),
+      claimedAnonymousPasses: buildPassGroup(claimedAnonUnits, eventsByUser),
+      unclaimedAnonymousPasses,
+      newSubscriptions: buildSubscriptionGroup(subscriptionUnits, eventsByUser),
+    };
+  }
+}

--- a/src/usecases/ops/GetPaidValueMonitorUseCase.test.ts
+++ b/src/usecases/ops/GetPaidValueMonitorUseCase.test.ts
@@ -1,0 +1,67 @@
+import { GetPaidValueMonitorUseCase } from './GetPaidValueMonitorUseCase';
+import type { PaidValueMonitorService } from '../../services/ops/PaidValueMonitorService';
+
+const SECONDS_PER_DAY = 24 * 60 * 60;
+
+const buildUseCase = () => {
+  const getStatus = jest.fn().mockResolvedValue({
+    window_since: '',
+    as_of: '',
+    passes: {
+      checked: 0,
+      withValue: 0,
+      zeroValueTried: 0,
+      zeroValueNeverTried: 0,
+      rows: [],
+    },
+    claimedAnonymousPasses: {
+      checked: 0,
+      withValue: 0,
+      zeroValueTried: 0,
+      zeroValueNeverTried: 0,
+      rows: [],
+    },
+    unclaimedAnonymousPasses: 0,
+    newSubscriptions: {
+      checked: 0,
+      withValue: 0,
+      zeroValueTried: 0,
+      zeroValueNeverTried: 0,
+      rows: [],
+    },
+  });
+  const service = { getStatus } as unknown as PaidValueMonitorService;
+  return { useCase: new GetPaidValueMonitorUseCase(service), getStatus };
+};
+
+const daysBetween = (since: Date, now: Date) =>
+  Math.round((now.getTime() - since.getTime()) / (SECONDS_PER_DAY * 1000));
+
+describe('GetPaidValueMonitorUseCase', () => {
+  it('defaults to a 7-day window', async () => {
+    const { useCase, getStatus } = buildUseCase();
+
+    await useCase.execute(undefined);
+
+    const [since, now] = getStatus.mock.calls[0];
+    expect(daysBetween(since, now)).toBe(7);
+  });
+
+  it('honours a valid window', async () => {
+    const { useCase, getStatus } = buildUseCase();
+
+    await useCase.execute('30d');
+
+    const [since, now] = getStatus.mock.calls[0];
+    expect(daysBetween(since, now)).toBe(30);
+  });
+
+  it('falls back to the default for an unknown window', async () => {
+    const { useCase, getStatus } = buildUseCase();
+
+    await useCase.execute('all-time');
+
+    const [since, now] = getStatus.mock.calls[0];
+    expect(daysBetween(since, now)).toBe(7);
+  });
+});

--- a/src/usecases/ops/GetPaidValueMonitorUseCase.ts
+++ b/src/usecases/ops/GetPaidValueMonitorUseCase.ts
@@ -1,0 +1,28 @@
+import {
+  PaidValueMonitorResponse,
+  PaidValueMonitorService,
+} from '../../services/ops/PaidValueMonitorService';
+
+const SECONDS_PER_DAY = 24 * 60 * 60;
+
+const WINDOW_DAYS: Record<string, number> = {
+  '1d': 1,
+  '7d': 7,
+  '14d': 14,
+  '30d': 30,
+};
+
+const DEFAULT_WINDOW = '7d';
+
+export class GetPaidValueMonitorUseCase {
+  constructor(private readonly service: PaidValueMonitorService) {}
+
+  execute(window: string | undefined): Promise<PaidValueMonitorResponse> {
+    const key =
+      window != null && WINDOW_DAYS[window] != null ? window : DEFAULT_WINDOW;
+    const days = WINDOW_DAYS[key];
+    const now = new Date();
+    const since = new Date(now.getTime() - days * SECONDS_PER_DAY * 1000);
+    return this.service.getStatus(since, now);
+  }
+}

--- a/web/src/pages/OpsPage/CommandsTab.tsx
+++ b/web/src/pages/OpsPage/CommandsTab.tsx
@@ -15,6 +15,7 @@ import {
   ReconcileOrphanedSubscriptionsResponse,
 } from './orphanedSubscriptions';
 import PassUnlockMonitorTab from './PassUnlockMonitorTab';
+import PaidValueMonitorTab from './PaidValueMonitorTab';
 
 type Status = 'idle' | 'loading' | 'success' | 'error';
 
@@ -375,6 +376,7 @@ export default function CommandsTab() {
       )}
 
       <PassUnlockMonitorTab />
+      <PaidValueMonitorTab />
     </>
   );
 }

--- a/web/src/pages/OpsPage/PaidValueMonitorTab.test.tsx
+++ b/web/src/pages/OpsPage/PaidValueMonitorTab.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -84,8 +84,8 @@ describe('PaidValueMonitorTab', () => {
     render(<PaidValueMonitorTab />);
     fireEvent.click(screen.getByRole('button', { name: 'Check value' }));
 
-    await waitFor(() => expect(screen.getByText('4242')).toBeInTheDocument());
-    const passRow = screen.getByText('4242').closest('tr');
+    const passCell = await screen.findByText('4242');
+    const passRow = passCell.closest('tr');
     expect(passRow).toHaveTextContent('24h');
     expect(passRow).toHaveTextContent('Tried, failed');
 
@@ -108,9 +108,7 @@ describe('PaidValueMonitorTab', () => {
     render(<PaidValueMonitorTab />);
     fireEvent.click(screen.getByRole('button', { name: 'Check value' }));
 
-    await waitFor(() =>
-      expect(screen.getByText(/5 paid units checked/)).toBeInTheDocument()
-    );
+    expect(await screen.findByText(/5 paid units checked/)).toBeInTheDocument();
     expect(
       screen.queryByRole('columnheader', { name: 'Result' })
     ).not.toBeInTheDocument();
@@ -127,10 +125,8 @@ describe('PaidValueMonitorTab', () => {
     render(<PaidValueMonitorTab />);
     fireEvent.click(screen.getByRole('button', { name: 'Check value' }));
 
-    await waitFor(() =>
-      expect(
-        screen.getByText('Failed to load paid value monitor')
-      ).toBeInTheDocument()
-    );
+    expect(
+      await screen.findByText('Failed to load paid value monitor')
+    ).toBeInTheDocument();
   });
 });

--- a/web/src/pages/OpsPage/PaidValueMonitorTab.test.tsx
+++ b/web/src/pages/OpsPage/PaidValueMonitorTab.test.tsx
@@ -1,0 +1,136 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import PaidValueMonitorTab from './PaidValueMonitorTab';
+import { PaidValueMonitorResponse } from './paidValueMonitor';
+
+const mockFetch = (payload: PaidValueMonitorResponse) => {
+  (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => payload,
+  });
+};
+
+const emptyGroup = {
+  checked: 0,
+  withValue: 0,
+  zeroValueTried: 0,
+  zeroValueNeverTried: 0,
+  rows: [],
+};
+
+const baseResponse: PaidValueMonitorResponse = {
+  window_since: '2026-07-07T12:00:00.000Z',
+  as_of: '2026-07-14T12:00:00.000Z',
+  passes: { ...emptyGroup, rows: [] },
+  claimedAnonymousPasses: { ...emptyGroup, rows: [] },
+  unclaimedAnonymousPasses: 0,
+  newSubscriptions: { ...emptyGroup, rows: [] },
+};
+
+describe('PaidValueMonitorTab', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test('lists zero-value pass and subscription rows after a check', async () => {
+    mockFetch({
+      ...baseResponse,
+      passes: {
+        checked: 2,
+        withValue: 1,
+        zeroValueTried: 1,
+        zeroValueNeverTried: 0,
+        rows: [
+          {
+            userId: 4242,
+            kind: '24h',
+            expiresAt: '2026-07-13T12:00:00.000Z',
+            successes: 0,
+            downloads: 0,
+            failures: 3,
+            classification: 'tried',
+          },
+        ],
+      },
+      newSubscriptions: {
+        checked: 1,
+        withValue: 0,
+        zeroValueTried: 0,
+        zeroValueNeverTried: 1,
+        rows: [
+          {
+            userId: 5150,
+            subscribedAt: '2026-07-13T00:00:00.000Z',
+            successes: 0,
+            downloads: 0,
+            failures: 0,
+            classification: 'never',
+          },
+        ],
+      },
+    });
+
+    render(<PaidValueMonitorTab />);
+    fireEvent.click(screen.getByRole('button', { name: 'Check value' }));
+
+    await waitFor(() => expect(screen.getByText('4242')).toBeInTheDocument());
+    const passRow = screen.getByText('4242').closest('tr');
+    expect(passRow).toHaveTextContent('24h');
+    expect(passRow).toHaveTextContent('Tried, failed');
+
+    const subRow = screen.getByText('5150').closest('tr');
+    expect(subRow).toHaveTextContent('Never tried');
+  });
+
+  test('reports a clean check with no zero-value tables', async () => {
+    mockFetch({
+      ...baseResponse,
+      passes: {
+        checked: 5,
+        withValue: 5,
+        zeroValueTried: 0,
+        zeroValueNeverTried: 0,
+        rows: [],
+      },
+    });
+
+    render(<PaidValueMonitorTab />);
+    fireEvent.click(screen.getByRole('button', { name: 'Check value' }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/5 paid units checked/)).toBeInTheDocument()
+    );
+    expect(
+      screen.queryByRole('columnheader', { name: 'Result' })
+    ).not.toBeInTheDocument();
+  });
+
+  test('surfaces a failed request', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: async () => ({ message: 'Failed to load paid value monitor' }),
+    });
+
+    render(<PaidValueMonitorTab />);
+    fireEvent.click(screen.getByRole('button', { name: 'Check value' }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Failed to load paid value monitor')
+      ).toBeInTheDocument()
+    );
+  });
+});

--- a/web/src/pages/OpsPage/PaidValueMonitorTab.tsx
+++ b/web/src/pages/OpsPage/PaidValueMonitorTab.tsx
@@ -1,0 +1,214 @@
+import { useState } from 'react';
+
+import sharedStyles from '../../styles/shared.module.css';
+import styles from './OpsPage.module.css';
+import MetricCard from './MetricCard';
+import {
+  getPaidValueMonitor,
+  PaidValueMonitorResponse,
+  PassValueGroup,
+  PassValueRow,
+  SubscriptionValueGroup,
+  SubscriptionValueRow,
+  PaidValueWindow,
+  PAID_VALUE_WINDOWS,
+} from './paidValueMonitor';
+
+type Status = 'idle' | 'loading' | 'success' | 'error';
+
+function summarize(data: PaidValueMonitorResponse): string {
+  const groups = [
+    data.passes,
+    data.claimedAnonymousPasses,
+    data.newSubscriptions,
+  ];
+  const checked = groups.reduce((sum, group) => sum + group.checked, 0);
+  const tried = groups.reduce((sum, group) => sum + group.zeroValueTried, 0);
+  const never = groups.reduce(
+    (sum, group) => sum + group.zeroValueNeverTried,
+    0
+  );
+  return `${checked} paid unit${checked === 1 ? '' : 's'} checked — ${tried} tried and failed, ${never} never tried, ${data.unclaimedAnonymousPasses} unclaimed anonymous pass${data.unclaimedAnonymousPasses === 1 ? '' : 'es'} (unlinkable).`;
+}
+
+function summaryCards(group: PassValueGroup | SubscriptionValueGroup) {
+  return (
+    <div className={styles.cardGrid}>
+      <MetricCard title="Checked" value={String(group.checked)} />
+      <MetricCard title="With value" value={String(group.withValue)} />
+      <MetricCard
+        title="Zero-value tried"
+        value={String(group.zeroValueTried)}
+      />
+      <MetricCard
+        title="Never tried"
+        value={String(group.zeroValueNeverTried)}
+      />
+    </div>
+  );
+}
+
+function resultLabel(row: PassValueRow | SubscriptionValueRow): string {
+  return row.classification === 'tried' ? 'Tried, failed' : 'Never tried';
+}
+
+function passRowsTable(rows: PassValueRow[]) {
+  if (rows.length === 0) {
+    return null;
+  }
+  return (
+    <div className={styles.tableScroll}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>User</th>
+            <th>Kind</th>
+            <th>Expires</th>
+            <th>Successes</th>
+            <th>Failures</th>
+            <th>Result</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={`${row.userId}-${row.expiresAt}`}>
+              <td>{row.userId}</td>
+              <td>{row.kind}</td>
+              <td>{new Date(row.expiresAt).toLocaleString()}</td>
+              <td>{row.successes}</td>
+              <td>{row.failures}</td>
+              <td>{resultLabel(row)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function subscriptionRowsTable(rows: SubscriptionValueRow[]) {
+  if (rows.length === 0) {
+    return null;
+  }
+  return (
+    <div className={styles.tableScroll}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>User</th>
+            <th>Subscribed</th>
+            <th>Successes</th>
+            <th>Failures</th>
+            <th>Result</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={`${row.userId}-${row.subscribedAt}`}>
+              <td>{row.userId}</td>
+              <td>{new Date(row.subscribedAt).toLocaleString()}</td>
+              <td>{row.successes}</td>
+              <td>{row.failures}</td>
+              <td>{resultLabel(row)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function renderResults(data: PaidValueMonitorResponse) {
+  return (
+    <>
+      <h3 className={styles.sectionTitle}>Day/Week passes</h3>
+      {summaryCards(data.passes)}
+      {passRowsTable(data.passes.rows)}
+
+      <h3 className={styles.sectionTitle}>Claimed anonymous passes</h3>
+      {summaryCards(data.claimedAnonymousPasses)}
+      {passRowsTable(data.claimedAnonymousPasses.rows)}
+
+      <h3 className={styles.sectionTitle}>New subscriptions</h3>
+      {summaryCards(data.newSubscriptions)}
+      {subscriptionRowsTable(data.newSubscriptions.rows)}
+    </>
+  );
+}
+
+export default function PaidValueMonitorTab() {
+  const [status, setStatus] = useState<Status>('idle');
+  const [message, setMessage] = useState('');
+  const [window, setWindow] = useState<PaidValueWindow>('7d');
+  const [data, setData] = useState<PaidValueMonitorResponse | null>(null);
+
+  const run = async () => {
+    setStatus('loading');
+    setMessage('');
+    try {
+      const result = await getPaidValueMonitor(window);
+      setData(result);
+      const tried =
+        result.passes.zeroValueTried +
+        result.claimedAnonymousPasses.zeroValueTried +
+        result.newSubscriptions.zeroValueTried;
+      setStatus(tried > 0 ? 'error' : 'success');
+      setMessage(summarize(result));
+    } catch (error) {
+      setData(null);
+      setStatus('error');
+      setMessage(error instanceof Error ? error.message : 'Unknown error');
+    }
+  };
+
+  return (
+    <section className={`${sharedStyles.surface} ${styles.card}`}>
+      <h2 className={styles.cardTitle}>Paid value monitor</h2>
+      <p className={styles.panelSubtitle}>
+        Finds paying users who produced zero successful conversions in their
+        paid window. Zero-value tried (a failure but no success or download) is
+        the urgent case — a buyer who hit a bug. Never tried is a buyer who
+        never uploaded. Unclaimed anonymous passes cannot be linked to a user,
+        so they are reported as a count only, never guessed.
+      </p>
+      <div className={styles.controls}>
+        <label htmlFor="paid-value-window" className={styles.controlsLabel}>
+          Window
+        </label>
+        <select
+          id="paid-value-window"
+          className={`${sharedStyles.select} ${styles.windowSelect}`}
+          value={window}
+          onChange={(e) => setWindow(e.target.value as PaidValueWindow)}
+        >
+          {PAID_VALUE_WINDOWS.map((w) => (
+            <option key={w} value={w}>
+              {w}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          className={sharedStyles.btnSmall}
+          onClick={run}
+          disabled={status === 'loading'}
+        >
+          {status === 'loading' ? 'Checking…' : 'Check value'}
+        </button>
+      </div>
+
+      {status === 'success' && message && (
+        <div className={`${sharedStyles.alertSuccess} ${styles.banner}`}>
+          {message}
+        </div>
+      )}
+      {status === 'error' && message && (
+        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
+          {message}
+        </div>
+      )}
+
+      {data != null && renderResults(data)}
+    </section>
+  );
+}

--- a/web/src/pages/OpsPage/paidValueMonitor.ts
+++ b/web/src/pages/OpsPage/paidValueMonitor.ts
@@ -1,0 +1,64 @@
+export type PaidValueClassification = 'tried' | 'never';
+
+export interface PassValueRow {
+  userId: number;
+  kind: string;
+  expiresAt: string;
+  successes: number;
+  downloads: number;
+  failures: number;
+  classification: PaidValueClassification;
+}
+
+export interface SubscriptionValueRow {
+  userId: number;
+  subscribedAt: string;
+  successes: number;
+  downloads: number;
+  failures: number;
+  classification: PaidValueClassification;
+}
+
+export interface PassValueGroup {
+  checked: number;
+  withValue: number;
+  zeroValueTried: number;
+  zeroValueNeverTried: number;
+  rows: PassValueRow[];
+}
+
+export interface SubscriptionValueGroup {
+  checked: number;
+  withValue: number;
+  zeroValueTried: number;
+  zeroValueNeverTried: number;
+  rows: SubscriptionValueRow[];
+}
+
+export interface PaidValueMonitorResponse {
+  window_since: string;
+  as_of: string;
+  passes: PassValueGroup;
+  claimedAnonymousPasses: PassValueGroup;
+  unclaimedAnonymousPasses: number;
+  newSubscriptions: SubscriptionValueGroup;
+}
+
+export const PAID_VALUE_WINDOWS = ['1d', '7d', '14d', '30d'] as const;
+export type PaidValueWindow = (typeof PAID_VALUE_WINDOWS)[number];
+
+export async function getPaidValueMonitor(
+  window: PaidValueWindow
+): Promise<PaidValueMonitorResponse> {
+  const response = await fetch(`/api/ops/value-monitor?window=${window}`, {
+    method: 'GET',
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(
+      data.message ?? `${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+}


### PR DESCRIPTION
## What
Adds an ops-gated `GET /api/ops/value-monitor` endpoint and a "Paid value monitor" tab under Ops → Commands. For each Day/Week pass, claimed anonymous pass, and new subscription in a rolling window (1d/7d/14d/30d, default 7d), it counts the conversion successes, downloads, and failures inside that unit's own paid window and splits each group into with-value, zero-value-tried (failures but no success/download — the urgent case), and zero-value-never-tried.

## Why
A day-pass user this week burned their whole pass against a conversion bug and we only learned via a support email. This monitor answers "which pass holders and new subscribers produced zero successful conversions in their paid window" from first-party data, split into tried-and-failed (urgent) vs never-tried, so a broken paid window is caught before the support ticket. It complements the existing pass unlock monitor: that one checks payment→entitlement, this one checks entitlement→value.

## How
- New `GetPaidValueMonitorUseCase` (mirrors `GetPassUnlockMonitorUseCase` window parsing) → `PaidValueMonitorService` (classification logic) → injected repositories.
- `user_passes`: active window = [expires_at − kindDuration, expires_at]; coarse SQL filter then exact JS intersection with [since, now].
- `anonymous_passes`: window = [created_at, expires_at]; claimed (by user id) vs unclaimed split.
- `subscriptions`: joined to `users` by normalized email (`lower(trim(...))`, mirroring `OrphanedSubscriptionsRepository`); value window = [created_at, min(created_at + 7d, now)].
- `events`: one query over the union of candidate user ids for the three value events, aggregated per unit per window in JS.
- Frontend mirrors the `PassUnlockMonitor` pair (fetch wrapper + tab), embedded in `CommandsTab` next to it.

Response shape:
```ts
{ window_since, as_of,
  passes: { checked, withValue, zeroValueTried, zeroValueNeverTried,
            rows: [{ userId, kind, expiresAt, successes, downloads, failures, classification }] },
  claimedAnonymousPasses: <same shape>,
  unclaimedAnonymousPasses: number,
  newSubscriptions: { checked, withValue, zeroValueTried, zeroValueNeverTried,
                      rows: [{ userId, subscribedAt, successes, downloads, failures, classification }] } }
```
Rows contain only zero-value units; numeric user ids only, no emails anywhere.

## Measuring success
Ops-internal signal, not a public funnel metric. Read it at Ops → Commands → "Paid value monitor" (or `GET /api/ops/value-monitor?window=7d`). The number to watch is `passes.zeroValueTried + claimedAnonymousPasses.zeroValueTried + newSubscriptions.zeroValueTried` — non-zero means a paying user hit a bug inside their paid window and should be reached out to / refunded.

## Decisions (please review)
- **Closed pass-kind set with 24h default + warn**: kindDuration is `{'24h': 24h, '7d': 7d}`; an unknown kind counts as 24h and logs a `console.warn`. The set is closed per the brief.
- **Zero-value rows only in the payload**: `rows` list only tried and never-tried units; with-value units are counted but not enumerated.
- **Unclaimed anonymous passes reported as an unlinkable count**: no user id, so they can't be joined to events — reported honestly as `unclaimedAnonymousPasses` (a number), never guessed.
- **Subscription value window = first 7 days**: `[created_at, min(created_at + 7d, now)]`. Selection is by `created_at` in [since, now] with no `active` filter (faithful to the brief); the inner join to `users` drops subscriptions that match no account (unattributable to events).
- **Deviation from brief**: the brief said "register in `opsTabs.ts` next to the unlock-monitor tab", but the unlock-monitor tab does not live in `opsTabs.ts` — `PassUnlockMonitorTab` is rendered inside `CommandsTab.tsx`. I mirrored the real pattern and rendered `PaidValueMonitorTab` next to it in `CommandsTab.tsx`.

## Testing
- Unit tests added:
  - `PaidValueMonitorService.test.ts` — success → withValue; only-failures → tried; no events → never; events outside the window ignored; subscriber first-week window; unknown kind → 24h default + warn; unclaimed anon counted-only + claimed anon attributed.
  - `GetPaidValueMonitorUseCase.test.ts` — window parsing (default 7d, valid, unknown fallback).
  - `PaidValueSubscriptionsRepository.sql.test.ts` — asserts the generated PG SQL for the raw email join (per testing.md).
  - `PaidValueMonitorTab.test.tsx` — lists zero-value rows; clean check hides tables; failed request surfaced.
- Full server Jest suite: **6254 passed**; the only failures are documented environmental suites (Python venv absent → `PythonExitError` in DeckParser/canary/golden; `pdfinfo` absent → `getPageCount`). None touch this change.
- Full web Vitest suite: **2826 passed, 0 failed**.
- `tsc -p . --noEmit` clean (compiles tests too, matching the deploy build); `pnpm arch` adds no new class of violation (the one `no-layer-skip-to-data-layer` warn on the new repo is the same composition-root DI pattern the OpsRouter already uses for every repo it wires); `pnpm format:check` clean tree-wide; web typecheck + web lint clean (lint warnings are all pre-existing, unrelated files).
- Local `sonar-scanner` couldn't run in this worktree (needs `SONAR_TOKEN` env, which the keychain-based `sonar auth` token isn't exposed as; Docker not running for the MCP path) — relying on the post-push `sonarqubecloud` PR decoration. Self-reviewed for the usual smells: no `any`, guard clauses (not negated if/else), the two near-identical group builders share one `accumulateUnit` helper to stay under the new-code duplication gate.

## Browser check
- [x] Golden path on localhost:3000 — `pnpm --filter 2anki-web test:golden-path` passed (2/2: landing + signed-in dashboard render without console errors at 375px). The new tab is ops-gated (404 for everyone except the ops owner), so the public golden path is unaffected — confirmed.
- [x] No console errors at 375px (golden-path asserts this).
Notes: The tab itself is an exact mirror of the already-shipped `PassUnlockMonitorTab`, covered by the vitest tab test.

## Changelog
No entry — internal ops tooling, gated to the ops owner (returns 404 for everyone else). Not user-visible.

## Risks
- Read-only: the endpoint only SELECTs; no writes, no external calls, no user input beyond the `window` enum (validated to a closed set, defaults to 7d).
- The subscription→user inner join drops subscriptions with no matching account; those are unattributable and intentionally excluded (documented above).
- Rollback: revert the PR; no migration, no schema change, no data written.

## Goal alignment
Serves the retention / per-user-value lever in CLAUDE.md (the "money's-worth" work): surfaces paying users who got nothing for their money so they can be reached before they churn or charge back. No acquisition funnel moves — this is internal ops tooling. Metric to watch: total `zeroValueTried` across the three groups, read at Ops → Commands, on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFM6MBEU4Gg2mVNtGsaxvP

no changelog entry — internal ops tooling, invisible to non-ops users