### PR TITLE
feat: convert zero-card uploads with Claude for entitled users

### DIFF
--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -1185,6 +1185,294 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
   });
 });
 
+describe('UploadService.handleSyncUpload — zero-card Claude fallback', () => {
+  const originalWorkspaceBase = process.env.WORKSPACE_BASE;
+  let tmpDir: string;
+  let infoSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    process.env.WORKSPACE_BASE = path.join(
+      os.tmpdir(),
+      'upload-service-fallback'
+    );
+  });
+
+  afterAll(() => {
+    process.env.WORKSPACE_BASE = originalWorkspaceBase;
+  });
+
+  beforeEach(() => {
+    MockGeneratePackagesUseCase.mockClear();
+    trackMock.mockClear();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fallback-ws-'));
+    mockWorkspaceLocation = tmpDir;
+    mockWorkspaceId = 'fallback-ws-id';
+    infoSpy = jest.spyOn(console, 'info').mockImplementation(() => undefined);
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    infoSpy.mockRestore();
+    errorSpy.mockRestore();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function zeroCardUseCase() {
+    MockGeneratePackagesUseCase.mockImplementation(
+      () =>
+        ({
+          execute: jest.fn().mockResolvedValue({ packages: [] }),
+        }) as unknown as InstanceType<typeof GeneratePackagesUseCase>
+    );
+  }
+
+  function jobRepositoryWithFailedGate(onFailed?: () => void): JobRepository {
+    return {
+      create: jest.fn().mockResolvedValue(undefined),
+      updateJobStatus: jest
+        .fn()
+        .mockImplementation((_id: string, _owner: string, status: string) => {
+          if (status === 'failed') {
+            onFailed?.();
+          }
+          return Promise.resolve(undefined);
+        }),
+      findJobById: jest.fn().mockResolvedValue(null),
+      deleteJob: jest.fn().mockResolvedValue(undefined),
+    } as unknown as JobRepository;
+  }
+
+  function entitledRequest(
+    overrides: Partial<express.Request> = {}
+  ): express.Request {
+    return buildRequest({
+      files: [
+        {
+          originalname: 'lecture.html',
+          mimetype: 'text/html',
+          size: 4096,
+          path: '/tmp/lecture.html',
+        } as unknown as Express.Multer.File,
+      ],
+      ...overrides,
+    });
+  }
+
+  function entitledResponse() {
+    const built = buildResponse();
+    (built.res.locals as Record<string, unknown>).owner = 42;
+    (built.res.locals as Record<string, unknown>).subscriber = true;
+    return built;
+  }
+
+  it('dispatches an async Claude job with 202 when an entitled user with AI never set gets zero cards', async () => {
+    zeroCardUseCase();
+    let resolveFailed!: () => void;
+    const failed = new Promise<void>((r) => {
+      resolveFailed = r;
+    });
+    const jobRepository = jobRepositoryWithFailedGate(resolveFailed);
+    const service = new UploadService(
+      buildRepository(),
+      jobRepository,
+      buildUsersRepo()
+    );
+    const req = entitledRequest();
+    const { res, capturedStatus, capturedJson } = entitledResponse();
+
+    await service.handleUpload(req, res);
+    await failed;
+
+    expect(capturedStatus()).toBe(202);
+    expect(capturedJson()).toEqual({ jobId: 'fallback-ws-id' });
+    expect(jobRepository.create).toHaveBeenCalledWith(
+      'fallback-ws-id',
+      '42',
+      expect.any(String),
+      'claude'
+    );
+    expect(trackMock).toHaveBeenCalledWith(
+      'ai_fallback_triggered',
+      expect.objectContaining({
+        userId: 42,
+        props: expect.objectContaining({ reason: 'empty_deck' }),
+      })
+    );
+  });
+
+  it('keeps the empty_export error when an entitled user explicitly turned AI off', async () => {
+    zeroCardUseCase();
+    const jobRepository = jobRepositoryWithFailedGate();
+    const service = new UploadService(
+      buildRepository(),
+      jobRepository,
+      buildUsersRepo()
+    );
+    const req = entitledRequest({
+      body: { 'claude-ai-flashcards': 'false' },
+    } as Partial<express.Request>);
+    const { res, capturedStatus, capturedJson } = entitledResponse();
+
+    await service.handleUpload(req, res);
+
+    expect(capturedStatus()).toBe(400);
+    expect((capturedJson() as { code: string }).code).toBe('empty_export');
+    expect(jobRepository.create).not.toHaveBeenCalled();
+    expect(trackMock).not.toHaveBeenCalledWith(
+      'ai_fallback_triggered',
+      expect.anything()
+    );
+    expect(trackMock).toHaveBeenCalledWith(
+      'conversion_failed',
+      expect.objectContaining({
+        props: expect.objectContaining({ reason: 'empty_deck' }),
+      })
+    );
+  });
+
+  it('keeps the empty_export error for a signed-in free user who is not entitled', async () => {
+    zeroCardUseCase();
+    const jobRepository = jobRepositoryWithFailedGate();
+    const service = new UploadService(
+      buildRepository(),
+      jobRepository,
+      buildUsersRepo()
+    );
+    const req = entitledRequest();
+    const { res, capturedStatus, capturedJson } = buildResponse();
+    (res.locals as Record<string, unknown>).owner = 42;
+
+    await service.handleUpload(req, res);
+
+    expect(capturedStatus()).toBe(400);
+    expect((capturedJson() as { code: string }).code).toBe('empty_export');
+    expect(jobRepository.create).not.toHaveBeenCalled();
+    expect(trackMock).not.toHaveBeenCalledWith(
+      'ai_fallback_triggered',
+      expect.anything()
+    );
+  });
+
+  it('keeps the empty_export error for an anonymous upload', async () => {
+    zeroCardUseCase();
+    const jobRepository = jobRepositoryWithFailedGate();
+    const service = new UploadService(
+      buildRepository(),
+      jobRepository,
+      buildUsersRepo()
+    );
+    const req = entitledRequest();
+    const { res, capturedStatus, capturedJson } = buildResponse();
+
+    await service.handleUpload(req, res);
+
+    expect(capturedStatus()).toBe(400);
+    expect((capturedJson() as { code: string }).code).toBe('empty_export');
+    expect(jobRepository.create).not.toHaveBeenCalled();
+    expect(trackMock).not.toHaveBeenCalledWith(
+      'ai_fallback_triggered',
+      expect.anything()
+    );
+  });
+
+  it('keeps the empty_export error when the entitled upload exceeds the Claude fallback size cap', async () => {
+    zeroCardUseCase();
+    const jobRepository = jobRepositoryWithFailedGate();
+    const service = new UploadService(
+      buildRepository(),
+      jobRepository,
+      buildUsersRepo()
+    );
+    const req = entitledRequest({
+      files: [
+        {
+          originalname: 'huge.html',
+          mimetype: 'text/html',
+          size: 60 * 1024 * 1024,
+          path: '/tmp/huge.html',
+        } as unknown as Express.Multer.File,
+      ],
+    } as Partial<express.Request>);
+    const { res, capturedStatus, capturedJson } = entitledResponse();
+
+    await service.handleUpload(req, res);
+
+    expect(capturedStatus()).toBe(400);
+    expect((capturedJson() as { code: string }).code).toBe('empty_export');
+    expect(jobRepository.create).not.toHaveBeenCalled();
+    expect(trackMock).not.toHaveBeenCalledWith(
+      'ai_fallback_triggered',
+      expect.anything()
+    );
+  });
+
+  it('keeps the image_only_no_text response for an entitled image-only upload and does not fall back to Claude', async () => {
+    zeroCardUseCase();
+    const jobRepository = jobRepositoryWithFailedGate();
+    const service = new UploadService(
+      buildRepository(),
+      jobRepository,
+      buildUsersRepo()
+    );
+    const req = entitledRequest({
+      files: [
+        {
+          originalname: 'slide.png',
+          mimetype: 'image/png',
+          size: 2048,
+          path: '/tmp/slide.png',
+        } as unknown as Express.Multer.File,
+      ],
+    } as Partial<express.Request>);
+    const { res, capturedStatus, capturedJson } = entitledResponse();
+
+    await service.handleUpload(req, res);
+
+    expect(capturedStatus()).toBe(400);
+    expect((capturedJson() as { code: string }).code).toBe(
+      'image_only_no_text'
+    );
+    expect(jobRepository.create).not.toHaveBeenCalled();
+    expect(trackMock).not.toHaveBeenCalledWith(
+      'ai_fallback_triggered',
+      expect.anything()
+    );
+  });
+
+  it('does not recurse: a fallback job that itself yields zero cards is marked failed once, never re-dispatched', async () => {
+    zeroCardUseCase();
+    let failedCount = 0;
+    let resolveFailed!: () => void;
+    const failed = new Promise<void>((r) => {
+      resolveFailed = r;
+    });
+    const jobRepository = jobRepositoryWithFailedGate(() => {
+      failedCount += 1;
+      resolveFailed();
+    });
+    const service = new UploadService(
+      buildRepository(),
+      jobRepository,
+      buildUsersRepo()
+    );
+    const req = entitledRequest();
+    const { res, capturedStatus } = entitledResponse();
+
+    await service.handleUpload(req, res);
+    await failed;
+    await new Promise((r) => setImmediate(r));
+
+    expect(capturedStatus()).toBe(202);
+    expect(jobRepository.create).toHaveBeenCalledTimes(1);
+    const fallbackCalls = trackMock.mock.calls.filter(
+      (call) => call[0] === 'ai_fallback_triggered'
+    );
+    expect(fallbackCalls).toHaveLength(1);
+    expect(failedCount).toBe(1);
+  });
+});
+
 describe('UploadService.deleteUpload — cascade', () => {
   beforeEach(() => {
     mockStorageDelete.mockClear();

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -116,6 +116,8 @@ interface ImageOnlyResponse {
 const IMAGE_ONLY_NO_TEXT_MESSAGE =
   'These look like images — no text to read. Turn them into cards with Photo to Deck.';
 
+const AI_FALLBACK_MAX_BYTES = 50 * 1024 * 1024;
+
 interface DeckTooLargeResponse {
   message: string;
 }
@@ -1076,6 +1078,43 @@ class UploadService {
     return res.status(202).json({ jobId: ws.id });
   }
 
+  private canFallBackToClaude(
+    req: express.Request,
+    owner: number | null,
+    paying: boolean
+  ): boolean {
+    if (owner == null || !paying) {
+      return false;
+    }
+    const files = req.files as UploadedFile[] | undefined;
+    if (isImageOnlyUpload(files)) {
+      return false;
+    }
+    const rawFlag = (req.body as Record<string, unknown> | undefined)?.[
+      'claude-ai-flashcards'
+    ];
+    if (rawFlag === 'false') {
+      return false;
+    }
+    const totalBytes = (files ?? []).reduce((sum, file) => sum + file.size, 0);
+    return totalBytes <= AI_FALLBACK_MAX_BYTES;
+  }
+
+  private buildClaudeFallbackSettings(
+    req: express.Request,
+    base: CardOption
+  ): CardOption {
+    const body = (req.body ?? {}) as Record<string, string>;
+    const fallback = new CardOption({
+      ...body,
+      'claude-ai-flashcards': 'true',
+    });
+    fallback.n2aBasic = base.n2aBasic;
+    fallback.n2aCloze = base.n2aCloze;
+    fallback.n2aInput = base.n2aInput;
+    return fallback;
+  }
+
   private async handleSyncUpload(
     req: express.Request,
     res: express.Response,
@@ -1122,8 +1161,27 @@ class UploadService {
 
     if (totalCards === 0) {
       logNoPackageDiagnostics(req.files as UploadedFile[]);
+      const ownerId = owner != null ? Number(owner) : null;
+      if (this.canFallBackToClaude(req, ownerId, paying)) {
+        track('ai_fallback_triggered', {
+          userId: ownerId,
+          anonymousId: this.resolveAnonId(req),
+          props: {
+            reason: 'empty_deck',
+            source: this.resolveUploadSource(req),
+          },
+        });
+        return await this.handleAsyncUpload(
+          req,
+          res,
+          this.buildClaudeFallbackSettings(req, settings),
+          new Workspace(true, 'fs'),
+          String(owner),
+          paying
+        );
+      }
       track('conversion_failed', {
-        userId: owner != null ? Number(owner) : null,
+        userId: ownerId,
         anonymousId: this.resolveAnonId(req),
         props: {
           source: this.resolveUploadSource(req),

--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -51,6 +51,7 @@ export const KNOWN_EVENTS = new Set([
   'cancel_during_generating',
   'pdf_print_options_used',
   'ai_conversion_completed',
+  'ai_fallback_triggered',
   'feature_flag_changed',
   'account_created',
   'account_offer_shown',

--- a/web/src/pages/WhatsNewPage/changelog/2026-08-08-zero-card-claude-fallback.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-08-08-zero-card-claude-fallback.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-08-08-zero-card-claude-fallback",
+  "date": "2026-08-08",
+  "type": "feature",
+  "title": "Uploads that produce no cards are converted with Claude automatically for members"
+}


### PR DESCRIPTION
## What

When a sync upload produces zero cards for an entitled member who has not explicitly turned AI off, the conversion is now automatically re-dispatched as an async Claude job returning `202 {jobId}` — the same path the AI-on branch already uses — instead of throwing `EmptyDeckError` and showing a 400 dead end. Explicit opt-out, free/anonymous users, image-only uploads, and uploads above a 50MB Claude budget keep today's behavior.

## Why

65 empty-deck (`conversion_failed reason=empty_deck`) events across 23 paying users in the last 30 days: the deterministic parser found nothing, the member got a 400 with no recovery, and the AI conversion that would very often have worked sat behind the `claude-ai-flashcards` toggle they never turned on. The paid capability existed; the unset toggle hid it. This closes the gap for members without asking them to know the toggle exists.

## How

`UploadService.handleSyncUpload`'s zero-card branch now checks `canFallBackToClaude` before throwing. Eligibility (all required): signed-in owner + `isPaying`; the raw `req.body['claude-ai-flashcards']` is not `'false'` (tri-state read taken *before* `CardOption` collapses it, so an explicit opt-out is respected); not an image-only upload; total upload bytes ≤ 50MB. On eligibility it builds a `CardOption` from the same body with `claude-ai-flashcards: 'true'` (carrying over any server-attached custom note templates) and calls the existing `handleAsyncUpload` with a fresh workspace — no duplicated job/exporter logic. The monthly-card-limit guard is unchanged because it lives inside the reused `promoteClaudeJobToUpload`. The server-only `ai_fallback_triggered` event (`{ reason: 'empty_deck', source }`) fires at dispatch.

## Measuring success

- Prod log/metric: `ai_fallback_triggered` at `/api/ops/metrics` — count of fallback dispatches per week.
- Follow it to outcome: of those jobs, the share that reach `conversion_succeeded` (async) vs `conversion_failed` (the async Claude run itself found nothing). A fallback that mostly succeeds is the win; a fallback that mostly fails means the input genuinely had no text and we should reconsider the trigger.
- Guardrail: `empty_deck` `conversion_failed` events for paying users should drop.

## Testing

- Unit tests added to `src/services/UploadService.test.ts` (`handleSyncUpload — zero-card Claude fallback`):
  - entitled + AI never set + zero cards → `202 {jobId}` + `jobRepository.create(..., 'claude')` + `ai_fallback_triggered`
  - entitled + explicit `'false'` + zero cards → `400 empty_export` exactly as today, no dispatch, no event
  - signed-in free user + zero cards → `400 empty_export`, no fallback
  - anonymous + zero cards → `400 empty_export`, no fallback
  - oversized (>50MB) entitled upload → `400 empty_export`, no fallback
  - entitled image-only upload → `400 image_only_no_text` (Photo to Deck), no fallback
  - recursion guard: a fallback job that itself yields zero cards is marked failed **once**, `ai_fallback_triggered` fires exactly once, response stays `202` (never re-enters the sync fallback)
- Suites: server `UploadService.test.ts` 73/73 pass; full server suite 666 suites / 6261 tests pass (only the 9 documented worktree-environmental suites fail — DeckParser/golden/canary needing the `create_deck` Python venv, and `getPageCount` needing pdfinfo at a hardcoded path). Full web suite 360 files / 2826 tests pass. tsc (incl. tests), `pnpm arch` (0 errors), `pnpm format:check`, web typecheck + lint all green.

## Browser check

- [x] Golden path on localhost:3000 — `pnpm --filter 2anki-web test:golden-path` 2 passed
- [x] No console errors at 375px — golden-path asserts "landing renders without console errors at 375px" and "signed-in dashboard renders without console errors at 375px", both green

Notes: No client code changed — the upload form already handles `202 {jobId}` (the AI-on branch has returned 202 all along), so the happy path needed no UI edit. SonarCloud's PR bot evaluates the gate on this PR; the new code is guard-clause-only (no nesting, no ternaries, cognitive complexity ~4) and matches the file's existing `return await this.handleAsyncUpload(...)` pattern.

## Changelog

`web/src/pages/WhatsNewPage/changelog/2026-08-08-zero-card-claude-fallback.json` — "Uploads that produce no cards are converted with Claude automatically for members"

## Decisions made overnight (please review)

- **No global default-on flip.** pm + engineer overruled designer's "just default AI on": defaulting AI on every conversion adds 2–30s latency and Claude token cost to the clean-export common case that already converts instantly with zero cards lost. The fallback only spends Claude when the deterministic parser genuinely produced nothing — the exact population that has nothing to lose.
- **Fallback only when the raw flag is not `'false'`.** An explicit opt-out is a deliberate choice and is respected by construction (tri-state read before `CardOption` collapses `false`/unset to the same boolean). Never-set and `'true'` are eligible; `'true'` users are already on the async path and normally can't reach here.
- **50MB fallback cap (reviewable number).** Chosen constant, independent of `getUploadLimits`' 10GB paid ceiling — a runaway document shouldn't be silently pushed to Claude at conversion time. Flagging the specific value: happy to raise/lower it. A too-large upload fails closed (no fallback, today's 400).
- **Single attempt, no recursion.** The fallback dispatches the async Claude path, which never calls back into the sync path — so a Claude run that itself yields zero cards marks its own job failed and stops. Asserted by the recursion-guard test.
- **`scheduleSync()` one-liner was already satisfied — no change made.** The task asked `toggleAi` to also call `scheduleSync()` so an explicit AI on/off choice persists server-side immediately. Verified: `toggleAi` already calls `saveValueInLocalStorage(AI_FLAG_KEY, next, null)`, and `saveValueInLocalStorage` with a `null` pageId has called `scheduleSync()` since 2026-05-13 (commit a04a319d). The behavior already exists; adding a second call would double-fire. Flagged rather than shipping a redundant line.
- **`ai_fallback_triggered` added to the server allowlist only, not web.** The event is emitted server-side. `events.parity.test.ts` only asserts web→server (every web-fired event exists server-side); there is no server→web check, and the web app never fires this event, so adding it to `web/src/lib/analytics/events.ts` would falsely imply the client emits it. Added only where the type-checker and the tests require it.

## Risks

- Extra Claude cost/latency **only** on the zero-card population (65 events/30d today) — bounded by the same monthly-card limit as any AI conversion, and by the 50MB size cap. No impact on conversions that already produce cards (the fallback never runs on them).
- Two `conversion_started` events fire for one upload that falls back (one `mode: sync`, one `mode: async`) — intentional and distinguishable; it reflects two real attempts. Dashboards keying on `conversion_started` count should be aware.
- Rollback: revert the PR; behavior returns to the immediate 400 `empty_export`. No migration, no schema, no data to unwind.

## Goal alignment

Retention/per-user value lever (the tracked priority): turns a paid-member dead end into a delivered deck without the member learning a toggle exists — a "drop something in, get a clean deck back" moment for exactly the users most likely to churn on a failed conversion. Funnel metric to move: paying-user `empty_deck` `conversion_failed` rate should fall and `conversion_succeeded` (async) should pick up the difference; read at `/api/ops/metrics`, first look T+7d after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFM6MBEU4Gg2mVNtGsaxvP
